### PR TITLE
Update mpox lineage hierarchy with newly designated lineages

### DIFF
--- a/definitions/mpox/lineages.yaml
+++ b/definitions/mpox/lineages.yaml
@@ -13,26 +13,6 @@ A.1.1:
   #  - B
   parents:
   - A.1
-A.2:
-  aliases: []
-  parents:
-  - A
-A.2.1:
-  aliases: []
-  parents:
-  - A.2
-A.2.2:
-  aliases: []
-  parents:
-  - A.2
-A.2.3:
-  aliases: []
-  parents:
-  - A.2
-A.3:
-  aliases: []
-  parents:
-  - A
 B.1:
   aliases: []
   #  - A.1.1.1
@@ -41,6 +21,109 @@ B.1:
 B.1.1:
   aliases: []
   #  - A.1.1.1.1
+  parents:
+  - B.1
+B.1.2:
+  aliases: []
+  #  - A.1.1.1.2
+  parents:
+  - B.1
+B.1.3:
+  aliases: []
+  #  - A.1.1.1.3
+  #  - C
+  parents:
+  - B.1
+C.1:
+  aliases: []
+  #  - A.1.1.1.3.1
+  #  - B.1.3.1
+  parents:
+  - B.1.3
+C.1.1:
+  aliases: []
+  #  - A.1.1.1.3.1.1
+  #  - B.1.3.1.1
+  #  - E
+  parents:
+  - C.1
+E.1:
+  aliases: []
+  #  - A.1.1.1.3.1.1.1
+  #  - C.1.1.1
+  parents:
+  - C.1.1
+E.1.1:
+  aliases: []
+  parents:
+  - E.1
+E.2:
+  aliases: []
+  #  - A.1.1.1.3.1.1.2
+  #  - C.1.1.2
+  parents:
+  - C.1.1
+E.2.1:
+  aliases: []
+  parents:
+  - E.2
+E.3:
+  aliases: []
+  #  - A.1.1.1.3.1.1.3
+  #  - C.1.1.3
+  parents:
+  - C.1.1
+E.3.1:
+  aliases: []
+  parents:
+  - E.3
+E.4:
+  aliases: []
+  parents:
+  - C.1.1
+C.1.2:
+  aliases: []
+  parents:
+  - C.1
+C.1.3:
+  aliases: []
+  parents:
+  - C.1
+B.1.4:
+  aliases: []
+  #  - A.1.1.1.4
+  parents:
+  - B.1
+B.1.5:
+  aliases: []
+  #  - A.1.1.1.5
+  parents:
+  - B.1
+B.1.6:
+  aliases: []
+  #  - A.1.1.1.6
+  #  - D
+  parents:
+  - B.1
+D.1:
+  aliases: []
+  #  - A.1.1.1.6.1
+  #  - B.1.6.1
+  parents:
+  - B.1.6
+B.1.7:
+  aliases: []
+  #  - A.1.1.1.7
+  parents:
+  - B.1
+B.1.8:
+  aliases: []
+  #  - A.1.1.1.8
+  parents:
+  - B.1
+B.1.9:
+  aliases: []
+  #  - A.1.1.1.9
   parents:
   - B.1
 B.1.10:
@@ -93,118 +176,32 @@ B.1.19:
   #  - A.1.1.1.19
   parents:
   - B.1
-B.1.2:
-  aliases: []
-  #  - A.1.1.1.2
-  parents:
-  - B.1
 B.1.20:
   aliases: []
   #  - A.1.1.1.20
   #  - F
   parents:
   - B.1
-B.1.21:
-  aliases: []
-  #  - A.1.1.1.21
-  parents:
-  - B.1
-B.1.22:
-  aliases: []
-  #  - A.1.1.1.22
-  parents:
-  - B.1
-B.1.23:
-  aliases: []
-  #  - A.1.1.1.23
-  parents:
-  - B.1
-B.1.3:
-  aliases: []
-  #  - A.1.1.1.3
-  #  - C
-  parents:
-  - B.1
-B.1.4:
-  aliases: []
-  #  - A.1.1.1.4
-  parents:
-  - B.1
-B.1.5:
-  aliases: []
-  #  - A.1.1.1.5
-  parents:
-  - B.1
-B.1.6:
-  aliases: []
-  #  - A.1.1.1.6
-  #  - D
-  parents:
-  - B.1
-B.1.7:
-  aliases: []
-  #  - A.1.1.1.7
-  parents:
-  - B.1
-B.1.8:
-  aliases: []
-  #  - A.1.1.1.8
-  parents:
-  - B.1
-B.1.9:
-  aliases: []
-  #  - A.1.1.1.9
-  parents:
-  - B.1
-C.1:
-  aliases: []
-  #  - A.1.1.1.3.1
-  #  - B.1.3.1
-  parents:
-  - B.1.3
-C.1.1:
-  aliases: []
-  #  - A.1.1.1.3.1.1
-  #  - B.1.3.1.1
-  #  - E
-  parents:
-  - C.1
-D.1:
-  aliases: []
-  #  - A.1.1.1.6.1
-  #  - B.1.6.1
-  parents:
-  - B.1.6
-E.1:
-  aliases: []
-  #  - A.1.1.1.3.1.1.1
-  #  - C.1.1.1
-  parents:
-  - C.1.1
-E.2:
-  aliases: []
-  #  - A.1.1.1.3.1.1.2
-  #  - C.1.1.2
-  parents:
-  - C.1.1
-E.3:
-  aliases: []
-  #  - A.1.1.1.3.1.1.3
-  #  - C.1.1.3
-  parents:
-  - C.1.1
 F.1:
   aliases: []
   #  - A.1.1.1.20.1
   #  - B.1.20.1
   parents:
   - B.1.20
+F.1.1:
+  aliases: []
+  parents:
+  - F.1
 F.2:
   aliases: []
   #  - A.1.1.1.20.2
   #  - B.1.20.2
   parents:
   - B.1.20
+F.2.1:
+  aliases: []
+  parents:
+  - F.2
 F.3:
   aliases: []
   #  - A.1.1.1.20.3
@@ -217,6 +214,10 @@ F.4:
   #  - B.1.20.4
   parents:
   - B.1.20
+F.4.1:
+  aliases: []
+  parents:
+  - F.4
 F.5:
   aliases: []
   #  - A.1.1.1.20.5
@@ -229,3 +230,62 @@ F.6:
   #  - B.1.20.6
   parents:
   - B.1.20
+B.1.21:
+  aliases: []
+  #  - A.1.1.1.21
+  parents:
+  - B.1
+B.1.22:
+  aliases: []
+  #  - A.1.1.1.22
+  parents:
+  - B.1
+J.1:
+  aliases: []
+  parents:
+  - B.1.22
+B.1.23:
+  aliases: []
+  #  - A.1.1.1.23
+  parents:
+  - B.1
+A.2:
+  aliases: []
+  parents:
+  - A
+A.2.1:
+  aliases: []
+  parents:
+  - A.2
+H.1:
+  aliases: []
+  parents:
+  - A.2.1
+H.2:
+  aliases: []
+  parents:
+  - A.2.1
+A.2.2:
+  aliases: []
+  parents:
+  - A.2
+G.1:
+  aliases: []
+  parents:
+  - A.2.2
+A.2.3:
+  aliases: []
+  parents:
+  - A.2
+A.2.4:
+  aliases: []
+  parents:
+  - A.2
+A.2.5:
+  aliases: []
+  parents:
+  - A.2
+A.3:
+  aliases: []
+  parents:
+  - A


### PR DESCRIPTION
Add newly designated mpox lineages: https://github.com/mpxv-lineages/lineage-designation/pull/47

Reorganize hierarchy in proper depth-first topological order with parents appearing before children.