### PR TITLE
Taxonomy lineage

### DIFF
--- a/definitions/taxonomy/2026-04-15/lineages.yaml
+++ b/definitions/taxonomy/2026-04-15/lineages.yaml
@@ -1,0 +1,32541 @@
+7157:
+  aliases: ['Mosquitos']
+  parents: []
+43816:
+  aliases: ['Anophelinae']
+  parents:
+  - 7157
+43817:
+  aliases: ['Culicinae']
+  parents:
+  - 7157
+43818:
+  aliases: ['Toxorhynchitinae']
+  parents:
+  - 7157
+359183:
+  aliases: ['environmental samples']
+  parents:
+  - 7157
+342889:
+  aliases: ['unclassified Culicidae']
+  parents:
+  - 7157
+1620265:
+  aliases: ['Aedeomyiini']
+  parents:
+  - 43817
+1056966:
+  aliases: ['Aedini']
+  parents:
+  - 43817
+7164:
+  aliases: ['Anopheles']
+  parents:
+  - 43816
+53562:
+  aliases: ['Bironella']
+  parents:
+  - 43816
+139051:
+  aliases: ['Chagasia']
+  parents:
+  - 43816
+2853107:
+  aliases: ['Culicidae Ae_JM910']
+  parents:
+  - 342889
+2853111:
+  aliases: ['Culicidae P_269_FSTHT']
+  parents:
+  - 342889
+2853109:
+  aliases: ['Culicidae P_270_FSTHT']
+  parents:
+  - 342889
+2853108:
+  aliases: ['Culicidae P_278_FSTHT']
+  parents:
+  - 342889
+2853110:
+  aliases: ['Culicidae P_321_FSTCO']
+  parents:
+  - 342889
+359184:
+  aliases: ['Culicidae environmental sample']
+  parents:
+  - 359183
+2766978:
+  aliases: ['Culicidae sp.']
+  parents:
+  - 342889
+2308251:
+  aliases: ['Culicidae sp. 08TTML-2107']
+  parents:
+  - 342889
+2030136:
+  aliases: ['Culicidae sp. 1 LC-2017']
+  parents:
+  - 342889
+2030137:
+  aliases: ['Culicidae sp. 2 LC-2017']
+  parents:
+  - 342889
+2030573:
+  aliases: ['Culicidae sp. 2JG16-30_Tr']
+  parents:
+  - 342889
+2030574:
+  aliases: ['Culicidae sp. 2JG20-14_Tr']
+  parents:
+  - 342889
+2030494:
+  aliases: ['Culicidae sp. 5JB33-4_Hw']
+  parents:
+  - 342889
+2030497:
+  aliases: ['Culicidae sp. 5JBr2-3_Wy']
+  parents:
+  - 342889
+2086771:
+  aliases: ['Culicidae sp. 7507_011']
+  parents:
+  - 342889
+2086772:
+  aliases: ['Culicidae sp. 7508_010']
+  parents:
+  - 342889
+2030576:
+  aliases: ['Culicidae sp. ANT190-1_Cx']
+  parents:
+  - 342889
+2030577:
+  aliases: ['Culicidae sp. ANT190-3_Cx']
+  parents:
+  - 342889
+2030578:
+  aliases: ['Culicidae sp. ANT190-4_Cx']
+  parents:
+  - 342889
+2030553:
+  aliases: ['Culicidae sp. ANT245-4_Hw']
+  parents:
+  - 342889
+2030523:
+  aliases: ['Culicidae sp. ANT249-11_Hw']
+  parents:
+  - 342889
+2030492:
+  aliases: ['Culicidae sp. ANT249-13_Hw']
+  parents:
+  - 342889
+2030571:
+  aliases: ['Culicidae sp. ANT249-14_Hw']
+  parents:
+  - 342889
+2030493:
+  aliases: ['Culicidae sp. ANT254-1_Hw']
+  parents:
+  - 342889
+2030592:
+  aliases: ['Culicidae sp. ANT263-10_Cx']
+  parents:
+  - 342889
+2030599:
+  aliases: ['Culicidae sp. ANT263-11_Cx']
+  parents:
+  - 342889
+2030590:
+  aliases: ['Culicidae sp. ANT263-12_Cx']
+  parents:
+  - 342889
+2030595:
+  aliases: ['Culicidae sp. ANT263-13_Cx']
+  parents:
+  - 342889
+2030584:
+  aliases: ['Culicidae sp. ANT263-16_Cx']
+  parents:
+  - 342889
+2030589:
+  aliases: ['Culicidae sp. ANT263-17_Cx']
+  parents:
+  - 342889
+2030587:
+  aliases: ['Culicidae sp. ANT263-19_Cx']
+  parents:
+  - 342889
+2030585:
+  aliases: ['Culicidae sp. ANT263-20_Cx']
+  parents:
+  - 342889
+2030593:
+  aliases: ['Culicidae sp. ANT263-21_Cx']
+  parents:
+  - 342889
+2030601:
+  aliases: ['Culicidae sp. ANT263-22_Cx']
+  parents:
+  - 342889
+2030591:
+  aliases: ['Culicidae sp. ANT263-23_Cx']
+  parents:
+  - 342889
+2030600:
+  aliases: ['Culicidae sp. ANT263-24_Cx']
+  parents:
+  - 342889
+2030602:
+  aliases: ['Culicidae sp. ANT263-25_Cx']
+  parents:
+  - 342889
+2030596:
+  aliases: ['Culicidae sp. ANT263-26_Cx']
+  parents:
+  - 342889
+2030586:
+  aliases: ['Culicidae sp. ANT263-27_Cx']
+  parents:
+  - 342889
+2030594:
+  aliases: ['Culicidae sp. ANT263-5_Cx']
+  parents:
+  - 342889
+2030597:
+  aliases: ['Culicidae sp. ANT263-6_Cx']
+  parents:
+  - 342889
+2030588:
+  aliases: ['Culicidae sp. ANT263-7_Cx']
+  parents:
+  - 342889
+2030598:
+  aliases: ['Culicidae sp. ANT263-8_Cx']
+  parents:
+  - 342889
+2030629:
+  aliases: ['Culicidae sp. ANT265-1_Hw']
+  parents:
+  - 342889
+2030628:
+  aliases: ['Culicidae sp. ANT265-3_Hw']
+  parents:
+  - 342889
+2030516:
+  aliases: ['Culicidae sp. ANT265-4_An']
+  parents:
+  - 342889
+2030505:
+  aliases: ['Culicidae sp. ANT265-5_Cx']
+  parents:
+  - 342889
+2030521:
+  aliases: ['Culicidae sp. ANT72-12_Tr']
+  parents:
+  - 342889
+2030520:
+  aliases: ['Culicidae sp. ANT72-7_Tr']
+  parents:
+  - 342889
+2030519:
+  aliases: ['Culicidae sp. ANT72-9_Tr']
+  parents:
+  - 342889
+2030502:
+  aliases: ['Culicidae sp. ANT79-131_Wy']
+  parents:
+  - 342889
+2030567:
+  aliases: ['Culicidae sp. BA-ANT-A-001_Hw']
+  parents:
+  - 342889
+2030625:
+  aliases: ['Culicidae sp. BA-ANT-A-002_Hw']
+  parents:
+  - 342889
+2030568:
+  aliases: ['Culicidae sp. BA-ANT-A-003_Hw']
+  parents:
+  - 342889
+2030563:
+  aliases: ['Culicidae sp. BA-ANT-A-004_Hw']
+  parents:
+  - 342889
+1829238:
+  aliases: ['Culicidae sp. BIOAI177-14']
+  parents:
+  - 342889
+1829239:
+  aliases: ['Culicidae sp. BIOAI591-14']
+  parents:
+  - 342889
+2533783:
+  aliases: ['Culicidae sp. BIOUG06197-H10']
+  parents:
+  - 342889
+2533784:
+  aliases: ['Culicidae sp. BIOUG06326-H09']
+  parents:
+  - 342889
+2533785:
+  aliases: ['Culicidae sp. BIOUG06350-E10']
+  parents:
+  - 342889
+2533786:
+  aliases: ['Culicidae sp. BIOUG06535-F01']
+  parents:
+  - 342889
+2556735:
+  aliases: ['Culicidae sp. BIOUG06618-E04']
+  parents:
+  - 342889
+2533787:
+  aliases: ['Culicidae sp. BIOUG07470-C05']
+  parents:
+  - 342889
+2533788:
+  aliases: ['Culicidae sp. BIOUG09685-E10']
+  parents:
+  - 342889
+2556736:
+  aliases: ['Culicidae sp. BIOUG10185-D09']
+  parents:
+  - 342889
+2533789:
+  aliases: ['Culicidae sp. BIOUG16832-H08']
+  parents:
+  - 342889
+2556737:
+  aliases: ['Culicidae sp. BIOUG17186-C01']
+  parents:
+  - 342889
+2533790:
+  aliases: ['Culicidae sp. BIOUG17221-A02']
+  parents:
+  - 342889
+2556738:
+  aliases: ['Culicidae sp. BIOUG17862-A04']
+  parents:
+  - 342889
+2556739:
+  aliases: ['Culicidae sp. BIOUG18015-D07']
+  parents:
+  - 342889
+2533791:
+  aliases: ['Culicidae sp. BIOUG20840-H02']
+  parents:
+  - 342889
+2308250:
+  aliases: ['Culicidae sp. BIOUG25752-E12']
+  parents:
+  - 342889
+2533792:
+  aliases: ['Culicidae sp. BIOUG27097-H02']
+  parents:
+  - 342889
+2030514:
+  aliases: ['Culicidae sp. BJ2011-15_An']
+  parents:
+  - 342889
+2030549:
+  aliases: ['Culicidae sp. BJ2011-20_Hw']
+  parents:
+  - 342889
+2030572:
+  aliases: ['Culicidae sp. BJ2011-4-2_Hw']
+  parents:
+  - 342889
+2030499:
+  aliases: ['Culicidae sp. BJ2011-5-4_Wy']
+  parents:
+  - 342889
+1886925:
+  aliases: ['Culicidae sp. BOLD-2016']
+  parents:
+  - 342889
+1304428:
+  aliases: ['Culicidae sp. BOLD:AAA3748']
+  parents:
+  - 342889
+1304429:
+  aliases: ['Culicidae sp. BOLD:AAA3750']
+  parents:
+  - 342889
+1838892:
+  aliases: ['Culicidae sp. BOLD:AAA3751']
+  parents:
+  - 342889
+1861244:
+  aliases: ['Culicidae sp. BOLD:AAA4751']
+  parents:
+  - 342889
+1304436:
+  aliases: ['Culicidae sp. BOLD:AAA6145']
+  parents:
+  - 342889
+1829240:
+  aliases: ['Culicidae sp. BOLD:AAA6148']
+  parents:
+  - 342889
+1829241:
+  aliases: ['Culicidae sp. BOLD:AAA7067']
+  parents:
+  - 342889
+1861245:
+  aliases: ['Culicidae sp. BOLD:AAA7661']
+  parents:
+  - 342889
+1304441:
+  aliases: ['Culicidae sp. BOLD:AAB1098']
+  parents:
+  - 342889
+1861246:
+  aliases: ['Culicidae sp. BOLD:AAB5696']
+  parents:
+  - 342889
+1304447:
+  aliases: ['Culicidae sp. BOLD:AAB6338']
+  parents:
+  - 342889
+1829242:
+  aliases: ['Culicidae sp. BOLD:AAB6943']
+  parents:
+  - 342889
+1861247:
+  aliases: ['Culicidae sp. BOLD:AAC0584']
+  parents:
+  - 342889
+1861248:
+  aliases: ['Culicidae sp. BOLD:AAC5210']
+  parents:
+  - 342889
+1838893:
+  aliases: ['Culicidae sp. BOLD:AAC9062']
+  parents:
+  - 342889
+1829243:
+  aliases: ['Culicidae sp. BOLD:AAC9132']
+  parents:
+  - 342889
+1829244:
+  aliases: ['Culicidae sp. BOLD:AAD3254']
+  parents:
+  - 342889
+1838894:
+  aliases: ['Culicidae sp. BOLD:AAD4406']
+  parents:
+  - 342889
+1304466:
+  aliases: ['Culicidae sp. BOLD:AAD7982']
+  parents:
+  - 342889
+1838895:
+  aliases: ['Culicidae sp. BOLD:AAE3210']
+  parents:
+  - 342889
+1838896:
+  aliases: ['Culicidae sp. BOLD:AAF2904']
+  parents:
+  - 342889
+2658544:
+  aliases: ['Culicidae sp. BOLD:AAG3845']
+  parents:
+  - 342889
+1754367:
+  aliases: ['Culicidae sp. BOLD:AAI1618']
+  parents:
+  - 342889
+1846870:
+  aliases: ['Culicidae sp. BOLD:AAJ7123']
+  parents:
+  - 342889
+1693837:
+  aliases: ['Culicidae sp. BOLD:AAL9067']
+  parents:
+  - 342889
+1838897:
+  aliases: ['Culicidae sp. BOLD:AAM4536']
+  parents:
+  - 342889
+2658542:
+  aliases: ['Culicidae sp. BOLD:AAP3603']
+  parents:
+  - 342889
+2658541:
+  aliases: ['Culicidae sp. BOLD:AAP3605']
+  parents:
+  - 342889
+1846871:
+  aliases: ['Culicidae sp. BOLD:AAP8896']
+  parents:
+  - 342889
+1829245:
+  aliases: ['Culicidae sp. BOLD:AAT9780']
+  parents:
+  - 342889
+2658543:
+  aliases: ['Culicidae sp. BOLD:AAV4158']
+  parents:
+  - 342889
+1838898:
+  aliases: ['Culicidae sp. BOLD:ABY6464']
+  parents:
+  - 342889
+1743932:
+  aliases: ['Culicidae sp. BOLD:ACC5413']
+  parents:
+  - 342889
+1749811:
+  aliases: ['Culicidae sp. BOLD:ACG3697']
+  parents:
+  - 342889
+1744282:
+  aliases: ['Culicidae sp. BOLD:ACG8894']
+  parents:
+  - 342889
+1749812:
+  aliases: ['Culicidae sp. BOLD:ACI3313']
+  parents:
+  - 342889
+1744301:
+  aliases: ['Culicidae sp. BOLD:ACI3314']
+  parents:
+  - 342889
+1749813:
+  aliases: ['Culicidae sp. BOLD:ACI6369']
+  parents:
+  - 342889
+1741580:
+  aliases: ['Culicidae sp. BOLD:ACI8783']
+  parents:
+  - 342889
+1693838:
+  aliases: ['Culicidae sp. BOLD:ACJ5399']
+  parents:
+  - 342889
+2030555:
+  aliases: ['Culicidae sp. C002-534-7_Hw']
+  parents:
+  - 342889
+2030579:
+  aliases: ['Culicidae sp. C002-559-7_An']
+  parents:
+  - 342889
+2030623:
+  aliases: ['Culicidae sp. CO002-552-006_Hw']
+  parents:
+  - 342889
+2030619:
+  aliases: ['Culicidae sp. CO02-534-7_Hw']
+  parents:
+  - 342889
+2030618:
+  aliases: ['Culicidae sp. CO02-559-9_Hw']
+  parents:
+  - 342889
+2030512:
+  aliases: ['Culicidae sp. COO2-559-7_An']
+  parents:
+  - 342889
+1457332:
+  aliases: ['Culicidae sp. ILOV_contig1']
+  parents:
+  - 342889
+1457333:
+  aliases: ['Culicidae sp. ILOV_contig2']
+  parents:
+  - 342889
+1457334:
+  aliases: ['Culicidae sp. ILOV_contig3']
+  parents:
+  - 342889
+1457335:
+  aliases: ['Culicidae sp. ILOV_contig4']
+  parents:
+  - 342889
+2030522:
+  aliases: ['Culicidae sp. JBB11-2_Tr']
+  parents:
+  - 342889
+2030575:
+  aliases: ['Culicidae sp. JBB21-4_Tr']
+  parents:
+  - 342889
+2030500:
+  aliases: ['Culicidae sp. JBB31-1_Wy']
+  parents:
+  - 342889
+2030517:
+  aliases: ['Culicidae sp. JBB31-2_Wy']
+  parents:
+  - 342889
+2030547:
+  aliases: ['Culicidae sp. JBI13-4_Hw']
+  parents:
+  - 342889
+2030544:
+  aliases: ['Culicidae sp. JBI15-7_Hw']
+  parents:
+  - 342889
+2030526:
+  aliases: ['Culicidae sp. JBI18-12_Hw']
+  parents:
+  - 342889
+2030501:
+  aliases: ['Culicidae sp. JBJ011-016_Wy']
+  parents:
+  - 342889
+2030518:
+  aliases: ['Culicidae sp. JBJ11-16_Wy']
+  parents:
+  - 342889
+2030503:
+  aliases: ['Culicidae sp. JPS017_Wy']
+  parents:
+  - 342889
+2030508:
+  aliases: ['Culicidae sp. JPS118_An']
+  parents:
+  - 342889
+2030507:
+  aliases: ['Culicidae sp. JPS120_An']
+  parents:
+  - 342889
+2030513:
+  aliases: ['Culicidae sp. JPS124_An']
+  parents:
+  - 342889
+2030552:
+  aliases: ['Culicidae sp. JPS15_Hw']
+  parents:
+  - 342889
+2030551:
+  aliases: ['Culicidae sp. JPS29_Hw']
+  parents:
+  - 342889
+2030647:
+  aliases: ['Culicidae sp. JPS35_Hw/Oc']
+  parents:
+  - 342889
+2030545:
+  aliases: ['Culicidae sp. JPS35_Hw/Och']
+  parents:
+  - 342889
+2030496:
+  aliases: ['Culicidae sp. JQC001-006_Hw']
+  parents:
+  - 342889
+2030511:
+  aliases: ['Culicidae sp. JQC002-006_An']
+  parents:
+  - 342889
+2030515:
+  aliases: ['Culicidae sp. JQC002-12_An']
+  parents:
+  - 342889
+2030510:
+  aliases: ['Culicidae sp. JQC002-17_An']
+  parents:
+  - 342889
+2030548:
+  aliases: ['Culicidae sp. JQC002-18_Hw']
+  parents:
+  - 342889
+2030542:
+  aliases: ['Culicidae sp. JQC002-19_Hw/Oc']
+  parents:
+  - 342889
+2030509:
+  aliases: ['Culicidae sp. JQC002-31_An']
+  parents:
+  - 342889
+2030580:
+  aliases: ['Culicidae sp. JQC002-6_An']
+  parents:
+  - 342889
+2030498:
+  aliases: ['Culicidae sp. JQPV003-11_Wy']
+  parents:
+  - 342889
+2030536:
+  aliases: ['Culicidae sp. JQQ002-001_Oc']
+  parents:
+  - 342889
+2030603:
+  aliases: ['Culicidae sp. JQQ002-4_Oc']
+  parents:
+  - 342889
+2030583:
+  aliases: ['Culicidae sp. JQQ003-082_Oc']
+  parents:
+  - 342889
+2030604:
+  aliases: ['Culicidae sp. JQQ003-119_Oc']
+  parents:
+  - 342889
+2030537:
+  aliases: ['Culicidae sp. JQQ003-126_Oc']
+  parents:
+  - 342889
+2030582:
+  aliases: ['Culicidae sp. JQQ003-13_Oc']
+  parents:
+  - 342889
+2030529:
+  aliases: ['Culicidae sp. JQQ003-33_Oc']
+  parents:
+  - 342889
+2030532:
+  aliases: ['Culicidae sp. JQQ003-37_Oc']
+  parents:
+  - 342889
+2030535:
+  aliases: ['Culicidae sp. JQQ003-42_Oc']
+  parents:
+  - 342889
+2030606:
+  aliases: ['Culicidae sp. JQQ003-43_Oc']
+  parents:
+  - 342889
+2030605:
+  aliases: ['Culicidae sp. JQQ003-46_Oc']
+  parents:
+  - 342889
+2030531:
+  aliases: ['Culicidae sp. JQQ003-49_Oc']
+  parents:
+  - 342889
+2030534:
+  aliases: ['Culicidae sp. JQQ003-52_Oc']
+  parents:
+  - 342889
+2030539:
+  aliases: ['Culicidae sp. JQQ003-54_Oc']
+  parents:
+  - 342889
+2030533:
+  aliases: ['Culicidae sp. JQQ003-66_Oc']
+  parents:
+  - 342889
+2030530:
+  aliases: ['Culicidae sp. JQQ003-73_Oc']
+  parents:
+  - 342889
+2030538:
+  aliases: ['Culicidae sp. JQQ003-78_Oc']
+  parents:
+  - 342889
+2030540:
+  aliases: ['Culicidae sp. JQQ003-94_Oc']
+  parents:
+  - 342889
+2030506:
+  aliases: ['Culicidae sp. JQQ004-101_Cx']
+  parents:
+  - 342889
+2030641:
+  aliases: ['Culicidae sp. JSHA16-13_Hw']
+  parents:
+  - 342889
+2030642:
+  aliases: ['Culicidae sp. JSHA16-18_Hw']
+  parents:
+  - 342889
+2030639:
+  aliases: ['Culicidae sp. JSHA16-1_Hw']
+  parents:
+  - 342889
+2030627:
+  aliases: ['Culicidae sp. JSHA16-9_Hw']
+  parents:
+  - 342889
+2030620:
+  aliases: ['Culicidae sp. JSHA36-11_Hw']
+  parents:
+  - 342889
+2030643:
+  aliases: ['Culicidae sp. JSHA36-4_Hw']
+  parents:
+  - 342889
+2030645:
+  aliases: ['Culicidae sp. JSHA36-6_Hw']
+  parents:
+  - 342889
+2030640:
+  aliases: ['Culicidae sp. JSHA36-9_Hw']
+  parents:
+  - 342889
+2030616:
+  aliases: ['Culicidae sp. JSHA39-2_Hw']
+  parents:
+  - 342889
+2030554:
+  aliases: ['Culicidae sp. JSHA47-1_Hw']
+  parents:
+  - 342889
+2030624:
+  aliases: ['Culicidae sp. JSHA48-2_Hw']
+  parents:
+  - 342889
+2030617:
+  aliases: ['Culicidae sp. JSHA53_Hw']
+  parents:
+  - 342889
+1457336:
+  aliases: ['Culicidae sp. LAMV_M07_contig1']
+  parents:
+  - 342889
+1457337:
+  aliases: ['Culicidae sp. LAMV_M07_contig2']
+  parents:
+  - 342889
+1457338:
+  aliases: ['Culicidae sp. LAMV_M07_contig3']
+  parents:
+  - 342889
+1457339:
+  aliases: ['Culicidae sp. LAMV_M07_contig4']
+  parents:
+  - 342889
+1457340:
+  aliases: ['Culicidae sp. LAMV_M07_contig5']
+  parents:
+  - 342889
+1457341:
+  aliases: ['Culicidae sp. LAMV_M07_contig6']
+  parents:
+  - 342889
+1457342:
+  aliases: ['Culicidae sp. LAMV_M07_contig7']
+  parents:
+  - 342889
+1457343:
+  aliases: ['Culicidae sp. LAMV_M07_contig8']
+  parents:
+  - 342889
+1457344:
+  aliases: ['Culicidae sp. LAMV_M07_contig9']
+  parents:
+  - 342889
+342890:
+  aliases: ['Culicidae sp. M32']
+  parents:
+  - 342889
+342891:
+  aliases: ['Culicidae sp. M36']
+  parents:
+  - 342889
+342892:
+  aliases: ['Culicidae sp. M53']
+  parents:
+  - 342889
+1688407:
+  aliases: ['Culicidae sp. N17AM']
+  parents:
+  - 342889
+1688408:
+  aliases: ['Culicidae sp. N21AM3']
+  parents:
+  - 342889
+1688409:
+  aliases: ['Culicidae sp. N22AM2']
+  parents:
+  - 342889
+1688410:
+  aliases: ['Culicidae sp. N23AM']
+  parents:
+  - 342889
+1688411:
+  aliases: ['Culicidae sp. N23BM']
+  parents:
+  - 342889
+1688412:
+  aliases: ['Culicidae sp. N24AM']
+  parents:
+  - 342889
+1688413:
+  aliases: ['Culicidae sp. N28AM']
+  parents:
+  - 342889
+1688414:
+  aliases: ['Culicidae sp. N36AM']
+  parents:
+  - 342889
+1688415:
+  aliases: ['Culicidae sp. N36AM2']
+  parents:
+  - 342889
+1688416:
+  aliases: ['Culicidae sp. N38B.M2']
+  parents:
+  - 342889
+1688417:
+  aliases: ['Culicidae sp. N39BM3']
+  parents:
+  - 342889
+1688418:
+  aliases: ['Culicidae sp. Ne39M']
+  parents:
+  - 342889
+2030622:
+  aliases: ['Culicidae sp. PS1013-10_Hw']
+  parents:
+  - 342889
+2030644:
+  aliases: ['Culicidae sp. PS1014-1_Hw']
+  parents:
+  - 342889
+2030560:
+  aliases: ['Culicidae sp. PSI-19_Hw']
+  parents:
+  - 342889
+2030566:
+  aliases: ['Culicidae sp. PSI-21_Hw']
+  parents:
+  - 342889
+2030543:
+  aliases: ['Culicidae sp. PSI-24_Hw']
+  parents:
+  - 342889
+2030564:
+  aliases: ['Culicidae sp. PSI-25_Hw']
+  parents:
+  - 342889
+2030565:
+  aliases: ['Culicidae sp. PSI-35_Hw']
+  parents:
+  - 342889
+2030527:
+  aliases: ['Culicidae sp. PSI-39_Hw']
+  parents:
+  - 342889
+2030557:
+  aliases: ['Culicidae sp. PSI-45_Hw']
+  parents:
+  - 342889
+2030558:
+  aliases: ['Culicidae sp. PSI-57_Hw']
+  parents:
+  - 342889
+2030559:
+  aliases: ['Culicidae sp. PSI-59_Hw']
+  parents:
+  - 342889
+2030528:
+  aliases: ['Culicidae sp. PSI-60_Hw']
+  parents:
+  - 342889
+2030562:
+  aliases: ['Culicidae sp. PSI-66_Hw']
+  parents:
+  - 342889
+2030556:
+  aliases: ['Culicidae sp. PSI-76_Hw']
+  parents:
+  - 342889
+2030550:
+  aliases: ['Culicidae sp. PSI004-003_Hw']
+  parents:
+  - 342889
+2030504:
+  aliases: ['Culicidae sp. PSI005-2_Cx']
+  parents:
+  - 342889
+2030570:
+  aliases: ['Culicidae sp. PSI012-4_Hw']
+  parents:
+  - 342889
+2030495:
+  aliases: ['Culicidae sp. PSI012-5_Hw']
+  parents:
+  - 342889
+2030569:
+  aliases: ['Culicidae sp. PSI013-10_Hw']
+  parents:
+  - 342889
+2030608:
+  aliases: ['Culicidae sp. PSI013-11']
+  parents:
+  - 342889
+2030613:
+  aliases: ['Culicidae sp. PSI013-14_Hw']
+  parents:
+  - 342889
+2030646:
+  aliases: ['Culicidae sp. PSI013-15_Hw']
+  parents:
+  - 342889
+2030621:
+  aliases: ['Culicidae sp. PSI013-9_Hw']
+  parents:
+  - 342889
+2030615:
+  aliases: ['Culicidae sp. PSI015-001_Hw']
+  parents:
+  - 342889
+2030525:
+  aliases: ['Culicidae sp. PSI015-1_Hw']
+  parents:
+  - 342889
+2030611:
+  aliases: ['Culicidae sp. PSI016-1_Hw']
+  parents:
+  - 342889
+2030524:
+  aliases: ['Culicidae sp. PSI018-1_Hw']
+  parents:
+  - 342889
+2030614:
+  aliases: ['Culicidae sp. PSI020-1_Hw']
+  parents:
+  - 342889
+2030631:
+  aliases: ['Culicidae sp. PSI12_Oc']
+  parents:
+  - 342889
+2030541:
+  aliases: ['Culicidae sp. PSI14_Hw/Oc']
+  parents:
+  - 342889
+2030546:
+  aliases: ['Culicidae sp. PSI23_Hw/Oc']
+  parents:
+  - 342889
+2030561:
+  aliases: ['Culicidae sp. PSI32_Hw']
+  parents:
+  - 342889
+2030626:
+  aliases: ['Culicidae sp. PSI40_Hw']
+  parents:
+  - 342889
+1921263:
+  aliases: ['Culicidae sp. RC2-003']
+  parents:
+  - 342889
+1749814:
+  aliases: ['Culicidae sp. SSJAA387-13']
+  parents:
+  - 342889
+1861249:
+  aliases: ['Culicidae sp. SSJAE5198-13']
+  parents:
+  - 342889
+1861250:
+  aliases: ['Culicidae sp. SSJAE9915-13']
+  parents:
+  - 342889
+1861251:
+  aliases: ['Culicidae sp. SSJAE9917-13']
+  parents:
+  - 342889
+1861252:
+  aliases: ['Culicidae sp. SSJAE9923-13']
+  parents:
+  - 342889
+1861253:
+  aliases: ['Culicidae sp. SSJAE9977-13']
+  parents:
+  - 342889
+1861254:
+  aliases: ['Culicidae sp. SSROA519-14']
+  parents:
+  - 342889
+409340:
+  aliases: ['Culicidae sp. Sallum-2006']
+  parents:
+  - 342889
+2744801:
+  aliases: ['Culicidae sp. W1']
+  parents:
+  - 342889
+2743523:
+  aliases: ['Culicidae sp. W10']
+  parents:
+  - 342889
+2742516:
+  aliases: ['Culicidae sp. W2']
+  parents:
+  - 342889
+2742517:
+  aliases: ['Culicidae sp. W3']
+  parents:
+  - 342889
+2742518:
+  aliases: ['Culicidae sp. W4']
+  parents:
+  - 342889
+2742519:
+  aliases: ['Culicidae sp. W5']
+  parents:
+  - 342889
+2743672:
+  aliases: ['Culicidae sp. W6']
+  parents:
+  - 342889
+2744364:
+  aliases: ['Culicidae sp. W7']
+  parents:
+  - 342889
+2743524:
+  aliases: ['Culicidae sp. W9']
+  parents:
+  - 342889
+1677833:
+  aliases: ['Culicidae sp. ZFMK PR005-Colombia']
+  parents:
+  - 342889
+2892218:
+  aliases: ['Culicidae sp. ZMUO 012838']
+  parents:
+  - 342889
+2892219:
+  aliases: ['Culicidae sp. ZMUO 012839']
+  parents:
+  - 342889
+2892220:
+  aliases: ['Culicidae sp. ZMUO 012840']
+  parents:
+  - 342889
+2892221:
+  aliases: ['Culicidae sp. ZMUO 012841']
+  parents:
+  - 342889
+2892222:
+  aliases: ['Culicidae sp. ZMUO 012842']
+  parents:
+  - 342889
+1900190:
+  aliases: ['Culicidae sp. sc_00010']
+  parents:
+  - 342889
+1900191:
+  aliases: ['Culicidae sp. sc_00377']
+  parents:
+  - 342889
+1900192:
+  aliases: ['Culicidae sp. sc_01319']
+  parents:
+  - 342889
+1900193:
+  aliases: ['Culicidae sp. sc_01327']
+  parents:
+  - 342889
+1900194:
+  aliases: ['Culicidae sp. sc_01371']
+  parents:
+  - 342889
+1900195:
+  aliases: ['Culicidae sp. sc_01973']
+  parents:
+  - 342889
+1900196:
+  aliases: ['Culicidae sp. sc_01974']
+  parents:
+  - 342889
+1900197:
+  aliases: ['Culicidae sp. sc_02090']
+  parents:
+  - 342889
+1900198:
+  aliases: ['Culicidae sp. sc_02111']
+  parents:
+  - 342889
+1900199:
+  aliases: ['Culicidae sp. sc_02121']
+  parents:
+  - 342889
+1900200:
+  aliases: ['Culicidae sp. sc_02702']
+  parents:
+  - 342889
+1900201:
+  aliases: ['Culicidae sp. sc_02703']
+  parents:
+  - 342889
+1900202:
+  aliases: ['Culicidae sp. sc_02856']
+  parents:
+  - 342889
+1900203:
+  aliases: ['Culicidae sp. sc_02857']
+  parents:
+  - 342889
+1900204:
+  aliases: ['Culicidae sp. sc_02858']
+  parents:
+  - 342889
+1900205:
+  aliases: ['Culicidae sp. sc_05279']
+  parents:
+  - 342889
+1900206:
+  aliases: ['Culicidae sp. sc_05280']
+  parents:
+  - 342889
+1900207:
+  aliases: ['Culicidae sp. sc_05290']
+  parents:
+  - 342889
+1900208:
+  aliases: ['Culicidae sp. sc_05334']
+  parents:
+  - 342889
+1900209:
+  aliases: ['Culicidae sp. sc_05400']
+  parents:
+  - 342889
+1900210:
+  aliases: ['Culicidae sp. sc_05401']
+  parents:
+  - 342889
+1900211:
+  aliases: ['Culicidae sp. sc_05593']
+  parents:
+  - 342889
+1900212:
+  aliases: ['Culicidae sp. sc_05594']
+  parents:
+  - 342889
+1900213:
+  aliases: ['Culicidae sp. sc_05595']
+  parents:
+  - 342889
+1900214:
+  aliases: ['Culicidae sp. sc_05789']
+  parents:
+  - 342889
+1900215:
+  aliases: ['Culicidae sp. sc_05960']
+  parents:
+  - 342889
+1900216:
+  aliases: ['Culicidae sp. sc_06471']
+  parents:
+  - 342889
+1900217:
+  aliases: ['Culicidae sp. sc_06676']
+  parents:
+  - 342889
+1900218:
+  aliases: ['Culicidae sp. sc_07008']
+  parents:
+  - 342889
+1900219:
+  aliases: ['Culicidae sp. sc_07177']
+  parents:
+  - 342889
+1900220:
+  aliases: ['Culicidae sp. sc_07178']
+  parents:
+  - 342889
+1900221:
+  aliases: ['Culicidae sp. sc_07181']
+  parents:
+  - 342889
+1900222:
+  aliases: ['Culicidae sp. sc_07189']
+  parents:
+  - 342889
+1900223:
+  aliases: ['Culicidae sp. sc_07844']
+  parents:
+  - 342889
+1900224:
+  aliases: ['Culicidae sp. sc_07850']
+  parents:
+  - 342889
+53550:
+  aliases: ['Culicini']
+  parents:
+  - 43817
+308729:
+  aliases: ['Culisetini']
+  parents:
+  - 43817
+308727:
+  aliases: ['Ficalbiini']
+  parents:
+  - 43817
+308728:
+  aliases: ['Hodgesiini']
+  parents:
+  - 43817
+254792:
+  aliases: ['Mansoniini']
+  parents:
+  - 43817
+149617:
+  aliases: ['Orthopodmyiini']
+  parents:
+  - 43817
+53549:
+  aliases: ['Sabethini']
+  parents:
+  - 43817
+46207:
+  aliases: ['Toxorhynchites']
+  parents:
+  - 43818
+149616:
+  aliases: ['Uranotaeniini']
+  parents:
+  - 43817
+2785975:
+  aliases: ['unclassified Anophelinae']
+  parents:
+  - 43816
+1693839:
+  aliases: ['unclassified Culicinae']
+  parents:
+  - 43817
+1548035:
+  aliases: ['Acartomyia']
+  parents:
+  - 1056966
+139057:
+  aliases: ['Aedeomyia']
+  parents:
+  - 1620265
+7158:
+  aliases: ['Aedes']
+  parents:
+  - 1056966
+44482:
+  aliases: ['Anopheles']
+  parents:
+  - 7164
+2785976:
+  aliases: ['Anophelinae sp.']
+  parents:
+  - 2785975
+124916:
+  aliases: ['Armigeres']
+  parents:
+  - 1056966
+53563:
+  aliases: ['Bironella']
+  parents:
+  - 53562
+425230:
+  aliases: ['Borichinda']
+  parents:
+  - 1056966
+53564:
+  aliases: ['Brugella']
+  parents:
+  - 53562
+2067443:
+  aliases: ['Catageiomyia']
+  parents:
+  - 1056966
+44534:
+  aliases: ['Cellia']
+  parents:
+  - 7164
+139052:
+  aliases: ['Chagasia bathana']
+  parents:
+  - 139051
+1426896:
+  aliases: ['Chagasia bonneae']
+  parents:
+  - 139051
+1426901:
+  aliases: ['Chagasia nr. fajardi BOLD:AAW1401']
+  parents:
+  - 139051
+1245380:
+  aliases: ['Collessius']
+  parents:
+  - 1056966
+329110:
+  aliases: ['Coquillettidia']
+  parents:
+  - 254792
+7174:
+  aliases: ['Culex']
+  parents:
+  - 53550
+2939109:
+  aliases: ['Culicinae sp.']
+  parents:
+  - 1693839
+2587930:
+  aliases: ['Culicinae sp. BAH_28365_A06']
+  parents:
+  - 1693839
+2308252:
+  aliases: ['Culicinae sp. BARS_2015_41_075']
+  parents:
+  - 1693839
+2308280:
+  aliases: ['Culicinae sp. BARS_2015_41_076']
+  parents:
+  - 1693839
+2308355:
+  aliases: ['Culicinae sp. BARS_2015_41_112']
+  parents:
+  - 1693839
+2308343:
+  aliases: ['Culicinae sp. BARS_2016_77_057']
+  parents:
+  - 1693839
+2327010:
+  aliases: ['Culicinae sp. BBDCP558-10']
+  parents:
+  - 1693839
+2308352:
+  aliases: ['Culicinae sp. BIOUG01402-B07']
+  parents:
+  - 1693839
+2308339:
+  aliases: ['Culicinae sp. BIOUG01402-C11']
+  parents:
+  - 1693839
+2533793:
+  aliases: ['Culicinae sp. BIOUG11374-H02']
+  parents:
+  - 1693839
+2557229:
+  aliases: ['Culicinae sp. BIOUG11377-H09']
+  parents:
+  - 1693839
+2533794:
+  aliases: ['Culicinae sp. BIOUG11668-A03']
+  parents:
+  - 1693839
+2208792:
+  aliases: ['Culicinae sp. BIOUG11985-E01']
+  parents:
+  - 1693839
+2533795:
+  aliases: ['Culicinae sp. BIOUG17745-C12']
+  parents:
+  - 1693839
+2533796:
+  aliases: ['Culicinae sp. BIOUG17771-F04']
+  parents:
+  - 1693839
+2208793:
+  aliases: ['Culicinae sp. BIOUG17863-D07']
+  parents:
+  - 1693839
+2533797:
+  aliases: ['Culicinae sp. BIOUG18015-A03']
+  parents:
+  - 1693839
+2533798:
+  aliases: ['Culicinae sp. BIOUG18113-A02']
+  parents:
+  - 1693839
+2208794:
+  aliases: ['Culicinae sp. BIOUG18381-D02']
+  parents:
+  - 1693839
+2533799:
+  aliases: ['Culicinae sp. BIOUG18454-E12']
+  parents:
+  - 1693839
+2208795:
+  aliases: ['Culicinae sp. BIOUG20564-D08']
+  parents:
+  - 1693839
+2208796:
+  aliases: ['Culicinae sp. BIOUG20666-F07']
+  parents:
+  - 1693839
+2208797:
+  aliases: ['Culicinae sp. BIOUG20666-F09']
+  parents:
+  - 1693839
+2208798:
+  aliases: ['Culicinae sp. BIOUG20869-B08']
+  parents:
+  - 1693839
+2208799:
+  aliases: ['Culicinae sp. BIOUG20869-D06']
+  parents:
+  - 1693839
+2208800:
+  aliases: ['Culicinae sp. BIOUG20869-E02']
+  parents:
+  - 1693839
+2208801:
+  aliases: ['Culicinae sp. BIOUG20878-F02']
+  parents:
+  - 1693839
+2533800:
+  aliases: ['Culicinae sp. BIOUG21061-F01']
+  parents:
+  - 1693839
+2208802:
+  aliases: ['Culicinae sp. BIOUG21103-G05']
+  parents:
+  - 1693839
+2208803:
+  aliases: ['Culicinae sp. BIOUG21104-H01']
+  parents:
+  - 1693839
+2208804:
+  aliases: ['Culicinae sp. BIOUG21106-D09']
+  parents:
+  - 1693839
+2208805:
+  aliases: ['Culicinae sp. BIOUG21113-G01']
+  parents:
+  - 1693839
+2208806:
+  aliases: ['Culicinae sp. BIOUG21114-F08']
+  parents:
+  - 1693839
+2208807:
+  aliases: ['Culicinae sp. BIOUG21162-C02']
+  parents:
+  - 1693839
+2208808:
+  aliases: ['Culicinae sp. BIOUG21641-C01']
+  parents:
+  - 1693839
+2208809:
+  aliases: ['Culicinae sp. BIOUG21641-D01']
+  parents:
+  - 1693839
+2208810:
+  aliases: ['Culicinae sp. BIOUG21642-F07']
+  parents:
+  - 1693839
+2208811:
+  aliases: ['Culicinae sp. BIOUG21868-D04']
+  parents:
+  - 1693839
+2208812:
+  aliases: ['Culicinae sp. BIOUG21868-D11']
+  parents:
+  - 1693839
+2208813:
+  aliases: ['Culicinae sp. BIOUG21868-D12']
+  parents:
+  - 1693839
+2208814:
+  aliases: ['Culicinae sp. BIOUG21868-H11']
+  parents:
+  - 1693839
+2308305:
+  aliases: ['Culicinae sp. BIOUG22042-G12']
+  parents:
+  - 1693839
+2208815:
+  aliases: ['Culicinae sp. BIOUG22131-G07']
+  parents:
+  - 1693839
+2208816:
+  aliases: ['Culicinae sp. BIOUG22134-A08']
+  parents:
+  - 1693839
+2208817:
+  aliases: ['Culicinae sp. BIOUG22134-E04']
+  parents:
+  - 1693839
+2208818:
+  aliases: ['Culicinae sp. BIOUG22134-G01']
+  parents:
+  - 1693839
+2208819:
+  aliases: ['Culicinae sp. BIOUG22134-G02']
+  parents:
+  - 1693839
+2208820:
+  aliases: ['Culicinae sp. BIOUG22135-A12']
+  parents:
+  - 1693839
+2208821:
+  aliases: ['Culicinae sp. BIOUG22135-D02']
+  parents:
+  - 1693839
+2208822:
+  aliases: ['Culicinae sp. BIOUG22135-D09']
+  parents:
+  - 1693839
+2208823:
+  aliases: ['Culicinae sp. BIOUG22135-H04']
+  parents:
+  - 1693839
+2208824:
+  aliases: ['Culicinae sp. BIOUG22136-A01']
+  parents:
+  - 1693839
+2208825:
+  aliases: ['Culicinae sp. BIOUG22136-F09']
+  parents:
+  - 1693839
+2208826:
+  aliases: ['Culicinae sp. BIOUG22138-D08']
+  parents:
+  - 1693839
+2208827:
+  aliases: ['Culicinae sp. BIOUG22138-E05']
+  parents:
+  - 1693839
+2208828:
+  aliases: ['Culicinae sp. BIOUG22138-F01']
+  parents:
+  - 1693839
+2208829:
+  aliases: ['Culicinae sp. BIOUG22139-B08']
+  parents:
+  - 1693839
+2208830:
+  aliases: ['Culicinae sp. BIOUG22139-B11']
+  parents:
+  - 1693839
+2208831:
+  aliases: ['Culicinae sp. BIOUG22139-C10']
+  parents:
+  - 1693839
+2208832:
+  aliases: ['Culicinae sp. BIOUG22139-C12']
+  parents:
+  - 1693839
+2208833:
+  aliases: ['Culicinae sp. BIOUG22139-G10']
+  parents:
+  - 1693839
+2208834:
+  aliases: ['Culicinae sp. BIOUG22139-H09']
+  parents:
+  - 1693839
+2208835:
+  aliases: ['Culicinae sp. BIOUG22158-F04']
+  parents:
+  - 1693839
+2208836:
+  aliases: ['Culicinae sp. BIOUG22376-B11']
+  parents:
+  - 1693839
+2208837:
+  aliases: ['Culicinae sp. BIOUG22429-A08']
+  parents:
+  - 1693839
+2208838:
+  aliases: ['Culicinae sp. BIOUG22429-B07']
+  parents:
+  - 1693839
+2208839:
+  aliases: ['Culicinae sp. BIOUG22430-A03']
+  parents:
+  - 1693839
+2208840:
+  aliases: ['Culicinae sp. BIOUG22430-A10']
+  parents:
+  - 1693839
+2208841:
+  aliases: ['Culicinae sp. BIOUG22430-B12']
+  parents:
+  - 1693839
+2208842:
+  aliases: ['Culicinae sp. BIOUG22430-D11']
+  parents:
+  - 1693839
+2208843:
+  aliases: ['Culicinae sp. BIOUG22430-F04']
+  parents:
+  - 1693839
+2308309:
+  aliases: ['Culicinae sp. BIOUG22432-G08']
+  parents:
+  - 1693839
+2308307:
+  aliases: ['Culicinae sp. BIOUG22515-B11']
+  parents:
+  - 1693839
+2308253:
+  aliases: ['Culicinae sp. BIOUG22524-A01']
+  parents:
+  - 1693839
+2308265:
+  aliases: ['Culicinae sp. BIOUG22524-A03']
+  parents:
+  - 1693839
+2308335:
+  aliases: ['Culicinae sp. BIOUG22524-A05']
+  parents:
+  - 1693839
+2308351:
+  aliases: ['Culicinae sp. BIOUG22524-E02']
+  parents:
+  - 1693839
+2308297:
+  aliases: ['Culicinae sp. BIOUG22524-E05']
+  parents:
+  - 1693839
+2308316:
+  aliases: ['Culicinae sp. BIOUG22524-E07']
+  parents:
+  - 1693839
+2308342:
+  aliases: ['Culicinae sp. BIOUG22524-E11']
+  parents:
+  - 1693839
+2308260:
+  aliases: ['Culicinae sp. BIOUG22524-F03']
+  parents:
+  - 1693839
+2308321:
+  aliases: ['Culicinae sp. BIOUG22524-F04']
+  parents:
+  - 1693839
+2308302:
+  aliases: ['Culicinae sp. BIOUG22524-G05']
+  parents:
+  - 1693839
+2308301:
+  aliases: ['Culicinae sp. BIOUG22524-G08']
+  parents:
+  - 1693839
+2308275:
+  aliases: ['Culicinae sp. BIOUG22524-H03']
+  parents:
+  - 1693839
+2308332:
+  aliases: ['Culicinae sp. BIOUG22524-H09']
+  parents:
+  - 1693839
+2208844:
+  aliases: ['Culicinae sp. BIOUG22858-B06']
+  parents:
+  - 1693839
+2208845:
+  aliases: ['Culicinae sp. BIOUG22859-E03']
+  parents:
+  - 1693839
+2208846:
+  aliases: ['Culicinae sp. BIOUG22860-H02']
+  parents:
+  - 1693839
+2308326:
+  aliases: ['Culicinae sp. BIOUG22956-A05']
+  parents:
+  - 1693839
+2308347:
+  aliases: ['Culicinae sp. BIOUG22959-A03']
+  parents:
+  - 1693839
+2308266:
+  aliases: ['Culicinae sp. BIOUG22960-H04']
+  parents:
+  - 1693839
+2308259:
+  aliases: ['Culicinae sp. BIOUG23267-F05']
+  parents:
+  - 1693839
+2208847:
+  aliases: ['Culicinae sp. BIOUG23382-B10']
+  parents:
+  - 1693839
+2208848:
+  aliases: ['Culicinae sp. BIOUG23383-A01']
+  parents:
+  - 1693839
+2308279:
+  aliases: ['Culicinae sp. BIOUG23535-A06']
+  parents:
+  - 1693839
+2308285:
+  aliases: ['Culicinae sp. BIOUG23580-C10']
+  parents:
+  - 1693839
+2308295:
+  aliases: ['Culicinae sp. BIOUG23666-A05']
+  parents:
+  - 1693839
+2208849:
+  aliases: ['Culicinae sp. BIOUG23678-C01']
+  parents:
+  - 1693839
+2208850:
+  aliases: ['Culicinae sp. BIOUG23787-G02']
+  parents:
+  - 1693839
+2308274:
+  aliases: ['Culicinae sp. BIOUG24097-E12']
+  parents:
+  - 1693839
+2308286:
+  aliases: ['Culicinae sp. BIOUG24355-H09']
+  parents:
+  - 1693839
+2208851:
+  aliases: ['Culicinae sp. BIOUG24582-F04']
+  parents:
+  - 1693839
+2208852:
+  aliases: ['Culicinae sp. BIOUG24639-C02']
+  parents:
+  - 1693839
+2533801:
+  aliases: ['Culicinae sp. BIOUG24639-E10']
+  parents:
+  - 1693839
+2208853:
+  aliases: ['Culicinae sp. BIOUG24639-F12']
+  parents:
+  - 1693839
+2308330:
+  aliases: ['Culicinae sp. BIOUG25706-E08']
+  parents:
+  - 1693839
+2308258:
+  aliases: ['Culicinae sp. BIOUG25809-B08']
+  parents:
+  - 1693839
+2308272:
+  aliases: ['Culicinae sp. BIOUG25809-B10']
+  parents:
+  - 1693839
+2308345:
+  aliases: ['Culicinae sp. BIOUG25810-D09']
+  parents:
+  - 1693839
+2308325:
+  aliases: ['Culicinae sp. BIOUG26011-B07']
+  parents:
+  - 1693839
+2308324:
+  aliases: ['Culicinae sp. BIOUG26011-E01']
+  parents:
+  - 1693839
+2308261:
+  aliases: ['Culicinae sp. BIOUG26011-F10']
+  parents:
+  - 1693839
+2308304:
+  aliases: ['Culicinae sp. BIOUG26012-A06']
+  parents:
+  - 1693839
+2308314:
+  aliases: ['Culicinae sp. BIOUG26012-A12']
+  parents:
+  - 1693839
+2308300:
+  aliases: ['Culicinae sp. BIOUG26012-C02']
+  parents:
+  - 1693839
+2308333:
+  aliases: ['Culicinae sp. BIOUG26012-C12']
+  parents:
+  - 1693839
+2308334:
+  aliases: ['Culicinae sp. BIOUG26012-E08']
+  parents:
+  - 1693839
+2308306:
+  aliases: ['Culicinae sp. BIOUG26012-E09']
+  parents:
+  - 1693839
+2308257:
+  aliases: ['Culicinae sp. BIOUG26012-F06']
+  parents:
+  - 1693839
+2308292:
+  aliases: ['Culicinae sp. BIOUG26012-H04']
+  parents:
+  - 1693839
+2308346:
+  aliases: ['Culicinae sp. BIOUG26012-H10']
+  parents:
+  - 1693839
+2308350:
+  aliases: ['Culicinae sp. BIOUG26017-A07']
+  parents:
+  - 1693839
+2308282:
+  aliases: ['Culicinae sp. BIOUG26017-A09']
+  parents:
+  - 1693839
+2308310:
+  aliases: ['Culicinae sp. BIOUG26017-B04']
+  parents:
+  - 1693839
+2308354:
+  aliases: ['Culicinae sp. BIOUG26017-B08']
+  parents:
+  - 1693839
+2308269:
+  aliases: ['Culicinae sp. BIOUG26017-C05']
+  parents:
+  - 1693839
+2308356:
+  aliases: ['Culicinae sp. BIOUG26017-C09']
+  parents:
+  - 1693839
+2308281:
+  aliases: ['Culicinae sp. BIOUG26017-C10']
+  parents:
+  - 1693839
+2308263:
+  aliases: ['Culicinae sp. BIOUG26017-D01']
+  parents:
+  - 1693839
+2308289:
+  aliases: ['Culicinae sp. BIOUG26017-D03']
+  parents:
+  - 1693839
+2308273:
+  aliases: ['Culicinae sp. BIOUG26017-E01']
+  parents:
+  - 1693839
+2308264:
+  aliases: ['Culicinae sp. BIOUG26017-E05']
+  parents:
+  - 1693839
+2308312:
+  aliases: ['Culicinae sp. BIOUG26017-H06']
+  parents:
+  - 1693839
+2308267:
+  aliases: ['Culicinae sp. BIOUG26018-H08']
+  parents:
+  - 1693839
+2308327:
+  aliases: ['Culicinae sp. BIOUG26019-A04']
+  parents:
+  - 1693839
+2208854:
+  aliases: ['Culicinae sp. BIOUG26185-E09']
+  parents:
+  - 1693839
+2208855:
+  aliases: ['Culicinae sp. BIOUG26185-E11']
+  parents:
+  - 1693839
+2208856:
+  aliases: ['Culicinae sp. BIOUG26185-H10']
+  parents:
+  - 1693839
+2308322:
+  aliases: ['Culicinae sp. BIOUG26213-B04']
+  parents:
+  - 1693839
+2308277:
+  aliases: ['Culicinae sp. BIOUG26213-B07']
+  parents:
+  - 1693839
+2208857:
+  aliases: ['Culicinae sp. BIOUG26261-B12']
+  parents:
+  - 1693839
+2308348:
+  aliases: ['Culicinae sp. BIOUG26576-E01']
+  parents:
+  - 1693839
+2308270:
+  aliases: ['Culicinae sp. BIOUG26576-F02']
+  parents:
+  - 1693839
+2308336:
+  aliases: ['Culicinae sp. BIOUG26576-H09']
+  parents:
+  - 1693839
+2208858:
+  aliases: ['Culicinae sp. BIOUG26660-H05']
+  parents:
+  - 1693839
+2208859:
+  aliases: ['Culicinae sp. BIOUG26782-F04']
+  parents:
+  - 1693839
+2208860:
+  aliases: ['Culicinae sp. BIOUG27097-A01']
+  parents:
+  - 1693839
+2208861:
+  aliases: ['Culicinae sp. BIOUG27104-E12']
+  parents:
+  - 1693839
+2208862:
+  aliases: ['Culicinae sp. BIOUG27226-C11']
+  parents:
+  - 1693839
+2208863:
+  aliases: ['Culicinae sp. BIOUG27359-C04']
+  parents:
+  - 1693839
+2208864:
+  aliases: ['Culicinae sp. BIOUG27360-A03']
+  parents:
+  - 1693839
+2208865:
+  aliases: ['Culicinae sp. BIOUG27486-B03']
+  parents:
+  - 1693839
+2308288:
+  aliases: ['Culicinae sp. BIOUG31032-G10']
+  parents:
+  - 1693839
+2308338:
+  aliases: ['Culicinae sp. BIOUG31041-G09']
+  parents:
+  - 1693839
+2308296:
+  aliases: ['Culicinae sp. BIOUG31043-G10']
+  parents:
+  - 1693839
+2308319:
+  aliases: ['Culicinae sp. BIOUG31046-B12']
+  parents:
+  - 1693839
+2308271:
+  aliases: ['Culicinae sp. BIOUG31047-A10']
+  parents:
+  - 1693839
+2308317:
+  aliases: ['Culicinae sp. BIOUG31050-C04']
+  parents:
+  - 1693839
+2308287:
+  aliases: ['Culicinae sp. BIOUG31069-F10']
+  parents:
+  - 1693839
+2308299:
+  aliases: ['Culicinae sp. BIOUG31069-H02']
+  parents:
+  - 1693839
+2308283:
+  aliases: ['Culicinae sp. BIOUG31088-F10']
+  parents:
+  - 1693839
+2308276:
+  aliases: ['Culicinae sp. BIOUG31088-G03']
+  parents:
+  - 1693839
+2308294:
+  aliases: ['Culicinae sp. BIOUG31120-B06']
+  parents:
+  - 1693839
+2308323:
+  aliases: ['Culicinae sp. BIOUG31120-C02']
+  parents:
+  - 1693839
+2308293:
+  aliases: ['Culicinae sp. BIOUG31121-D08']
+  parents:
+  - 1693839
+2308341:
+  aliases: ['Culicinae sp. BIOUG31121-G04']
+  parents:
+  - 1693839
+2308255:
+  aliases: ['Culicinae sp. BIOUG31801-F05']
+  parents:
+  - 1693839
+2308331:
+  aliases: ['Culicinae sp. BIOUG31834-E10']
+  parents:
+  - 1693839
+2308262:
+  aliases: ['Culicinae sp. BIOUG31834-F08']
+  parents:
+  - 1693839
+2308291:
+  aliases: ['Culicinae sp. BIOUG31834-H05']
+  parents:
+  - 1693839
+2308349:
+  aliases: ['Culicinae sp. BIOUG31863-B12']
+  parents:
+  - 1693839
+2308254:
+  aliases: ['Culicinae sp. BIOUG31863-C01']
+  parents:
+  - 1693839
+2308290:
+  aliases: ['Culicinae sp. BIOUG31863-C02']
+  parents:
+  - 1693839
+2308311:
+  aliases: ['Culicinae sp. BIOUG31863-C03']
+  parents:
+  - 1693839
+2308315:
+  aliases: ['Culicinae sp. BIOUG31991-C01']
+  parents:
+  - 1693839
+2308320:
+  aliases: ['Culicinae sp. BIOUG32136-G08']
+  parents:
+  - 1693839
+2308308:
+  aliases: ['Culicinae sp. BIOUG32138-G12']
+  parents:
+  - 1693839
+2308344:
+  aliases: ['Culicinae sp. BIOUG32139-A07']
+  parents:
+  - 1693839
+2308313:
+  aliases: ['Culicinae sp. BIOUG32141-H10']
+  parents:
+  - 1693839
+2308353:
+  aliases: ['Culicinae sp. BIOUG32165-F01']
+  parents:
+  - 1693839
+2308337:
+  aliases: ['Culicinae sp. BIOUG32167-E10']
+  parents:
+  - 1693839
+2308278:
+  aliases: ['Culicinae sp. BIOUG32168-D12']
+  parents:
+  - 1693839
+2308298:
+  aliases: ['Culicinae sp. BIOUG32187-C10']
+  parents:
+  - 1693839
+2308284:
+  aliases: ['Culicinae sp. BIOUG32187-E09']
+  parents:
+  - 1693839
+2308318:
+  aliases: ['Culicinae sp. BIOUG32187-F10']
+  parents:
+  - 1693839
+2308268:
+  aliases: ['Culicinae sp. BIOUG32188-F11']
+  parents:
+  - 1693839
+2308329:
+  aliases: ['Culicinae sp. BIOUG32188-G09']
+  parents:
+  - 1693839
+2308328:
+  aliases: ['Culicinae sp. BIOUG32272-G07']
+  parents:
+  - 1693839
+2308340:
+  aliases: ['Culicinae sp. BIOUG32273-D08']
+  parents:
+  - 1693839
+2308303:
+  aliases: ['Culicinae sp. BIOUG32311-H10']
+  parents:
+  - 1693839
+2308256:
+  aliases: ['Culicinae sp. BIOUG32484-G01']
+  parents:
+  - 1693839
+1881760:
+  aliases: ['Culicinae sp. BOLD-2016']
+  parents:
+  - 1693839
+1693840:
+  aliases: ['Culicinae sp. BOLD:AAA3748']
+  parents:
+  - 1693839
+1693841:
+  aliases: ['Culicinae sp. BOLD:AAA3750']
+  parents:
+  - 1693839
+1741581:
+  aliases: ['Culicinae sp. BOLD:AAA3751']
+  parents:
+  - 1693839
+1741582:
+  aliases: ['Culicinae sp. BOLD:AAA6145']
+  parents:
+  - 1693839
+1693842:
+  aliases: ['Culicinae sp. BOLD:AAA6148']
+  parents:
+  - 1693839
+1741583:
+  aliases: ['Culicinae sp. BOLD:AAA7067']
+  parents:
+  - 1693839
+1693843:
+  aliases: ['Culicinae sp. BOLD:AAB1098']
+  parents:
+  - 1693839
+1693844:
+  aliases: ['Culicinae sp. BOLD:AAB2539']
+  parents:
+  - 1693839
+1722173:
+  aliases: ['Culicinae sp. BOLD:AAB5696']
+  parents:
+  - 1693839
+1693845:
+  aliases: ['Culicinae sp. BOLD:AAB6338']
+  parents:
+  - 1693839
+1693846:
+  aliases: ['Culicinae sp. BOLD:AAC9062']
+  parents:
+  - 1693839
+1822824:
+  aliases: ['Culicinae sp. BOLD:AAC9531']
+  parents:
+  - 1693839
+1749815:
+  aliases: ['Culicinae sp. BOLD:AAD3254']
+  parents:
+  - 1693839
+1749816:
+  aliases: ['Culicinae sp. BOLD:AAD4326']
+  parents:
+  - 1693839
+1722174:
+  aliases: ['Culicinae sp. BOLD:AAD4355']
+  parents:
+  - 1693839
+1722175:
+  aliases: ['Culicinae sp. BOLD:AAD4406']
+  parents:
+  - 1693839
+1754368:
+  aliases: ['Culicinae sp. BOLD:AAD7982']
+  parents:
+  - 1693839
+1722176:
+  aliases: ['Culicinae sp. BOLD:AAD8027']
+  parents:
+  - 1693839
+1693847:
+  aliases: ['Culicinae sp. BOLD:AAF2904']
+  parents:
+  - 1693839
+1724674:
+  aliases: ['Culicinae sp. BOLD:AAI1618']
+  parents:
+  - 1693839
+1693848:
+  aliases: ['Culicinae sp. BOLD:AAM4536']
+  parents:
+  - 1693839
+1693849:
+  aliases: ['Culicinae sp. BOLD:ABY6464']
+  parents:
+  - 1693839
+1822825:
+  aliases: ['Culicinae sp. BOLD:ACC5413']
+  parents:
+  - 1693839
+1693850:
+  aliases: ['Culicinae sp. BOLD:ACE6286']
+  parents:
+  - 1693839
+1822826:
+  aliases: ['Culicinae sp. CNPKE559-14']
+  parents:
+  - 1693839
+1754369:
+  aliases: ['Culicinae sp. CNWBG1694-13']
+  parents:
+  - 1693839
+1744653:
+  aliases: ['Culicinae sp. SSBAB2152-12']
+  parents:
+  - 1693839
+1744688:
+  aliases: ['Culicinae sp. SSBAD895-12']
+  parents:
+  - 1693839
+1744726:
+  aliases: ['Culicinae sp. SSBAE5252-13']
+  parents:
+  - 1693839
+1744727:
+  aliases: ['Culicinae sp. SSBAE5301-13']
+  parents:
+  - 1693839
+1744728:
+  aliases: ['Culicinae sp. SSBAE5321-13']
+  parents:
+  - 1693839
+1744730:
+  aliases: ['Culicinae sp. SSBAE5480-13']
+  parents:
+  - 1693839
+1744731:
+  aliases: ['Culicinae sp. SSBAE5509-13']
+  parents:
+  - 1693839
+1749817:
+  aliases: ['Culicinae sp. SSEIA7153-13']
+  parents:
+  - 1693839
+1749818:
+  aliases: ['Culicinae sp. SSEIB1985-13']
+  parents:
+  - 1693839
+1741584:
+  aliases: ['Culicinae sp. SSJAE2136-13']
+  parents:
+  - 1693839
+1693851:
+  aliases: ['Culicinae sp. SSPAB9906-13']
+  parents:
+  - 1693839
+1693852:
+  aliases: ['Culicinae sp. SSPAG130-13']
+  parents:
+  - 1693839
+1693853:
+  aliases: ['Culicinae sp. SSWLA4556-13']
+  parents:
+  - 1693839
+174825:
+  aliases: ['Culiseta']
+  parents:
+  - 308729
+53524:
+  aliases: ['Deinocerites']
+  parents:
+  - 53550
+317801:
+  aliases: ['Eretmapodites']
+  parents:
+  - 1056966
+308730:
+  aliases: ['Ficalbia']
+  parents:
+  - 308727
+2773402:
+  aliases: ['Gilesius']
+  parents:
+  - 1056966
+7180:
+  aliases: ['Haemagogus']
+  parents:
+  - 1056966
+317799:
+  aliases: ['Heizmannia']
+  parents:
+  - 1056966
+425228:
+  aliases: ['Hodgesia']
+  parents:
+  - 308728
+2007253:
+  aliases: ['Johnbelkinia']
+  parents:
+  - 53549
+68877:
+  aliases: ['Kerteszia']
+  parents:
+  - 7164
+704164:
+  aliases: ['Limatus']
+  parents:
+  - 53549
+273457:
+  aliases: ['Lophopodomyia']
+  parents:
+  - 7164
+53533:
+  aliases: ['Lutzia']
+  parents:
+  - 53550
+149618:
+  aliases: ['Malaya']
+  parents:
+  - 53549
+149459:
+  aliases: ['Mansonia']
+  parents:
+  - 254792
+704166:
+  aliases: ['Maorigoeldia']
+  parents:
+  - 53549
+308736:
+  aliases: ['Mimomyia']
+  parents:
+  - 308727
+53565:
+  aliases: ['Neobironella']
+  parents:
+  - 53562
+1367702:
+  aliases: ['Nyctomyia']
+  parents:
+  - 1056966
+44543:
+  aliases: ['Nyssorhynchus']
+  parents:
+  - 7164
+190765:
+  aliases: ['Ochlerotatus']
+  parents:
+  - 1056966
+2007256:
+  aliases: ['Onirion']
+  parents:
+  - 53549
+317800:
+  aliases: ['Opifex']
+  parents:
+  - 1056966
+139053:
+  aliases: ['Orthopodomyia']
+  parents:
+  - 149617
+1245386:
+  aliases: ['Phagomyia']
+  parents:
+  - 1056966
+7182:
+  aliases: ['Psorophora']
+  parents:
+  - 1056966
+2007258:
+  aliases: ['Runchomyia']
+  parents:
+  - 53549
+53551:
+  aliases: ['Sabethes']
+  parents:
+  - 53549
+704168:
+  aliases: ['Shannoniana']
+  parents:
+  - 53549
+273456:
+  aliases: ['Stethomyia']
+  parents:
+  - 7164
+1608558:
+  aliases: ['Tanakaius']
+  parents:
+  - 1056966
+1245394:
+  aliases: ['Topomyia']
+  parents:
+  - 53549
+46208:
+  aliases: ['Toxorhynchites amboinensis']
+  parents:
+  - 46207
+1245331:
+  aliases: ['Toxorhynchites aurifluus']
+  parents:
+  - 46207
+332059:
+  aliases: ['Toxorhynchites brevipalpis']
+  parents:
+  - 46207
+2108402:
+  aliases: ['Toxorhynchites caatingensis']
+  parents:
+  - 46207
+1310325:
+  aliases: ['Toxorhynchites christophi']
+  parents:
+  - 46207
+1245332:
+  aliases: ['Toxorhynchites edwardsi']
+  parents:
+  - 46207
+1245333:
+  aliases: ['Toxorhynchites gravelyi']
+  parents:
+  - 46207
+2007224:
+  aliases: ['Toxorhynchites guadeloupensis']
+  parents:
+  - 46207
+2007225:
+  aliases: ['Toxorhynchites haemorrhoidalis']
+  parents:
+  - 46207
+1245334:
+  aliases: ['Toxorhynchites kempi']
+  parents:
+  - 46207
+2498889:
+  aliases: ['Toxorhynchites manicatus']
+  parents:
+  - 46207
+2007228:
+  aliases: ['Toxorhynchites moctezuma']
+  parents:
+  - 46207
+2875522:
+  aliases: ['Toxorhynchites okinawensis']
+  parents:
+  - 46207
+3014951:
+  aliases: ['Toxorhynchites portoricensis']
+  parents:
+  - 46207
+53553:
+  aliases: ['Toxorhynchites rutilus']
+  parents:
+  - 46207
+2681096:
+  aliases: ['Toxorhynchites speciosus']
+  parents:
+  - 46207
+498392:
+  aliases: ['Toxorhynchites splendens']
+  parents:
+  - 46207
+2587270:
+  aliases: ['Toxorhynchites sunthorni']
+  parents:
+  - 46207
+1969993:
+  aliases: ['Toxorhynchites theobaldi']
+  parents:
+  - 46207
+1652498:
+  aliases: ['Toxorhynchites towadensis']
+  parents:
+  - 46207
+1231455:
+  aliases: ['Toxorhynchites tyagii']
+  parents:
+  - 46207
+704162:
+  aliases: ['Trichoprosopon']
+  parents:
+  - 53549
+53567:
+  aliases: ['Tripteroides']
+  parents:
+  - 53549
+1245387:
+  aliases: ['Udaya']
+  parents:
+  - 1056966
+139055:
+  aliases: ['Uranotaenia']
+  parents:
+  - 149616
+317805:
+  aliases: ['Verrallina']
+  parents:
+  - 1056966
+174620:
+  aliases: ['Wyeomyia']
+  parents:
+  - 53549
+1424509:
+  aliases: ['Zeugnomyia']
+  parents:
+  - 1056966
+2811849:
+  aliases: ['environmental samples']
+  parents:
+  - 7164
+63365:
+  aliases: ['unclassified Anopheles']
+  parents:
+  - 7164
+2629023:
+  aliases: ['unclassified Chagasia']
+  parents:
+  - 139051
+2624694:
+  aliases: ['unclassified Toxorhynchites']
+  parents:
+  - 46207
+120875:
+  aliases: ['Acartomyia mariae']
+  parents:
+  - 1548035
+1548036:
+  aliases: ['Acartomyia phoeniciae']
+  parents:
+  - 1548035
+1548034:
+  aliases: ['Acartomyia zammitii']
+  parents:
+  - 1548035
+1701320:
+  aliases: ['Aedeomyia africana']
+  parents:
+  - 139057
+308708:
+  aliases: ['Aedeomyia catasticta']
+  parents:
+  - 139057
+1799668:
+  aliases: ['Aedeomyia furfurea']
+  parents:
+  - 139057
+1620266:
+  aliases: ['Aedeomyia madagascarica']
+  parents:
+  - 139057
+139058:
+  aliases: ['Aedeomyia squamipennis']
+  parents:
+  - 139057
+1806173:
+  aliases: ['Aedeomyia venustipes']
+  parents:
+  - 139057
+149531:
+  aliases: ['Aedes']
+  parents:
+  - 7158
+1806188:
+  aliases: ['Aedes incertae sedis']
+  parents:
+  - 7158
+53540:
+  aliases: ['Aedimorphus']
+  parents:
+  - 7158
+1640510:
+  aliases: ['Aedinus']
+  parents:
+  - 7174
+300144:
+  aliases: ['Albuginosus']
+  parents:
+  - 7158
+44483:
+  aliases: ['Angusticorn']
+  parents:
+  - 44482
+1426913:
+  aliases: ['Anoedioporpa']
+  parents:
+  - 7174
+2830294:
+  aliases: ['Anopheles (Anopheles) sp. 1485']
+  parents:
+  - 63365
+2830320:
+  aliases: ['Anopheles (Anopheles) sp. 200']
+  parents:
+  - 63365
+2830307:
+  aliases: ['Anopheles (Anopheles) sp. 2000']
+  parents:
+  - 63365
+2830321:
+  aliases: ['Anopheles (Anopheles) sp. 2024']
+  parents:
+  - 63365
+2830322:
+  aliases: ['Anopheles (Anopheles) sp. 2093']
+  parents:
+  - 63365
+2830295:
+  aliases: ['Anopheles (Anopheles) sp. 215']
+  parents:
+  - 63365
+2830308:
+  aliases: ['Anopheles (Anopheles) sp. 2649']
+  parents:
+  - 63365
+2830296:
+  aliases: ['Anopheles (Anopheles) sp. 3387']
+  parents:
+  - 63365
+2830309:
+  aliases: ['Anopheles (Anopheles) sp. 3394']
+  parents:
+  - 63365
+2830323:
+  aliases: ['Anopheles (Anopheles) sp. 3397']
+  parents:
+  - 63365
+2830324:
+  aliases: ['Anopheles (Anopheles) sp. 3398']
+  parents:
+  - 63365
+2830310:
+  aliases: ['Anopheles (Anopheles) sp. 3399']
+  parents:
+  - 63365
+2830325:
+  aliases: ['Anopheles (Anopheles) sp. 3404']
+  parents:
+  - 63365
+2830297:
+  aliases: ['Anopheles (Anopheles) sp. 3438']
+  parents:
+  - 63365
+2830311:
+  aliases: ['Anopheles (Anopheles) sp. 3456']
+  parents:
+  - 63365
+2830312:
+  aliases: ['Anopheles (Anopheles) sp. 3467']
+  parents:
+  - 63365
+2830313:
+  aliases: ['Anopheles (Anopheles) sp. 3471']
+  parents:
+  - 63365
+2830314:
+  aliases: ['Anopheles (Anopheles) sp. 3474']
+  parents:
+  - 63365
+2830298:
+  aliases: ['Anopheles (Anopheles) sp. 3522']
+  parents:
+  - 63365
+2830326:
+  aliases: ['Anopheles (Anopheles) sp. 3610']
+  parents:
+  - 63365
+2830315:
+  aliases: ['Anopheles (Anopheles) sp. 3614']
+  parents:
+  - 63365
+2830299:
+  aliases: ['Anopheles (Anopheles) sp. 3621']
+  parents:
+  - 63365
+2830327:
+  aliases: ['Anopheles (Anopheles) sp. 3622']
+  parents:
+  - 63365
+2830328:
+  aliases: ['Anopheles (Anopheles) sp. 3623']
+  parents:
+  - 63365
+2830316:
+  aliases: ['Anopheles (Anopheles) sp. 3626']
+  parents:
+  - 63365
+2830300:
+  aliases: ['Anopheles (Anopheles) sp. 3631']
+  parents:
+  - 63365
+2830329:
+  aliases: ['Anopheles (Anopheles) sp. 3632']
+  parents:
+  - 63365
+2830330:
+  aliases: ['Anopheles (Anopheles) sp. 3675']
+  parents:
+  - 63365
+2830301:
+  aliases: ['Anopheles (Anopheles) sp. 3680']
+  parents:
+  - 63365
+2830331:
+  aliases: ['Anopheles (Anopheles) sp. 3705']
+  parents:
+  - 63365
+2830302:
+  aliases: ['Anopheles (Anopheles) sp. 3732']
+  parents:
+  - 63365
+2830303:
+  aliases: ['Anopheles (Anopheles) sp. 3736']
+  parents:
+  - 63365
+2830304:
+  aliases: ['Anopheles (Anopheles) sp. 3742']
+  parents:
+  - 63365
+2830317:
+  aliases: ['Anopheles (Anopheles) sp. 3745']
+  parents:
+  - 63365
+2830318:
+  aliases: ['Anopheles (Anopheles) sp. 3749']
+  parents:
+  - 63365
+2830332:
+  aliases: ['Anopheles (Anopheles) sp. 3750']
+  parents:
+  - 63365
+2830305:
+  aliases: ['Anopheles (Anopheles) sp. 3753']
+  parents:
+  - 63365
+2830319:
+  aliases: ['Anopheles (Anopheles) sp. 3757']
+  parents:
+  - 63365
+2830306:
+  aliases: ['Anopheles (Anopheles) sp. 3762']
+  parents:
+  - 63365
+2830333:
+  aliases: ['Anopheles (Anopheles) sp. M12']
+  parents:
+  - 63365
+190375:
+  aliases: ['Anopheles acanthotorynus']
+  parents:
+  - 273456
+2171928:
+  aliases: ['Anopheles aff. konderi A PGF-2018']
+  parents:
+  - 44543
+2171929:
+  aliases: ['Anopheles aff. konderi B PGF-2018']
+  parents:
+  - 44543
+2171930:
+  aliases: ['Anopheles aff. konderi C PGF-2018']
+  parents:
+  - 44543
+2860267:
+  aliases: ['Anopheles aff. konderi C TMPO-2021']
+  parents:
+  - 44543
+2171931:
+  aliases: ['Anopheles aff. lutzii A PGF-2018']
+  parents:
+  - 44543
+2171932:
+  aliases: ['Anopheles aff. lutzii B PGF-2018']
+  parents:
+  - 44543
+2830290:
+  aliases: ['Anopheles aff. neivai A TMPO-2021a']
+  parents:
+  - 68877
+2830291:
+  aliases: ['Anopheles aff. neivai B TMPO-2021a']
+  parents:
+  - 68877
+596823:
+  aliases: ['Anopheles antunesi']
+  parents:
+  - 44543
+1833978:
+  aliases: ['Anopheles azaniae']
+  parents:
+  - 44534
+2972757:
+  aliases: ['Anopheles azevedoi']
+  parents:
+  - 44534
+3031291:
+  aliases: ['Anopheles bambusicolus']
+  parents:
+  - 68877
+139047:
+  aliases: ['Anopheles bellator']
+  parents:
+  - 68877
+3031302:
+  aliases: ['Anopheles bellator complex 2BB']
+  parents:
+  - 68877
+2044755:
+  aliases: ['Anopheles boliviensis']
+  parents:
+  - 68877
+3031303:
+  aliases: ['Anopheles boliviensis complex 1BB']
+  parents:
+  - 68877
+2748954:
+  aliases: ['Anopheles brohieri']
+  parents:
+  - 44534
+2564023:
+  aliases: ['Anopheles brunnipes']
+  parents:
+  - 44534
+185577:
+  aliases: ['Anopheles carnevalei']
+  parents:
+  - 44534
+3097606:
+  aliases: ['Anopheles cf. coustani/ziemanni']
+  parents:
+  - 63365
+2807519:
+  aliases: ['Anopheles cf. pharoensis']
+  parents:
+  - 44534
+3097607:
+  aliases: ['Anopheles cf. vaneedeni/longipalpis']
+  parents:
+  - 63365
+1632206:
+  aliases: ['Anopheles cinereus']
+  parents:
+  - 44534
+2219645:
+  aliases: ['Anopheles coluzzii x Anopheles arabiensis']
+  parents:
+  - 44534
+2219646:
+  aliases: ['Anopheles coluzzii x Anopheles quadriannulatus']
+  parents:
+  - 44534
+68878:
+  aliases: ['Anopheles cruzii']
+  parents:
+  - 68877
+2748953:
+  aliases: ['Anopheles dureni']
+  parents:
+  - 44534
+2811792:
+  aliases: ['Anopheles environmental sample']
+  parents:
+  - 2811849
+3135065:
+  aliases: ['Anopheles fuscivenosus']
+  parents:
+  - 44534
+2913601:
+  aliases: ['Anopheles gibbinsi']
+  parents:
+  - 44534
+2171669:
+  aliases: ['Anopheles gilesi']
+  parents:
+  - 273457
+1048867:
+  aliases: ['Anopheles guarani']
+  parents:
+  - 44543
+1162629:
+  aliases: ['Anopheles hackeri']
+  parents:
+  - 44534
+1049720:
+  aliases: ['Anopheles halophylus']
+  parents:
+  - 44543
+3163323:
+  aliases: ['Anopheles hargreavesi']
+  parents:
+  - 44534
+486634:
+  aliases: ['Anopheles harrisoni']
+  parents:
+  - 44534
+369908:
+  aliases: ['Anopheles homunculus']
+  parents:
+  - 68877
+3031304:
+  aliases: ['Anopheles homunculus complex 1 YML-2023a']
+  parents:
+  - 68877
+3031305:
+  aliases: ['Anopheles homunculus complex 1BB']
+  parents:
+  - 68877
+190374:
+  aliases: ['Anopheles incertae sedis']
+  parents:
+  - 44482
+320069:
+  aliases: ['Anopheles indefinitus']
+  parents:
+  - 44534
+1678524:
+  aliases: ['Anopheles ininii']
+  parents:
+  - 44543
+1548502:
+  aliases: ['Anopheles introlatus']
+  parents:
+  - 44534
+2564024:
+  aliases: ['Anopheles jebudensis']
+  parents:
+  - 44534
+139048:
+  aliases: ['Anopheles kompi']
+  parents:
+  - 273456
+43180:
+  aliases: ['Anopheles konderi']
+  parents:
+  - 44543
+369909:
+  aliases: ['Anopheles laneanus']
+  parents:
+  - 68877
+596824:
+  aliases: ['Anopheles lanei']
+  parents:
+  - 44543
+1108002:
+  aliases: ['Anopheles lepidotus']
+  parents:
+  - 68877
+2793954:
+  aliases: ['Anopheles limosus']
+  parents:
+  - 44534
+2995624:
+  aliases: ['Anopheles ludlowae']
+  parents:
+  - 44534
+596825:
+  aliases: ['Anopheles lutzii']
+  parents:
+  - 44543
+1184682:
+  aliases: ['Anopheles lutzii s.l. 1 RS16']
+  parents:
+  - 44543
+1184683:
+  aliases: ['Anopheles lutzii s.l. 2 RS19']
+  parents:
+  - 44543
+1184684:
+  aliases: ['Anopheles lutzii s.l. 2 RS33']
+  parents:
+  - 44543
+2259328:
+  aliases: ['Anopheles mascarensis']
+  parents:
+  - 44534
+1194503:
+  aliases: ['Anopheles moghulensis']
+  parents:
+  - 44534
+139046:
+  aliases: ['Anopheles neivai']
+  parents:
+  - 68877
+3031306:
+  aliases: ['Anopheles neivai complex 2BB']
+  parents:
+  - 68877
+3031307:
+  aliases: ['Anopheles neivai complex 3BB']
+  parents:
+  - 68877
+3031308:
+  aliases: ['Anopheles neivai complex 4BB']
+  parents:
+  - 68877
+925982:
+  aliases: ['Anopheles nimbus']
+  parents:
+  - 273456
+632896:
+  aliases: ['Anopheles nr. antunesi MAMS-2009']
+  parents:
+  - 44543
+1406129:
+  aliases: ['Anopheles nr. dravidicus YML2012']
+  parents:
+  - 44534
+2138373:
+  aliases: ['Anopheles nr. konderi 39']
+  parents:
+  - 44543
+2138374:
+  aliases: ['Anopheles nr. konderi 40']
+  parents:
+  - 44543
+2138375:
+  aliases: ['Anopheles nr. konderi 42']
+  parents:
+  - 44543
+2049329:
+  aliases: ['Anopheles nr. konderi 424B']
+  parents:
+  - 44543
+2138376:
+  aliases: ['Anopheles nr. konderi 43']
+  parents:
+  - 44543
+2049330:
+  aliases: ['Anopheles nr. konderi 471B']
+  parents:
+  - 44543
+2049331:
+  aliases: ['Anopheles nr. konderi 479B']
+  parents:
+  - 44543
+2735825:
+  aliases: ['Anopheles nr. konderi Do B38']
+  parents:
+  - 44543
+2735826:
+  aliases: ['Anopheles nr. konderi Do B40']
+  parents:
+  - 44543
+1326108:
+  aliases: ['Anopheles nr. konderi FRL-2013']
+  parents:
+  - 44543
+2419676:
+  aliases: ['Anopheles nr. konderi MAMS-2018']
+  parents:
+  - 44543
+1280485:
+  aliases: ['Anopheles ovengensis']
+  parents:
+  - 44534
+596827:
+  aliases: ['Anopheles parvus']
+  parents:
+  - 44543
+1620269:
+  aliases: ['Anopheles pauliani']
+  parents:
+  - 44534
+221566:
+  aliases: ['Anopheles pharoensis']
+  parents:
+  - 44534
+319534:
+  aliases: ['Anopheles philippinensis']
+  parents:
+  - 44534
+1108003:
+  aliases: ['Anopheles pholidotus']
+  parents:
+  - 68877
+3031309:
+  aliases: ['Anopheles pholidotus complex 1BB']
+  parents:
+  - 68877
+3031310:
+  aliases: ['Anopheles pholidotus complex 2BB']
+  parents:
+  - 68877
+1141471:
+  aliases: ['Anopheles pretoriensis']
+  parents:
+  - 44534
+516961:
+  aliases: ['Anopheles pseudojamesi']
+  parents:
+  - 44534
+2171670:
+  aliases: ['Anopheles pseudotibiamaculatus']
+  parents:
+  - 273457
+1632207:
+  aliases: ['Anopheles rhodesiensis']
+  parents:
+  - 44534
+3031311:
+  aliases: ['Anopheles rollai complex 1BB']
+  parents:
+  - 68877
+3031312:
+  aliases: ['Anopheles rollai complex 2BB']
+  parents:
+  - 68877
+3031313:
+  aliases: ['Anopheles rollai complex 4BB']
+  parents:
+  - 68877
+3031314:
+  aliases: ['Anopheles rollai complex 5BB']
+  parents:
+  - 68877
+3424145:
+  aliases: ['Anopheles rondoniensis']
+  parents:
+  - 44543
+1141472:
+  aliases: ['Anopheles rufipes']
+  parents:
+  - 44534
+38782:
+  aliases: ['Anopheles sp.']
+  parents:
+  - 63365
+1496334:
+  aliases: ['Anopheles sp. 1 BSL-2014']
+  parents:
+  - 63365
+2609882:
+  aliases: ['Anopheles sp. 1 BSL-2014 cf1']
+  parents:
+  - 63365
+2731378:
+  aliases: ['Anopheles sp. 1 DZ-2020']
+  parents:
+  - 63365
+1293408:
+  aliases: ['Anopheles sp. 1 GW-2013']
+  parents:
+  - 63365
+2014930:
+  aliases: ['Anopheles sp. 1 YL-2017']
+  parents:
+  - 63365
+2510657:
+  aliases: ['Anopheles sp. 10FCM']
+  parents:
+  - 63365
+1496338:
+  aliases: ['Anopheles sp. 11 BSL-2014']
+  parents:
+  - 63365
+2499885:
+  aliases: ['Anopheles sp. 11 CMJ-2018']
+  parents:
+  - 63365
+2731379:
+  aliases: ['Anopheles sp. 11 DZ-2020']
+  parents:
+  - 63365
+2510658:
+  aliases: ['Anopheles sp. 11FCM']
+  parents:
+  - 63365
+2510659:
+  aliases: ['Anopheles sp. 12FCM']
+  parents:
+  - 63365
+1496339:
+  aliases: ['Anopheles sp. 14 BSL-2014']
+  parents:
+  - 63365
+2499886:
+  aliases: ['Anopheles sp. 14 CMJ-2018']
+  parents:
+  - 63365
+2731380:
+  aliases: ['Anopheles sp. 14 DZ-2020']
+  parents:
+  - 63365
+1496340:
+  aliases: ['Anopheles sp. 15 BSL-2014']
+  parents:
+  - 63365
+2499887:
+  aliases: ['Anopheles sp. 15 CMJ-2018']
+  parents:
+  - 63365
+2731381:
+  aliases: ['Anopheles sp. 15 DZ-2020']
+  parents:
+  - 63365
+2726198:
+  aliases: ['Anopheles sp. 15 JEF-2020']
+  parents:
+  - 63365
+1496341:
+  aliases: ['Anopheles sp. 16 BSL-2014']
+  parents:
+  - 63365
+2730096:
+  aliases: ['Anopheles sp. 17 DZ-2020']
+  parents:
+  - 63365
+2731382:
+  aliases: ['Anopheles sp. 18 DZ-2020']
+  parents:
+  - 63365
+3137592:
+  aliases: ['Anopheles sp. 18 EE-2024']
+  parents:
+  - 63365
+2731383:
+  aliases: ['Anopheles sp. 19 DZ-2020']
+  parents:
+  - 63365
+3137593:
+  aliases: ['Anopheles sp. 19 KHH1 EE-2024']
+  parents:
+  - 63365
+2510648:
+  aliases: ['Anopheles sp. 1FCM']
+  parents:
+  - 63365
+3137594:
+  aliases: ['Anopheles sp. 20 EE-2024']
+  parents:
+  - 63365
+3135066:
+  aliases: ['Anopheles sp. 2022ETH0173']
+  parents:
+  - 63365
+2510649:
+  aliases: ['Anopheles sp. 2FCM']
+  parents:
+  - 63365
+2510650:
+  aliases: ['Anopheles sp. 3FCM']
+  parents:
+  - 63365
+2304023:
+  aliases: ['Anopheles sp. 4 JV-2018']
+  parents:
+  - 63365
+2510651:
+  aliases: ['Anopheles sp. 4FCM']
+  parents:
+  - 63365
+2510652:
+  aliases: ['Anopheles sp. 5FCM']
+  parents:
+  - 63365
+1496335:
+  aliases: ['Anopheles sp. 6 BSL-2014']
+  parents:
+  - 63365
+2499888:
+  aliases: ['Anopheles sp. 6 CMJ-2018']
+  parents:
+  - 63365
+2730097:
+  aliases: ['Anopheles sp. 6 DZ-2020']
+  parents:
+  - 63365
+2510653:
+  aliases: ['Anopheles sp. 6FCM']
+  parents:
+  - 63365
+1496336:
+  aliases: ['Anopheles sp. 7 BSL-2014']
+  parents:
+  - 63365
+2731384:
+  aliases: ['Anopheles sp. 7 DZ-2020']
+  parents:
+  - 63365
+2304024:
+  aliases: ['Anopheles sp. 7 JV-2018']
+  parents:
+  - 63365
+2510654:
+  aliases: ['Anopheles sp. 7FCM']
+  parents:
+  - 63365
+2510655:
+  aliases: ['Anopheles sp. 8FCM']
+  parents:
+  - 63365
+1496337:
+  aliases: ['Anopheles sp. 9 BSL-2014']
+  parents:
+  - 63365
+2730098:
+  aliases: ['Anopheles sp. 9 DZ-2020']
+  parents:
+  - 63365
+2510656:
+  aliases: ['Anopheles sp. 9FCM']
+  parents:
+  - 63365
+2267823:
+  aliases: ['Anopheles sp. A/1']
+  parents:
+  - 63365
+2746495:
+  aliases: ['Anopheles sp. A113']
+  parents:
+  - 63365
+1833979:
+  aliases: ['Anopheles sp. AGB-2016']
+  parents:
+  - 63365
+2751541:
+  aliases: ['Anopheles sp. AN13']
+  parents:
+  - 63365
+2751542:
+  aliases: ['Anopheles sp. AN14']
+  parents:
+  - 63365
+2751543:
+  aliases: ['Anopheles sp. AN15']
+  parents:
+  - 63365
+2751544:
+  aliases: ['Anopheles sp. AN16']
+  parents:
+  - 63365
+2751545:
+  aliases: ['Anopheles sp. AN17']
+  parents:
+  - 63365
+2751546:
+  aliases: ['Anopheles sp. AN18']
+  parents:
+  - 63365
+2751540:
+  aliases: ['Anopheles sp. AN9']
+  parents:
+  - 63365
+465798:
+  aliases: ['Anopheles sp. Ah36']
+  parents:
+  - 63365
+2746496:
+  aliases: ['Anopheles sp. B242']
+  parents:
+  - 63365
+2746497:
+  aliases: ['Anopheles sp. B245']
+  parents:
+  - 63365
+2314999:
+  aliases: ['Anopheles sp. BIOUG25498-G06']
+  parents:
+  - 63365
+2207149:
+  aliases: ['Anopheles sp. BIOUG27392-B04']
+  parents:
+  - 63365
+2207150:
+  aliases: ['Anopheles sp. BIOUG27392-G12']
+  parents:
+  - 63365
+2315000:
+  aliases: ['Anopheles sp. BIOUG28195-H10']
+  parents:
+  - 63365
+1888154:
+  aliases: ['Anopheles sp. BOLD-2016']
+  parents:
+  - 63365
+2657478:
+  aliases: ['Anopheles sp. BOLD:AAA5103']
+  parents:
+  - 63365
+2657479:
+  aliases: ['Anopheles sp. BOLD:AAA5104']
+  parents:
+  - 63365
+1754996:
+  aliases: ['Anopheles sp. BOLD:AAC0584']
+  parents:
+  - 63365
+2657477:
+  aliases: ['Anopheles sp. BOLD:AAI4553']
+  parents:
+  - 63365
+1744827:
+  aliases: ['Anopheles sp. BOLD:ACB9644']
+  parents:
+  - 63365
+2746498:
+  aliases: ['Anopheles sp. C181']
+  parents:
+  - 63365
+2746499:
+  aliases: ['Anopheles sp. C194']
+  parents:
+  - 63365
+2746500:
+  aliases: ['Anopheles sp. C197']
+  parents:
+  - 63365
+2746501:
+  aliases: ['Anopheles sp. C203']
+  parents:
+  - 63365
+1866959:
+  aliases: ['Anopheles sp. CMJ-2016']
+  parents:
+  - 63365
+2569800:
+  aliases: ['Anopheles sp. GAB-1 43']
+  parents:
+  - 63365
+2569801:
+  aliases: ['Anopheles sp. GAB-1 45']
+  parents:
+  - 63365
+2569802:
+  aliases: ['Anopheles sp. GAB-1 46']
+  parents:
+  - 63365
+2569803:
+  aliases: ['Anopheles sp. GAB-1 47']
+  parents:
+  - 63365
+2569804:
+  aliases: ['Anopheles sp. GAB-1 48']
+  parents:
+  - 63365
+2569805:
+  aliases: ['Anopheles sp. GAB-1 49']
+  parents:
+  - 63365
+2569806:
+  aliases: ['Anopheles sp. GAB-1 71']
+  parents:
+  - 63365
+2569807:
+  aliases: ['Anopheles sp. GAB-1 72']
+  parents:
+  - 63365
+2569808:
+  aliases: ['Anopheles sp. GAB-2 BNG3373']
+  parents:
+  - 63365
+2569809:
+  aliases: ['Anopheles sp. GAB-2 BNG4103']
+  parents:
+  - 63365
+2569810:
+  aliases: ['Anopheles sp. GAB-2 BNG5460']
+  parents:
+  - 63365
+2569811:
+  aliases: ['Anopheles sp. GAB-2 BNG5479']
+  parents:
+  - 63365
+2569812:
+  aliases: ['Anopheles sp. GAB-2 MKB21']
+  parents:
+  - 63365
+2569813:
+  aliases: ['Anopheles sp. GAB-2 MKB24']
+  parents:
+  - 63365
+2569814:
+  aliases: ['Anopheles sp. GAB-2 MKB47']
+  parents:
+  - 63365
+2569815:
+  aliases: ['Anopheles sp. GAB-2 MKB48']
+  parents:
+  - 63365
+2569816:
+  aliases: ['Anopheles sp. GAB-3 BTK50']
+  parents:
+  - 63365
+2267822:
+  aliases: ['Anopheles sp. GUI-KAN1']
+  parents:
+  - 63365
+296737:
+  aliases: ['Anopheles sp. JN03-1']
+  parents:
+  - 63365
+2609883:
+  aliases: ['Anopheles sp. KHH11']
+  parents:
+  - 63365
+2931889:
+  aliases: ['Anopheles sp. KV11']
+  parents:
+  - 63365
+2920257:
+  aliases: ['Anopheles sp. KV14']
+  parents:
+  - 63365
+2920258:
+  aliases: ['Anopheles sp. KV17']
+  parents:
+  - 63365
+2931890:
+  aliases: ['Anopheles sp. KV22']
+  parents:
+  - 63365
+2920259:
+  aliases: ['Anopheles sp. KV23']
+  parents:
+  - 63365
+2920262:
+  aliases: ['Anopheles sp. KV4']
+  parents:
+  - 63365
+2920261:
+  aliases: ['Anopheles sp. KV8']
+  parents:
+  - 63365
+1803712:
+  aliases: ['Anopheles sp. M36YA']
+  parents:
+  - 63365
+1551378:
+  aliases: ['Anopheles sp. MBI-14']
+  parents:
+  - 63365
+293436:
+  aliases: ['Anopheles sp. MYJ-1']
+  parents:
+  - 63365
+293437:
+  aliases: ['Anopheles sp. MYJ-2']
+  parents:
+  - 63365
+293438:
+  aliases: ['Anopheles sp. MYJ-3']
+  parents:
+  - 63365
+2654948:
+  aliases: ['Anopheles sp. Mali 1']
+  parents:
+  - 63365
+2665661:
+  aliases: ['Anopheles sp. Mm-47']
+  parents:
+  - 63365
+2665662:
+  aliases: ['Anopheles sp. Mm-9']
+  parents:
+  - 63365
+1712672:
+  aliases: ['Anopheles sp. NFL-2015']
+  parents:
+  - 63365
+2920260:
+  aliases: ['Anopheles sp. NG1']
+  parents:
+  - 63365
+2654949:
+  aliases: ['Anopheles sp. NMNH 2017-026-E05']
+  parents:
+  - 63365
+2267821:
+  aliases: ['Anopheles sp. O/15']
+  parents:
+  - 63365
+356795:
+  aliases: ['Anopheles sp. P40']
+  parents:
+  - 63365
+98337:
+  aliases: ['Anopheles sp. RGS-1']
+  parents:
+  - 63365
+98338:
+  aliases: ['Anopheles sp. RGS-2']
+  parents:
+  - 63365
+98339:
+  aliases: ['Anopheles sp. RGS-3']
+  parents:
+  - 63365
+98340:
+  aliases: ['Anopheles sp. RGS-4']
+  parents:
+  - 63365
+2588643:
+  aliases: ['Anopheles sp. RP-2019-1']
+  parents:
+  - 63365
+2588644:
+  aliases: ['Anopheles sp. RP-2019-2']
+  parents:
+  - 63365
+696724:
+  aliases: ['Anopheles sp. SMMU-f3']
+  parents:
+  - 63365
+696722:
+  aliases: ['Anopheles sp. SMMU-flp1']
+  parents:
+  - 63365
+696723:
+  aliases: ['Anopheles sp. SMMU-jp3']
+  parents:
+  - 63365
+2500423:
+  aliases: ['Anopheles sp. SMRU:METF 54758']
+  parents:
+  - 63365
+2500180:
+  aliases: ['Anopheles sp. SMRU:METF 54764']
+  parents:
+  - 63365
+2500181:
+  aliases: ['Anopheles sp. SMRU:METF 54766']
+  parents:
+  - 63365
+2500182:
+  aliases: ['Anopheles sp. SMRU:METF 54819']
+  parents:
+  - 63365
+2500183:
+  aliases: ['Anopheles sp. SMRU:METF 54825']
+  parents:
+  - 63365
+2500424:
+  aliases: ['Anopheles sp. SMRU:METF 54828']
+  parents:
+  - 63365
+2500184:
+  aliases: ['Anopheles sp. SMRU:METF 54830']
+  parents:
+  - 63365
+2500185:
+  aliases: ['Anopheles sp. SMRU:METF 54924']
+  parents:
+  - 63365
+2500186:
+  aliases: ['Anopheles sp. SMRU:METF 54960']
+  parents:
+  - 63365
+2500187:
+  aliases: ['Anopheles sp. SMRU:METF 54978']
+  parents:
+  - 63365
+2500188:
+  aliases: ['Anopheles sp. SMRU:METF 54995']
+  parents:
+  - 63365
+2500189:
+  aliases: ['Anopheles sp. SMRU:METF 55018']
+  parents:
+  - 63365
+2500190:
+  aliases: ['Anopheles sp. SMRU:METF 55128']
+  parents:
+  - 63365
+2500191:
+  aliases: ['Anopheles sp. SMRU:METF 55157']
+  parents:
+  - 63365
+2500192:
+  aliases: ['Anopheles sp. SMRU:METF 55260']
+  parents:
+  - 63365
+2500193:
+  aliases: ['Anopheles sp. SMRU:METF 55284']
+  parents:
+  - 63365
+2500194:
+  aliases: ['Anopheles sp. SMRU:METF 55341']
+  parents:
+  - 63365
+2500195:
+  aliases: ['Anopheles sp. SMRU:METF 55344']
+  parents:
+  - 63365
+2500425:
+  aliases: ['Anopheles sp. SMRU:METF 55366']
+  parents:
+  - 63365
+2500426:
+  aliases: ['Anopheles sp. SMRU:METF 55375']
+  parents:
+  - 63365
+2500444:
+  aliases: ['Anopheles sp. SMRU:METF 55378']
+  parents:
+  - 63365
+2500196:
+  aliases: ['Anopheles sp. SMRU:METF 55384']
+  parents:
+  - 63365
+2500197:
+  aliases: ['Anopheles sp. SMRU:METF 55386']
+  parents:
+  - 63365
+2500445:
+  aliases: ['Anopheles sp. SMRU:METF 55418']
+  parents:
+  - 63365
+2500198:
+  aliases: ['Anopheles sp. SMRU:METF 55454']
+  parents:
+  - 63365
+2500199:
+  aliases: ['Anopheles sp. SMRU:METF 55457']
+  parents:
+  - 63365
+2500427:
+  aliases: ['Anopheles sp. SMRU:METF 55669']
+  parents:
+  - 63365
+2500200:
+  aliases: ['Anopheles sp. SMRU:METF 55753']
+  parents:
+  - 63365
+2500201:
+  aliases: ['Anopheles sp. SMRU:METF 55800']
+  parents:
+  - 63365
+2500202:
+  aliases: ['Anopheles sp. SMRU:METF 55803']
+  parents:
+  - 63365
+2500203:
+  aliases: ['Anopheles sp. SMRU:METF 55805']
+  parents:
+  - 63365
+2500446:
+  aliases: ['Anopheles sp. SMRU:METF 55816']
+  parents:
+  - 63365
+2500428:
+  aliases: ['Anopheles sp. SMRU:METF 55819']
+  parents:
+  - 63365
+2500204:
+  aliases: ['Anopheles sp. SMRU:METF 55824']
+  parents:
+  - 63365
+2500447:
+  aliases: ['Anopheles sp. SMRU:METF 55900']
+  parents:
+  - 63365
+2500448:
+  aliases: ['Anopheles sp. SMRU:METF 56034']
+  parents:
+  - 63365
+2500429:
+  aliases: ['Anopheles sp. SMRU:METF 56038']
+  parents:
+  - 63365
+2500205:
+  aliases: ['Anopheles sp. SMRU:METF 56041']
+  parents:
+  - 63365
+2500206:
+  aliases: ['Anopheles sp. SMRU:METF 56149']
+  parents:
+  - 63365
+2500207:
+  aliases: ['Anopheles sp. SMRU:METF 56175']
+  parents:
+  - 63365
+2500449:
+  aliases: ['Anopheles sp. SMRU:METF 56276']
+  parents:
+  - 63365
+2500208:
+  aliases: ['Anopheles sp. SMRU:METF 56283']
+  parents:
+  - 63365
+2500209:
+  aliases: ['Anopheles sp. SMRU:METF 56301']
+  parents:
+  - 63365
+2500210:
+  aliases: ['Anopheles sp. SMRU:METF 56302']
+  parents:
+  - 63365
+2500211:
+  aliases: ['Anopheles sp. SMRU:METF 56303']
+  parents:
+  - 63365
+2500212:
+  aliases: ['Anopheles sp. SMRU:METF 56305']
+  parents:
+  - 63365
+2500213:
+  aliases: ['Anopheles sp. SMRU:METF 56308']
+  parents:
+  - 63365
+2500214:
+  aliases: ['Anopheles sp. SMRU:METF 56311']
+  parents:
+  - 63365
+2500450:
+  aliases: ['Anopheles sp. SMRU:METF 56329']
+  parents:
+  - 63365
+2500215:
+  aliases: ['Anopheles sp. SMRU:METF 56345']
+  parents:
+  - 63365
+2500216:
+  aliases: ['Anopheles sp. SMRU:METF 56586']
+  parents:
+  - 63365
+2500451:
+  aliases: ['Anopheles sp. SMRU:METF 56604']
+  parents:
+  - 63365
+2500217:
+  aliases: ['Anopheles sp. SMRU:METF 56608']
+  parents:
+  - 63365
+2500218:
+  aliases: ['Anopheles sp. SMRU:METF 56617']
+  parents:
+  - 63365
+2500430:
+  aliases: ['Anopheles sp. SMRU:METF 56631']
+  parents:
+  - 63365
+2500452:
+  aliases: ['Anopheles sp. SMRU:METF 56977']
+  parents:
+  - 63365
+2500219:
+  aliases: ['Anopheles sp. SMRU:METF 56981']
+  parents:
+  - 63365
+2500220:
+  aliases: ['Anopheles sp. SMRU:METF 56990']
+  parents:
+  - 63365
+2500453:
+  aliases: ['Anopheles sp. SMRU:METF 56991']
+  parents:
+  - 63365
+2500221:
+  aliases: ['Anopheles sp. SMRU:METF 56993']
+  parents:
+  - 63365
+2500222:
+  aliases: ['Anopheles sp. SMRU:METF 56996']
+  parents:
+  - 63365
+2500454:
+  aliases: ['Anopheles sp. SMRU:METF 57029']
+  parents:
+  - 63365
+2500223:
+  aliases: ['Anopheles sp. SMRU:METF 57051']
+  parents:
+  - 63365
+2500455:
+  aliases: ['Anopheles sp. SMRU:METF 57055']
+  parents:
+  - 63365
+2500456:
+  aliases: ['Anopheles sp. SMRU:METF 57058']
+  parents:
+  - 63365
+2500224:
+  aliases: ['Anopheles sp. SMRU:METF 57223']
+  parents:
+  - 63365
+2500225:
+  aliases: ['Anopheles sp. SMRU:METF 57227']
+  parents:
+  - 63365
+2500226:
+  aliases: ['Anopheles sp. SMRU:METF 57234']
+  parents:
+  - 63365
+2500457:
+  aliases: ['Anopheles sp. SMRU:METF 57272']
+  parents:
+  - 63365
+2500227:
+  aliases: ['Anopheles sp. SMRU:METF 57427']
+  parents:
+  - 63365
+2500228:
+  aliases: ['Anopheles sp. SMRU:METF 57439']
+  parents:
+  - 63365
+2500229:
+  aliases: ['Anopheles sp. SMRU:METF 57480']
+  parents:
+  - 63365
+2500458:
+  aliases: ['Anopheles sp. SMRU:METF 57488']
+  parents:
+  - 63365
+2500230:
+  aliases: ['Anopheles sp. SMRU:METF 57492']
+  parents:
+  - 63365
+2500459:
+  aliases: ['Anopheles sp. SMRU:METF 57597']
+  parents:
+  - 63365
+2500231:
+  aliases: ['Anopheles sp. SMRU:METF 57604']
+  parents:
+  - 63365
+2500232:
+  aliases: ['Anopheles sp. SMRU:METF 57607']
+  parents:
+  - 63365
+2500233:
+  aliases: ['Anopheles sp. SMRU:METF 57642']
+  parents:
+  - 63365
+2500234:
+  aliases: ['Anopheles sp. SMRU:METF 57655']
+  parents:
+  - 63365
+2500460:
+  aliases: ['Anopheles sp. SMRU:METF 57703']
+  parents:
+  - 63365
+2500235:
+  aliases: ['Anopheles sp. SMRU:METF 57704']
+  parents:
+  - 63365
+2500236:
+  aliases: ['Anopheles sp. SMRU:METF 57710']
+  parents:
+  - 63365
+2500237:
+  aliases: ['Anopheles sp. SMRU:METF 57713']
+  parents:
+  - 63365
+2500238:
+  aliases: ['Anopheles sp. SMRU:METF 57714']
+  parents:
+  - 63365
+2500461:
+  aliases: ['Anopheles sp. SMRU:METF 57717']
+  parents:
+  - 63365
+2500462:
+  aliases: ['Anopheles sp. SMRU:METF 57718']
+  parents:
+  - 63365
+2500463:
+  aliases: ['Anopheles sp. SMRU:METF 57719']
+  parents:
+  - 63365
+2500239:
+  aliases: ['Anopheles sp. SMRU:METF 57720']
+  parents:
+  - 63365
+2500240:
+  aliases: ['Anopheles sp. SMRU:METF 57731']
+  parents:
+  - 63365
+2500464:
+  aliases: ['Anopheles sp. SMRU:METF 57737']
+  parents:
+  - 63365
+2500241:
+  aliases: ['Anopheles sp. SMRU:METF 57738']
+  parents:
+  - 63365
+2500465:
+  aliases: ['Anopheles sp. SMRU:METF 57949']
+  parents:
+  - 63365
+2500242:
+  aliases: ['Anopheles sp. SMRU:METF 57950']
+  parents:
+  - 63365
+2500243:
+  aliases: ['Anopheles sp. SMRU:METF 57952']
+  parents:
+  - 63365
+2500244:
+  aliases: ['Anopheles sp. SMRU:METF 57953']
+  parents:
+  - 63365
+2500245:
+  aliases: ['Anopheles sp. SMRU:METF 57955']
+  parents:
+  - 63365
+2500246:
+  aliases: ['Anopheles sp. SMRU:METF 57963']
+  parents:
+  - 63365
+2500247:
+  aliases: ['Anopheles sp. SMRU:METF 57964']
+  parents:
+  - 63365
+2500248:
+  aliases: ['Anopheles sp. SMRU:METF 57970']
+  parents:
+  - 63365
+2500249:
+  aliases: ['Anopheles sp. SMRU:METF 57975']
+  parents:
+  - 63365
+2500250:
+  aliases: ['Anopheles sp. SMRU:METF 58254']
+  parents:
+  - 63365
+2500251:
+  aliases: ['Anopheles sp. SMRU:METF 58255']
+  parents:
+  - 63365
+2500252:
+  aliases: ['Anopheles sp. SMRU:METF 58256']
+  parents:
+  - 63365
+2500466:
+  aliases: ['Anopheles sp. SMRU:METF 58261']
+  parents:
+  - 63365
+2500253:
+  aliases: ['Anopheles sp. SMRU:METF 58264']
+  parents:
+  - 63365
+2500467:
+  aliases: ['Anopheles sp. SMRU:METF 58265']
+  parents:
+  - 63365
+2500254:
+  aliases: ['Anopheles sp. SMRU:METF 58266']
+  parents:
+  - 63365
+2500255:
+  aliases: ['Anopheles sp. SMRU:METF 58267']
+  parents:
+  - 63365
+2500256:
+  aliases: ['Anopheles sp. SMRU:METF 58268']
+  parents:
+  - 63365
+2500468:
+  aliases: ['Anopheles sp. SMRU:METF 58270']
+  parents:
+  - 63365
+2500257:
+  aliases: ['Anopheles sp. SMRU:METF 58273']
+  parents:
+  - 63365
+2500258:
+  aliases: ['Anopheles sp. SMRU:METF 58274']
+  parents:
+  - 63365
+2500469:
+  aliases: ['Anopheles sp. SMRU:METF 58278']
+  parents:
+  - 63365
+2500259:
+  aliases: ['Anopheles sp. SMRU:METF 58279']
+  parents:
+  - 63365
+2500260:
+  aliases: ['Anopheles sp. SMRU:METF 58280']
+  parents:
+  - 63365
+2500261:
+  aliases: ['Anopheles sp. SMRU:METF 58466']
+  parents:
+  - 63365
+2500470:
+  aliases: ['Anopheles sp. SMRU:METF 58473']
+  parents:
+  - 63365
+2500471:
+  aliases: ['Anopheles sp. SMRU:METF 58474']
+  parents:
+  - 63365
+2500262:
+  aliases: ['Anopheles sp. SMRU:METF 58478']
+  parents:
+  - 63365
+2500263:
+  aliases: ['Anopheles sp. SMRU:METF 58483']
+  parents:
+  - 63365
+2500431:
+  aliases: ['Anopheles sp. SMRU:METF 58511']
+  parents:
+  - 63365
+2500472:
+  aliases: ['Anopheles sp. SMRU:METF 58513']
+  parents:
+  - 63365
+2500473:
+  aliases: ['Anopheles sp. SMRU:METF 58514']
+  parents:
+  - 63365
+2500264:
+  aliases: ['Anopheles sp. SMRU:METF 58519']
+  parents:
+  - 63365
+2500474:
+  aliases: ['Anopheles sp. SMRU:METF 58527']
+  parents:
+  - 63365
+2500265:
+  aliases: ['Anopheles sp. SMRU:METF 58611']
+  parents:
+  - 63365
+2500432:
+  aliases: ['Anopheles sp. SMRU:METF 58614']
+  parents:
+  - 63365
+2500266:
+  aliases: ['Anopheles sp. SMRU:METF 58625']
+  parents:
+  - 63365
+2500475:
+  aliases: ['Anopheles sp. SMRU:METF 58632']
+  parents:
+  - 63365
+2500476:
+  aliases: ['Anopheles sp. SMRU:METF 58642']
+  parents:
+  - 63365
+2500477:
+  aliases: ['Anopheles sp. SMRU:METF 58643']
+  parents:
+  - 63365
+2500478:
+  aliases: ['Anopheles sp. SMRU:METF 58644']
+  parents:
+  - 63365
+2500479:
+  aliases: ['Anopheles sp. SMRU:METF 58653']
+  parents:
+  - 63365
+2500267:
+  aliases: ['Anopheles sp. SMRU:METF 58668']
+  parents:
+  - 63365
+2500433:
+  aliases: ['Anopheles sp. SMRU:METF 58819']
+  parents:
+  - 63365
+2500480:
+  aliases: ['Anopheles sp. SMRU:METF 58837']
+  parents:
+  - 63365
+2500481:
+  aliases: ['Anopheles sp. SMRU:METF 58846']
+  parents:
+  - 63365
+2500482:
+  aliases: ['Anopheles sp. SMRU:METF 58854']
+  parents:
+  - 63365
+2500483:
+  aliases: ['Anopheles sp. SMRU:METF 58859']
+  parents:
+  - 63365
+2500268:
+  aliases: ['Anopheles sp. SMRU:METF 58961']
+  parents:
+  - 63365
+2500269:
+  aliases: ['Anopheles sp. SMRU:METF 58966']
+  parents:
+  - 63365
+2500270:
+  aliases: ['Anopheles sp. SMRU:METF 58985']
+  parents:
+  - 63365
+2500271:
+  aliases: ['Anopheles sp. SMRU:METF 58986']
+  parents:
+  - 63365
+2500272:
+  aliases: ['Anopheles sp. SMRU:METF 59015']
+  parents:
+  - 63365
+2500273:
+  aliases: ['Anopheles sp. SMRU:METF 59017']
+  parents:
+  - 63365
+2500274:
+  aliases: ['Anopheles sp. SMRU:METF 59020']
+  parents:
+  - 63365
+2500275:
+  aliases: ['Anopheles sp. SMRU:METF 59026']
+  parents:
+  - 63365
+2500276:
+  aliases: ['Anopheles sp. SMRU:METF 59028']
+  parents:
+  - 63365
+2500277:
+  aliases: ['Anopheles sp. SMRU:METF 59038']
+  parents:
+  - 63365
+2500278:
+  aliases: ['Anopheles sp. SMRU:METF 59046']
+  parents:
+  - 63365
+2500279:
+  aliases: ['Anopheles sp. SMRU:METF 59048']
+  parents:
+  - 63365
+2500280:
+  aliases: ['Anopheles sp. SMRU:METF 59106']
+  parents:
+  - 63365
+2500281:
+  aliases: ['Anopheles sp. SMRU:METF 59130']
+  parents:
+  - 63365
+2500282:
+  aliases: ['Anopheles sp. SMRU:METF 59154']
+  parents:
+  - 63365
+2500283:
+  aliases: ['Anopheles sp. SMRU:METF 59156']
+  parents:
+  - 63365
+2500284:
+  aliases: ['Anopheles sp. SMRU:METF 59161']
+  parents:
+  - 63365
+2500285:
+  aliases: ['Anopheles sp. SMRU:METF 59164']
+  parents:
+  - 63365
+2500286:
+  aliases: ['Anopheles sp. SMRU:METF 59264']
+  parents:
+  - 63365
+2500287:
+  aliases: ['Anopheles sp. SMRU:METF 59266']
+  parents:
+  - 63365
+2500288:
+  aliases: ['Anopheles sp. SMRU:METF 59270']
+  parents:
+  - 63365
+2500289:
+  aliases: ['Anopheles sp. SMRU:METF 59272']
+  parents:
+  - 63365
+2500290:
+  aliases: ['Anopheles sp. SMRU:METF 59288']
+  parents:
+  - 63365
+2500484:
+  aliases: ['Anopheles sp. SMRU:METF 59319']
+  parents:
+  - 63365
+2500291:
+  aliases: ['Anopheles sp. SMRU:METF 59378']
+  parents:
+  - 63365
+2500292:
+  aliases: ['Anopheles sp. SMRU:METF 59380']
+  parents:
+  - 63365
+2500293:
+  aliases: ['Anopheles sp. SMRU:METF 59395']
+  parents:
+  - 63365
+2500485:
+  aliases: ['Anopheles sp. SMRU:METF 59398']
+  parents:
+  - 63365
+2500294:
+  aliases: ['Anopheles sp. SMRU:METF 59406']
+  parents:
+  - 63365
+2500295:
+  aliases: ['Anopheles sp. SMRU:METF 59426']
+  parents:
+  - 63365
+2500296:
+  aliases: ['Anopheles sp. SMRU:METF 59429']
+  parents:
+  - 63365
+2500297:
+  aliases: ['Anopheles sp. SMRU:METF 59432']
+  parents:
+  - 63365
+2500298:
+  aliases: ['Anopheles sp. SMRU:METF 59535']
+  parents:
+  - 63365
+2500299:
+  aliases: ['Anopheles sp. SMRU:METF 59542']
+  parents:
+  - 63365
+2500300:
+  aliases: ['Anopheles sp. SMRU:METF 59556']
+  parents:
+  - 63365
+2500301:
+  aliases: ['Anopheles sp. SMRU:METF 59567']
+  parents:
+  - 63365
+2500302:
+  aliases: ['Anopheles sp. SMRU:METF 59570']
+  parents:
+  - 63365
+2500303:
+  aliases: ['Anopheles sp. SMRU:METF 59674']
+  parents:
+  - 63365
+2500304:
+  aliases: ['Anopheles sp. SMRU:METF 59675']
+  parents:
+  - 63365
+2500305:
+  aliases: ['Anopheles sp. SMRU:METF 59683']
+  parents:
+  - 63365
+2500306:
+  aliases: ['Anopheles sp. SMRU:METF 59684']
+  parents:
+  - 63365
+2500307:
+  aliases: ['Anopheles sp. SMRU:METF 59685']
+  parents:
+  - 63365
+2500308:
+  aliases: ['Anopheles sp. SMRU:METF 59686']
+  parents:
+  - 63365
+2500309:
+  aliases: ['Anopheles sp. SMRU:METF 59706']
+  parents:
+  - 63365
+2500310:
+  aliases: ['Anopheles sp. SMRU:METF 59707']
+  parents:
+  - 63365
+2500434:
+  aliases: ['Anopheles sp. SMRU:METF 59838']
+  parents:
+  - 63365
+2500311:
+  aliases: ['Anopheles sp. SMRU:METF 59846']
+  parents:
+  - 63365
+2500312:
+  aliases: ['Anopheles sp. SMRU:METF 59886']
+  parents:
+  - 63365
+2500313:
+  aliases: ['Anopheles sp. SMRU:METF 59896']
+  parents:
+  - 63365
+2500314:
+  aliases: ['Anopheles sp. SMRU:METF 59898']
+  parents:
+  - 63365
+2500315:
+  aliases: ['Anopheles sp. SMRU:METF 59899']
+  parents:
+  - 63365
+2500316:
+  aliases: ['Anopheles sp. SMRU:METF 59902']
+  parents:
+  - 63365
+2500317:
+  aliases: ['Anopheles sp. SMRU:METF 59904']
+  parents:
+  - 63365
+2500486:
+  aliases: ['Anopheles sp. SMRU:METF 60126']
+  parents:
+  - 63365
+2500318:
+  aliases: ['Anopheles sp. SMRU:METF 60135']
+  parents:
+  - 63365
+2500319:
+  aliases: ['Anopheles sp. SMRU:METF 60136']
+  parents:
+  - 63365
+2500320:
+  aliases: ['Anopheles sp. SMRU:METF 60139']
+  parents:
+  - 63365
+2500321:
+  aliases: ['Anopheles sp. SMRU:METF 60142']
+  parents:
+  - 63365
+2500322:
+  aliases: ['Anopheles sp. SMRU:METF 60201']
+  parents:
+  - 63365
+2500323:
+  aliases: ['Anopheles sp. SMRU:METF 60203']
+  parents:
+  - 63365
+2500324:
+  aliases: ['Anopheles sp. SMRU:METF 60210']
+  parents:
+  - 63365
+2500325:
+  aliases: ['Anopheles sp. SMRU:METF 60224']
+  parents:
+  - 63365
+2500326:
+  aliases: ['Anopheles sp. SMRU:METF 60654']
+  parents:
+  - 63365
+2500327:
+  aliases: ['Anopheles sp. SMRU:METF 60682']
+  parents:
+  - 63365
+2500487:
+  aliases: ['Anopheles sp. SMRU:METF 60710']
+  parents:
+  - 63365
+2500328:
+  aliases: ['Anopheles sp. SMRU:METF 60721']
+  parents:
+  - 63365
+2500329:
+  aliases: ['Anopheles sp. SMRU:METF 60723']
+  parents:
+  - 63365
+2500330:
+  aliases: ['Anopheles sp. SMRU:METF 60724']
+  parents:
+  - 63365
+2500331:
+  aliases: ['Anopheles sp. SMRU:METF 60761']
+  parents:
+  - 63365
+2500332:
+  aliases: ['Anopheles sp. SMRU:METF 60763']
+  parents:
+  - 63365
+2500488:
+  aliases: ['Anopheles sp. SMRU:METF 60958']
+  parents:
+  - 63365
+2500333:
+  aliases: ['Anopheles sp. SMRU:METF 61004']
+  parents:
+  - 63365
+2500334:
+  aliases: ['Anopheles sp. SMRU:METF 61013']
+  parents:
+  - 63365
+2500489:
+  aliases: ['Anopheles sp. SMRU:METF 61033']
+  parents:
+  - 63365
+2500335:
+  aliases: ['Anopheles sp. SMRU:METF 61240']
+  parents:
+  - 63365
+2500336:
+  aliases: ['Anopheles sp. SMRU:METF 61266']
+  parents:
+  - 63365
+2500337:
+  aliases: ['Anopheles sp. SMRU:METF 61284']
+  parents:
+  - 63365
+2500338:
+  aliases: ['Anopheles sp. SMRU:METF 61319']
+  parents:
+  - 63365
+2500339:
+  aliases: ['Anopheles sp. SMRU:METF 61320']
+  parents:
+  - 63365
+2500340:
+  aliases: ['Anopheles sp. SMRU:METF 61321']
+  parents:
+  - 63365
+2500490:
+  aliases: ['Anopheles sp. SMRU:METF 61322']
+  parents:
+  - 63365
+2500491:
+  aliases: ['Anopheles sp. SMRU:METF 61375']
+  parents:
+  - 63365
+2500341:
+  aliases: ['Anopheles sp. SMRU:METF 61387']
+  parents:
+  - 63365
+2500492:
+  aliases: ['Anopheles sp. SMRU:METF 61444']
+  parents:
+  - 63365
+2500493:
+  aliases: ['Anopheles sp. SMRU:METF 61561']
+  parents:
+  - 63365
+2500342:
+  aliases: ['Anopheles sp. SMRU:METF 61581']
+  parents:
+  - 63365
+2500435:
+  aliases: ['Anopheles sp. SMRU:METF 61588']
+  parents:
+  - 63365
+2500343:
+  aliases: ['Anopheles sp. SMRU:METF 61597']
+  parents:
+  - 63365
+2500494:
+  aliases: ['Anopheles sp. SMRU:METF 61891']
+  parents:
+  - 63365
+2500344:
+  aliases: ['Anopheles sp. SMRU:METF 61905']
+  parents:
+  - 63365
+2500345:
+  aliases: ['Anopheles sp. SMRU:METF 61954']
+  parents:
+  - 63365
+2500495:
+  aliases: ['Anopheles sp. SMRU:METF 62048']
+  parents:
+  - 63365
+2500346:
+  aliases: ['Anopheles sp. SMRU:METF 62103']
+  parents:
+  - 63365
+2500496:
+  aliases: ['Anopheles sp. SMRU:METF 62119']
+  parents:
+  - 63365
+2500436:
+  aliases: ['Anopheles sp. SMRU:METF 62213']
+  parents:
+  - 63365
+2500497:
+  aliases: ['Anopheles sp. SMRU:METF 62697']
+  parents:
+  - 63365
+2500437:
+  aliases: ['Anopheles sp. SMRU:METF 62741']
+  parents:
+  - 63365
+2500347:
+  aliases: ['Anopheles sp. SMRU:METF 62798']
+  parents:
+  - 63365
+2500498:
+  aliases: ['Anopheles sp. SMRU:METF 62819']
+  parents:
+  - 63365
+2500348:
+  aliases: ['Anopheles sp. SMRU:METF 63084']
+  parents:
+  - 63365
+2500349:
+  aliases: ['Anopheles sp. SMRU:METF 63092']
+  parents:
+  - 63365
+2500350:
+  aliases: ['Anopheles sp. SMRU:METF 63383']
+  parents:
+  - 63365
+2500351:
+  aliases: ['Anopheles sp. SMRU:METF 63384']
+  parents:
+  - 63365
+2500352:
+  aliases: ['Anopheles sp. SMRU:METF 63386']
+  parents:
+  - 63365
+2500353:
+  aliases: ['Anopheles sp. SMRU:METF 63392']
+  parents:
+  - 63365
+2500354:
+  aliases: ['Anopheles sp. SMRU:METF 63393']
+  parents:
+  - 63365
+2500355:
+  aliases: ['Anopheles sp. SMRU:METF 63399']
+  parents:
+  - 63365
+2500356:
+  aliases: ['Anopheles sp. SMRU:METF 63403']
+  parents:
+  - 63365
+2500499:
+  aliases: ['Anopheles sp. SMRU:METF 63411']
+  parents:
+  - 63365
+2500357:
+  aliases: ['Anopheles sp. SMRU:METF 63412']
+  parents:
+  - 63365
+2500358:
+  aliases: ['Anopheles sp. SMRU:METF 63414']
+  parents:
+  - 63365
+2500359:
+  aliases: ['Anopheles sp. SMRU:METF 63416']
+  parents:
+  - 63365
+2500360:
+  aliases: ['Anopheles sp. SMRU:METF 63423']
+  parents:
+  - 63365
+2500438:
+  aliases: ['Anopheles sp. SMRU:METF 63429']
+  parents:
+  - 63365
+2500500:
+  aliases: ['Anopheles sp. SMRU:METF 63440']
+  parents:
+  - 63365
+2500501:
+  aliases: ['Anopheles sp. SMRU:METF 63443']
+  parents:
+  - 63365
+2500361:
+  aliases: ['Anopheles sp. SMRU:METF 63464']
+  parents:
+  - 63365
+2500502:
+  aliases: ['Anopheles sp. SMRU:METF 63504']
+  parents:
+  - 63365
+2500362:
+  aliases: ['Anopheles sp. SMRU:METF 63511']
+  parents:
+  - 63365
+2500363:
+  aliases: ['Anopheles sp. SMRU:METF 63516']
+  parents:
+  - 63365
+2500503:
+  aliases: ['Anopheles sp. SMRU:METF 63522']
+  parents:
+  - 63365
+2500364:
+  aliases: ['Anopheles sp. SMRU:METF 63642']
+  parents:
+  - 63365
+2500365:
+  aliases: ['Anopheles sp. SMRU:METF 63654']
+  parents:
+  - 63365
+2500366:
+  aliases: ['Anopheles sp. SMRU:METF 63655']
+  parents:
+  - 63365
+2500367:
+  aliases: ['Anopheles sp. SMRU:METF 63657']
+  parents:
+  - 63365
+2500368:
+  aliases: ['Anopheles sp. SMRU:METF 63658']
+  parents:
+  - 63365
+2500369:
+  aliases: ['Anopheles sp. SMRU:METF 63659']
+  parents:
+  - 63365
+2500370:
+  aliases: ['Anopheles sp. SMRU:METF 63660']
+  parents:
+  - 63365
+2500439:
+  aliases: ['Anopheles sp. SMRU:METF 63671']
+  parents:
+  - 63365
+2500504:
+  aliases: ['Anopheles sp. SMRU:METF 63691']
+  parents:
+  - 63365
+2500505:
+  aliases: ['Anopheles sp. SMRU:METF 63694']
+  parents:
+  - 63365
+2500506:
+  aliases: ['Anopheles sp. SMRU:METF 63709']
+  parents:
+  - 63365
+2500371:
+  aliases: ['Anopheles sp. SMRU:METF 63722']
+  parents:
+  - 63365
+2500372:
+  aliases: ['Anopheles sp. SMRU:METF 63925']
+  parents:
+  - 63365
+2500373:
+  aliases: ['Anopheles sp. SMRU:METF 63926']
+  parents:
+  - 63365
+2500374:
+  aliases: ['Anopheles sp. SMRU:METF 63927']
+  parents:
+  - 63365
+2500375:
+  aliases: ['Anopheles sp. SMRU:METF 63928']
+  parents:
+  - 63365
+2500376:
+  aliases: ['Anopheles sp. SMRU:METF 63929']
+  parents:
+  - 63365
+2500377:
+  aliases: ['Anopheles sp. SMRU:METF 63932']
+  parents:
+  - 63365
+2500378:
+  aliases: ['Anopheles sp. SMRU:METF 63933']
+  parents:
+  - 63365
+2500379:
+  aliases: ['Anopheles sp. SMRU:METF 63934']
+  parents:
+  - 63365
+2500380:
+  aliases: ['Anopheles sp. SMRU:METF 63938']
+  parents:
+  - 63365
+2500381:
+  aliases: ['Anopheles sp. SMRU:METF 63949']
+  parents:
+  - 63365
+2500507:
+  aliases: ['Anopheles sp. SMRU:METF 63950']
+  parents:
+  - 63365
+2500382:
+  aliases: ['Anopheles sp. SMRU:METF 63970']
+  parents:
+  - 63365
+2500383:
+  aliases: ['Anopheles sp. SMRU:METF 63972']
+  parents:
+  - 63365
+2500384:
+  aliases: ['Anopheles sp. SMRU:METF 63973']
+  parents:
+  - 63365
+2500385:
+  aliases: ['Anopheles sp. SMRU:METF 63975']
+  parents:
+  - 63365
+2500508:
+  aliases: ['Anopheles sp. SMRU:METF 63980']
+  parents:
+  - 63365
+2500386:
+  aliases: ['Anopheles sp. SMRU:METF 63992']
+  parents:
+  - 63365
+2500509:
+  aliases: ['Anopheles sp. SMRU:METF 64000']
+  parents:
+  - 63365
+2500387:
+  aliases: ['Anopheles sp. SMRU:METF 64298']
+  parents:
+  - 63365
+2500440:
+  aliases: ['Anopheles sp. SMRU:METF 64313']
+  parents:
+  - 63365
+2500510:
+  aliases: ['Anopheles sp. SMRU:METF 64315']
+  parents:
+  - 63365
+2500388:
+  aliases: ['Anopheles sp. SMRU:METF 64318']
+  parents:
+  - 63365
+2500389:
+  aliases: ['Anopheles sp. SMRU:METF 64319']
+  parents:
+  - 63365
+2500390:
+  aliases: ['Anopheles sp. SMRU:METF 64320']
+  parents:
+  - 63365
+2500391:
+  aliases: ['Anopheles sp. SMRU:METF 64321']
+  parents:
+  - 63365
+2500392:
+  aliases: ['Anopheles sp. SMRU:METF 64322']
+  parents:
+  - 63365
+2500393:
+  aliases: ['Anopheles sp. SMRU:METF 64329']
+  parents:
+  - 63365
+2500394:
+  aliases: ['Anopheles sp. SMRU:METF 64336']
+  parents:
+  - 63365
+2500511:
+  aliases: ['Anopheles sp. SMRU:METF 64471']
+  parents:
+  - 63365
+2500395:
+  aliases: ['Anopheles sp. SMRU:METF 64477']
+  parents:
+  - 63365
+2500512:
+  aliases: ['Anopheles sp. SMRU:METF 64502']
+  parents:
+  - 63365
+2500513:
+  aliases: ['Anopheles sp. SMRU:METF 64511']
+  parents:
+  - 63365
+2500396:
+  aliases: ['Anopheles sp. SMRU:METF 64541']
+  parents:
+  - 63365
+2500397:
+  aliases: ['Anopheles sp. SMRU:METF 64546']
+  parents:
+  - 63365
+2500398:
+  aliases: ['Anopheles sp. SMRU:METF 64547']
+  parents:
+  - 63365
+2500399:
+  aliases: ['Anopheles sp. SMRU:METF 64633']
+  parents:
+  - 63365
+2500400:
+  aliases: ['Anopheles sp. SMRU:METF 64634']
+  parents:
+  - 63365
+2500401:
+  aliases: ['Anopheles sp. SMRU:METF 64636']
+  parents:
+  - 63365
+2500402:
+  aliases: ['Anopheles sp. SMRU:METF 64639']
+  parents:
+  - 63365
+2500403:
+  aliases: ['Anopheles sp. SMRU:METF 64882']
+  parents:
+  - 63365
+2500404:
+  aliases: ['Anopheles sp. SMRU:METF 64889']
+  parents:
+  - 63365
+2500405:
+  aliases: ['Anopheles sp. SMRU:METF 64890']
+  parents:
+  - 63365
+2500406:
+  aliases: ['Anopheles sp. SMRU:METF 64891']
+  parents:
+  - 63365
+2500407:
+  aliases: ['Anopheles sp. SMRU:METF 64892']
+  parents:
+  - 63365
+2500514:
+  aliases: ['Anopheles sp. SMRU:METF 64901']
+  parents:
+  - 63365
+2500441:
+  aliases: ['Anopheles sp. SMRU:METF 64905']
+  parents:
+  - 63365
+2500408:
+  aliases: ['Anopheles sp. SMRU:METF 65221']
+  parents:
+  - 63365
+2500409:
+  aliases: ['Anopheles sp. SMRU:METF 65222']
+  parents:
+  - 63365
+2500410:
+  aliases: ['Anopheles sp. SMRU:METF 65224']
+  parents:
+  - 63365
+2500411:
+  aliases: ['Anopheles sp. SMRU:METF 65256']
+  parents:
+  - 63365
+2500412:
+  aliases: ['Anopheles sp. SMRU:METF 65643']
+  parents:
+  - 63365
+2500413:
+  aliases: ['Anopheles sp. SMRU:METF 65644']
+  parents:
+  - 63365
+2500414:
+  aliases: ['Anopheles sp. SMRU:METF 65646']
+  parents:
+  - 63365
+2500415:
+  aliases: ['Anopheles sp. SMRU:METF 65650']
+  parents:
+  - 63365
+2500515:
+  aliases: ['Anopheles sp. SMRU:METF 65651']
+  parents:
+  - 63365
+2500416:
+  aliases: ['Anopheles sp. SMRU:METF 65666']
+  parents:
+  - 63365
+2500417:
+  aliases: ['Anopheles sp. SMRU:METF 65944']
+  parents:
+  - 63365
+2500442:
+  aliases: ['Anopheles sp. SMRU:METF 65949']
+  parents:
+  - 63365
+2500516:
+  aliases: ['Anopheles sp. SMRU:METF 66153']
+  parents:
+  - 63365
+2500418:
+  aliases: ['Anopheles sp. SMRU:METF 66155']
+  parents:
+  - 63365
+2500419:
+  aliases: ['Anopheles sp. SMRU:METF 66157']
+  parents:
+  - 63365
+2500420:
+  aliases: ['Anopheles sp. SMRU:METF 66158']
+  parents:
+  - 63365
+2500421:
+  aliases: ['Anopheles sp. SMRU:METF 66164']
+  parents:
+  - 63365
+2500443:
+  aliases: ['Anopheles sp. SMRU:METF 66177']
+  parents:
+  - 63365
+2500422:
+  aliases: ['Anopheles sp. SMRU:METF 66199']
+  parents:
+  - 63365
+1576576:
+  aliases: ['Anopheles sp. SOKN050']
+  parents:
+  - 63365
+2746494:
+  aliases: ['Anopheles sp. TENGRELA']
+  parents:
+  - 63365
+1426909:
+  aliases: ['Anopheles sp. TIP1']
+  parents:
+  - 63365
+2326595:
+  aliases: ['Anopheles sp. TTMDJ373-10']
+  parents:
+  - 63365
+2499882:
+  aliases: ['Anopheles sp. UG1']
+  parents:
+  - 63365
+2499883:
+  aliases: ['Anopheles sp. UG2']
+  parents:
+  - 63365
+2499884:
+  aliases: ['Anopheles sp. UG3']
+  parents:
+  - 63365
+2781778:
+  aliases: ['Anopheles sp. X CLJ-2020']
+  parents:
+  - 63365
+2079318:
+  aliases: ['Anopheles sp. YL-2017']
+  parents:
+  - 63365
+234803:
+  aliases: ['Anopheles sp. YM-2003a']
+  parents:
+  - 63365
+283719:
+  aliases: ['Anopheles sp. YM-2003b']
+  parents:
+  - 63365
+283721:
+  aliases: ['Anopheles sp. YM-2003c']
+  parents:
+  - 63365
+2892205:
+  aliases: ['Anopheles sp. ZMUO 001712']
+  parents:
+  - 63365
+1199415:
+  aliases: ['Anopheles sp. clade C JRL-2012']
+  parents:
+  - 63365
+1199416:
+  aliases: ['Anopheles sp. clade D JRL-2012']
+  parents:
+  - 63365
+1199417:
+  aliases: ['Anopheles sp. clade E JRL-2012']
+  parents:
+  - 63365
+337524:
+  aliases: ['Anopheles sp. dg19']
+  parents:
+  - 63365
+337525:
+  aliases: ['Anopheles sp. dg20']
+  parents:
+  - 63365
+139050:
+  aliases: ['Anopheles squamifemur']
+  parents:
+  - 273457
+911292:
+  aliases: ['Anopheles squamosus']
+  parents:
+  - 44534
+2847163:
+  aliases: ['Anopheles tadei']
+  parents:
+  - 44543
+1141473:
+  aliases: ['Anopheles theileri']
+  parents:
+  - 44534
+43182:
+  aliases: ['Anopheles trinkae']
+  parents:
+  - 44543
+317811:
+  aliases: ['Armigeres']
+  parents:
+  - 124916
+346054:
+  aliases: ['Aztecaedes']
+  parents:
+  - 7158
+53528:
+  aliases: ['Barraudius']
+  parents:
+  - 7174
+2756214:
+  aliases: ['Bironella derooki']
+  parents:
+  - 53565
+53566:
+  aliases: ['Bironella gracilis']
+  parents:
+  - 53563
+59138:
+  aliases: ['Bironella hollandi']
+  parents:
+  - 53564
+425231:
+  aliases: ['Borichinda cavernicola']
+  parents:
+  - 425230
+346052:
+  aliases: ['Bothaella']
+  parents:
+  - 7158
+1245277:
+  aliases: ['Bruceharrisonius']
+  parents:
+  - 7158
+300146:
+  aliases: ['Cancraedes']
+  parents:
+  - 7158
+794814:
+  aliases: ['Carrollia']
+  parents:
+  - 7174
+2067444:
+  aliases: ['Catageiomyia argenteopunctata']
+  parents:
+  - 2067443
+2761508:
+  aliases: ['Catageiomyia microsticta']
+  parents:
+  - 2067443
+346055:
+  aliases: ['Chaetocruiomyia']
+  parents:
+  - 190765
+2767512:
+  aliases: ['Chagasia sp. 1 SJ-2020']
+  parents:
+  - 2629023
+2171937:
+  aliases: ['Chagasia sp. SP54_C']
+  parents:
+  - 2629023
+1285601:
+  aliases: ['Chrysoconops']
+  parents:
+  - 190765
+2339219:
+  aliases: ['Coetzeemyia']
+  parents:
+  - 7158
+706477:
+  aliases: ['Collessius hatorii']
+  parents:
+  - 1245380
+2900299:
+  aliases: ['Collessius macfarlanei']
+  parents:
+  - 1245380
+1529933:
+  aliases: ['Collessius pseudotaeniatus']
+  parents:
+  - 1245380
+1245336:
+  aliases: ['Collessius tonkinensis']
+  parents:
+  - 1245380
+464955:
+  aliases: ['Conopostegus']
+  parents:
+  - 7180
+1273083:
+  aliases: ['Coquillettidia albicosta']
+  parents:
+  - 329110
+2993644:
+  aliases: ['Coquillettidia arribalzagae']
+  parents:
+  - 329110
+667557:
+  aliases: ['Coquillettidia aurea']
+  parents:
+  - 329110
+653291:
+  aliases: ['Coquillettidia aurites']
+  parents:
+  - 329110
+2547966:
+  aliases: ['Coquillettidia buxtoni']
+  parents:
+  - 329110
+2597061:
+  aliases: ['Coquillettidia chrysonotum']
+  parents:
+  - 329110
+1799669:
+  aliases: ['Coquillettidia chrysosoma']
+  parents:
+  - 329110
+1245327:
+  aliases: ['Coquillettidia crassipes']
+  parents:
+  - 329110
+667558:
+  aliases: ['Coquillettidia fuscopennata']
+  parents:
+  - 329110
+2719870:
+  aliases: ['Coquillettidia hermanoi']
+  parents:
+  - 329110
+2292400:
+  aliases: ['Coquillettidia iracunda']
+  parents:
+  - 329110
+2719871:
+  aliases: ['Coquillettidia juxtamansonia']
+  parents:
+  - 329110
+1806174:
+  aliases: ['Coquillettidia linealis']
+  parents:
+  - 329110
+2689571:
+  aliases: ['Coquillettidia lynchi']
+  parents:
+  - 329110
+667559:
+  aliases: ['Coquillettidia maculipennis']
+  parents:
+  - 329110
+653292:
+  aliases: ['Coquillettidia metallica']
+  parents:
+  - 329110
+1799670:
+  aliases: ['Coquillettidia microannulata']
+  parents:
+  - 329110
+1257098:
+  aliases: ['Coquillettidia nigricans']
+  parents:
+  - 329110
+1424508:
+  aliases: ['Coquillettidia nigrosignata']
+  parents:
+  - 329110
+3687341:
+  aliases: ['Coquillettidia nr. linealis']
+  parents:
+  - 329110
+1771330:
+  aliases: ['Coquillettidia ochracea']
+  parents:
+  - 329110
+329111:
+  aliases: ['Coquillettidia perturbans']
+  parents:
+  - 329110
+1245328:
+  aliases: ['Coquillettidia richiardii']
+  parents:
+  - 329110
+2795833:
+  aliases: ['Coquillettidia shannoni']
+  parents:
+  - 329110
+2292401:
+  aliases: ['Coquillettidia tenuipalpis']
+  parents:
+  - 329110
+3073409:
+  aliases: ['Coquillettidia variegata']
+  parents:
+  - 329110
+2488822:
+  aliases: ['Coquillettidia venezuelensis']
+  parents:
+  - 329110
+1799671:
+  aliases: ['Coquillettidia versicolor']
+  parents:
+  - 329110
+569586:
+  aliases: ['Coquillettidia xanthogaster']
+  parents:
+  - 329110
+53527:
+  aliases: ['Culex']
+  parents:
+  - 7174
+2007271:
+  aliases: ['Culex incertae sedis']
+  parents:
+  - 7174
+53530:
+  aliases: ['Culiciomyia']
+  parents:
+  - 7174
+1788509:
+  aliases: ['Culiseta alaskaensis']
+  parents:
+  - 174825
+332058:
+  aliases: ['Culiseta annulata']
+  parents:
+  - 174825
+3114447:
+  aliases: ['Culiseta atra']
+  parents:
+  - 174825
+866104:
+  aliases: ['Culiseta bergrothi']
+  parents:
+  - 174825
+2517338:
+  aliases: ['Culiseta cf. subochrea/annulata Cs.s/a093LR']
+  parents:
+  - 174825
+2517337:
+  aliases: ['Culiseta cf. subochrea/annulata Cs.s/a93LR']
+  parents:
+  - 174825
+2517340:
+  aliases: ['Culiseta cf. subochrea/annulata mb30']
+  parents:
+  - 174825
+2517339:
+  aliases: ['Culiseta cf. subochrea/annulata mb5']
+  parents:
+  - 174825
+2517341:
+  aliases: ['Culiseta cf. subochrea/annulata mb58']
+  parents:
+  - 174825
+1538645:
+  aliases: ['Culiseta fumipennis']
+  parents:
+  - 174825
+2025599:
+  aliases: ['Culiseta glaphyroptera']
+  parents:
+  - 174825
+174826:
+  aliases: ['Culiseta impatiens']
+  parents:
+  - 174825
+1582038:
+  aliases: ['Culiseta incidens']
+  parents:
+  - 174825
+1806175:
+  aliases: ['Culiseta inconspicua']
+  parents:
+  - 174825
+704160:
+  aliases: ['Culiseta inornata']
+  parents:
+  - 174825
+2579876:
+  aliases: ['Culiseta litorea']
+  parents:
+  - 174825
+1206072:
+  aliases: ['Culiseta longiareolata']
+  parents:
+  - 174825
+329109:
+  aliases: ['Culiseta melanura']
+  parents:
+  - 174825
+329108:
+  aliases: ['Culiseta minnesotae']
+  parents:
+  - 174825
+329107:
+  aliases: ['Culiseta morsitans']
+  parents:
+  - 174825
+1245330:
+  aliases: ['Culiseta nipponica']
+  parents:
+  - 174825
+2292402:
+  aliases: ['Culiseta novaezealandiae']
+  parents:
+  - 174825
+1904329:
+  aliases: ['Culiseta nr. morsitans APHA-8-2015A12']
+  parents:
+  - 174825
+1904330:
+  aliases: ['Culiseta nr. morsitans APHA-8-2015B01']
+  parents:
+  - 174825
+1904328:
+  aliases: ['Culiseta nr. subochrea APHA-2-2015C11']
+  parents:
+  - 174825
+866105:
+  aliases: ['Culiseta ochroptera']
+  parents:
+  - 174825
+1206282:
+  aliases: ['Culiseta particeps']
+  parents:
+  - 174825
+1788510:
+  aliases: ['Culiseta subochrea']
+  parents:
+  - 174825
+2292403:
+  aliases: ['Culiseta tonnoiri']
+  parents:
+  - 174825
+2575618:
+  aliases: ['Dahliana']
+  parents:
+  - 7158
+1245381:
+  aliases: ['Danielsia']
+  parents:
+  - 7158
+1631187:
+  aliases: ['Deinocerites atlanticus']
+  parents:
+  - 53524
+53525:
+  aliases: ['Deinocerites cancer']
+  parents:
+  - 53524
+2487799:
+  aliases: ['Deinocerites magnus']
+  parents:
+  - 53524
+2863125:
+  aliases: ['Deinocerites pseudes']
+  parents:
+  - 53524
+53539:
+  aliases: ['Diceromyia']
+  parents:
+  - 7158
+1806171:
+  aliases: ['Dobrotworskyius']
+  parents:
+  - 7158
+1245382:
+  aliases: ['Downsiomyia']
+  parents:
+  - 7158
+300148:
+  aliases: ['Edwardsaedes']
+  parents:
+  - 7158
+2665659:
+  aliases: ['Eretmapodites chrysogaster']
+  parents:
+  - 317801
+667560:
+  aliases: ['Eretmapodites intermedius']
+  parents:
+  - 317801
+864620:
+  aliases: ['Eretmapodites leucopous']
+  parents:
+  - 317801
+2989693:
+  aliases: ['Eretmapodites plioleucus']
+  parents:
+  - 317801
+503352:
+  aliases: ['Eretmapodites quinquevittatus']
+  parents:
+  - 317801
+2907952:
+  aliases: ['Eretmapodites subsimplicipes']
+  parents:
+  - 317801
+308739:
+  aliases: ['Etorletiomyia']
+  parents:
+  - 308736
+53531:
+  aliases: ['Eumelanomyia']
+  parents:
+  - 7174
+308731:
+  aliases: ['Ficalbia minima']
+  parents:
+  - 308730
+2918766:
+  aliases: ['Ficalbia uniformis']
+  parents:
+  - 308730
+53542:
+  aliases: ['Finlaya']
+  parents:
+  - 7158
+300149:
+  aliases: ['Fredwardsius']
+  parents:
+  - 7158
+1866276:
+  aliases: ['Georgecraigius']
+  parents:
+  - 7158
+346056:
+  aliases: ['Geoskusea']
+  parents:
+  - 190765
+2773400:
+  aliases: ['Gilesius pulchriventer']
+  parents:
+  - 2773402
+346057:
+  aliases: ['Gymnometopa']
+  parents:
+  - 190765
+464954:
+  aliases: ['Haemagogus']
+  parents:
+  - 7180
+71821:
+  aliases: ['Halaedes']
+  parents:
+  - 190765
+317809:
+  aliases: ['Harbachius']
+  parents:
+  - 317805
+325437:
+  aliases: ['Heizmannia']
+  parents:
+  - 317799
+1245383:
+  aliases: ['Himalaius']
+  parents:
+  - 7158
+498391:
+  aliases: ['Hodgesia bailyi']
+  parents:
+  - 425228
+190766:
+  aliases: ['Howardina']
+  parents:
+  - 7158
+1245384:
+  aliases: ['Hulecoeteomyia']
+  parents:
+  - 7158
+2007254:
+  aliases: ['Johnbelkinia longipes']
+  parents:
+  - 2007253
+2007255:
+  aliases: ['Johnbelkinia ulopus']
+  parents:
+  - 2007253
+1289136:
+  aliases: ['Juppius']
+  parents:
+  - 190765
+346058:
+  aliases: ['Kenknightia']
+  parents:
+  - 190765
+2989691:
+  aliases: ['Kitzmilleria']
+  parents:
+  - 7174
+346059:
+  aliases: ['Kompia']
+  parents:
+  - 190765
+58247:
+  aliases: ['Laticorn']
+  parents:
+  - 44482
+317812:
+  aliases: ['Leicesteria']
+  parents:
+  - 124916
+3014974:
+  aliases: ['Lewnielsenius']
+  parents:
+  - 7158
+2872817:
+  aliases: ['Limatus asulleptus']
+  parents:
+  - 704164
+704165:
+  aliases: ['Limatus durhamii']
+  parents:
+  - 704164
+1426897:
+  aliases: ['Limatus flavisetosus']
+  parents:
+  - 704164
+3468594:
+  aliases: ['Limatus paraensis']
+  parents:
+  - 704164
+308715:
+  aliases: ['Lophoceraomyia']
+  parents:
+  - 7174
+300153:
+  aliases: ['Lorrainea']
+  parents:
+  - 7158
+1245385:
+  aliases: ['Luius']
+  parents:
+  - 7158
+1426898:
+  aliases: ['Lutzia allostigma']
+  parents:
+  - 53533
+707284:
+  aliases: ['Lutzia bigoti']
+  parents:
+  - 53533
+2502097:
+  aliases: ['Lutzia chiangmaiensis']
+  parents:
+  - 53533
+308712:
+  aliases: ['Lutzia fuscana']
+  parents:
+  - 53533
+1245329:
+  aliases: ['Lutzia halifaxii']
+  parents:
+  - 53533
+2730086:
+  aliases: ['Lutzia shinonagai']
+  parents:
+  - 53533
+42432:
+  aliases: ['Lutzia tigripes']
+  parents:
+  - 53533
+1652497:
+  aliases: ['Lutzia vorax']
+  parents:
+  - 53533
+346061:
+  aliases: ['Macleaya']
+  parents:
+  - 7158
+53534:
+  aliases: ['Maillotia']
+  parents:
+  - 7174
+325434:
+  aliases: ['Malaya genurostris']
+  parents:
+  - 149618
+149619:
+  aliases: ['Malaya jacobsoni']
+  parents:
+  - 149618
+308734:
+  aliases: ['Mansonia']
+  parents:
+  - 149459
+308733:
+  aliases: ['Mansonioides']
+  parents:
+  - 149459
+704167:
+  aliases: ['Maorigoeldia argyropus']
+  parents:
+  - 704166
+317802:
+  aliases: ['Mattinglyia']
+  parents:
+  - 317799
+53535:
+  aliases: ['Melanoconion']
+  parents:
+  - 7174
+2891964:
+  aliases: ['Micraedes']
+  parents:
+  - 7174
+707272:
+  aliases: ['Microculex']
+  parents:
+  - 7174
+308737:
+  aliases: ['Mimomyia']
+  parents:
+  - 308736
+53536:
+  aliases: ['Mochlostyrax']
+  parents:
+  - 7174
+53543:
+  aliases: ['Mucidus']
+  parents:
+  - 7158
+59140:
+  aliases: ['Myzomyia']
+  parents:
+  - 44534
+44535:
+  aliases: ['Neocellia']
+  parents:
+  - 44534
+53537:
+  aliases: ['Neoculex']
+  parents:
+  - 7174
+317806:
+  aliases: ['Neomacleaya']
+  parents:
+  - 317805
+53544:
+  aliases: ['Neomelaniconion']
+  parents:
+  - 7158
+44536:
+  aliases: ['Neomyzomyia']
+  parents:
+  - 44534
+1346164:
+  aliases: ['Nyctomyia pholeocola']
+  parents:
+  - 1367702
+53545:
+  aliases: ['Ochlerotatus']
+  parents:
+  - 190765
+767021:
+  aliases: ['Ochlerotatus incertae sedis']
+  parents:
+  - 190765
+667565:
+  aliases: ['Oculeomyia']
+  parents:
+  - 7174
+2292399:
+  aliases: ['Opifex chathamicus']
+  parents:
+  - 317800
+704161:
+  aliases: ['Opifex fuscus']
+  parents:
+  - 317800
+139054:
+  aliases: ['Orthopodomyia alba']
+  parents:
+  - 139053
+3569222:
+  aliases: ['Orthopodomyia andamanensis']
+  parents:
+  - 139053
+325430:
+  aliases: ['Orthopodomyia anopheloides']
+  parents:
+  - 139053
+2007214:
+  aliases: ['Orthopodomyia fascipes']
+  parents:
+  - 139053
+665337:
+  aliases: ['Orthopodomyia kummi']
+  parents:
+  - 139053
+665338:
+  aliases: ['Orthopodomyia pulcripalpis']
+  parents:
+  - 139053
+3569223:
+  aliases: ['Orthopodomyia siamensis']
+  parents:
+  - 139053
+665339:
+  aliases: ['Orthopodomyia signifera']
+  parents:
+  - 139053
+300154:
+  aliases: ['Paraedes']
+  parents:
+  - 7158
+262669:
+  aliases: ['Paramyzomyia']
+  parents:
+  - 44534
+1245346:
+  aliases: ['Phagomyia assamensis']
+  parents:
+  - 1245386
+1529942:
+  aliases: ['Phagomyia cogilli']
+  parents:
+  - 1245386
+1245347:
+  aliases: ['Phagomyia khazani']
+  parents:
+  - 1245386
+1245348:
+  aliases: ['Phagomyia prominens']
+  parents:
+  - 1245386
+707270:
+  aliases: ['Phenacomyia']
+  parents:
+  - 7174
+1091057:
+  aliases: ['Phytotelmatomyia']
+  parents:
+  - 7174
+1806189:
+  aliases: ['Polylepidomyia']
+  parents:
+  - 53567
+1379452:
+  aliases: ['Protoculex']
+  parents:
+  - 190765
+119225:
+  aliases: ['Protomacleaya']
+  parents:
+  - 190765
+325427:
+  aliases: ['Pseudoficalbia']
+  parents:
+  - 139055
+346065:
+  aliases: ['Pseudoskusea']
+  parents:
+  - 190765
+1631548:
+  aliases: ['Psorophora (Grabhamia) sp. RHL-2015']
+  parents:
+  - 7182
+1916147:
+  aliases: ['Psorophora albigenu']
+  parents:
+  - 7182
+869069:
+  aliases: ['Psorophora albipes']
+  parents:
+  - 7182
+329106:
+  aliases: ['Psorophora ciliata']
+  parents:
+  - 7182
+549315:
+  aliases: ['Psorophora cingulata']
+  parents:
+  - 7182
+869070:
+  aliases: ['Psorophora columbiae']
+  parents:
+  - 7182
+869071:
+  aliases: ['Psorophora confinnis']
+  parents:
+  - 7182
+869072:
+  aliases: ['Psorophora cyanescens']
+  parents:
+  - 7182
+1206287:
+  aliases: ['Psorophora discolor']
+  parents:
+  - 7182
+1921085:
+  aliases: ['Psorophora discrucians']
+  parents:
+  - 7182
+7183:
+  aliases: ['Psorophora ferox']
+  parents:
+  - 7182
+3153700:
+  aliases: ['Psorophora forceps']
+  parents:
+  - 7182
+2689572:
+  aliases: ['Psorophora funiculus']
+  parents:
+  - 7182
+2067438:
+  aliases: ['Psorophora horrida']
+  parents:
+  - 7182
+869073:
+  aliases: ['Psorophora howardii']
+  parents:
+  - 7182
+1206012:
+  aliases: ['Psorophora insularia']
+  parents:
+  - 7182
+3014949:
+  aliases: ['Psorophora jamaicensis']
+  parents:
+  - 7182
+1206013:
+  aliases: ['Psorophora longipalpus']
+  parents:
+  - 7182
+3014950:
+  aliases: ['Psorophora mathesoni']
+  parents:
+  - 7182
+2795834:
+  aliases: ['Psorophora paulli']
+  parents:
+  - 7182
+1206014:
+  aliases: ['Psorophora pygmaea']
+  parents:
+  - 7182
+2597062:
+  aliases: ['Psorophora saeva']
+  parents:
+  - 7182
+1206015:
+  aliases: ['Psorophora signipennis']
+  parents:
+  - 7182
+3014948:
+  aliases: ['Psorophora tolteca']
+  parents:
+  - 7182
+933869:
+  aliases: ['Psorophora varinervis']
+  parents:
+  - 7182
+2488823:
+  aliases: ['Psorophora varipes']
+  parents:
+  - 7182
+44537:
+  aliases: ['Pyretophorus']
+  parents:
+  - 44534
+325440:
+  aliases: ['Rachionotomyia']
+  parents:
+  - 53567
+3014975:
+  aliases: ['Rachisoura']
+  parents:
+  - 53567
+1919242:
+  aliases: ['Rampamyia']
+  parents:
+  - 7158
+345925:
+  aliases: ['Rhinoskusea']
+  parents:
+  - 190765
+2007259:
+  aliases: ['Runchomyia magna']
+  parents:
+  - 2007258
+2597063:
+  aliases: ['Runchomyia reversa']
+  parents:
+  - 2007258
+190767:
+  aliases: ['Rusticoidus']
+  parents:
+  - 190765
+518694:
+  aliases: ['Sabethes albiprivus']
+  parents:
+  - 53551
+464956:
+  aliases: ['Sabethes belisarioi']
+  parents:
+  - 53551
+2984125:
+  aliases: ['Sabethes bipartipes']
+  parents:
+  - 53551
+521044:
+  aliases: ['Sabethes cf. albiprivus B PMP-2008']
+  parents:
+  - 53551
+865939:
+  aliases: ['Sabethes chloropterus']
+  parents:
+  - 53551
+3153701:
+  aliases: ['Sabethes conditus']
+  parents:
+  - 53551
+53552:
+  aliases: ['Sabethes cyaneus']
+  parents:
+  - 53551
+2153043:
+  aliases: ['Sabethes glaucodaemon']
+  parents:
+  - 53551
+2007215:
+  aliases: ['Sabethes hadrognathus']
+  parents:
+  - 53551
+3381344:
+  aliases: ['Sabethes identicus']
+  parents:
+  - 53551
+2007216:
+  aliases: ['Sabethes idiogenes']
+  parents:
+  - 53551
+758603:
+  aliases: ['Sabethes intermedius']
+  parents:
+  - 53551
+2007217:
+  aliases: ['Sabethes paradoxus']
+  parents:
+  - 53551
+3029984:
+  aliases: ['Sabethes quasicyaneus']
+  parents:
+  - 53551
+2007218:
+  aliases: ['Sabethes soperi']
+  parents:
+  - 53551
+2984126:
+  aliases: ['Sabethes tarsopus']
+  parents:
+  - 53551
+2007222:
+  aliases: ['Sabethes undosus']
+  parents:
+  - 53551
+3153702:
+  aliases: ['Sallumia']
+  parents:
+  - 190765
+300155:
+  aliases: ['Scutomyia']
+  parents:
+  - 7158
+704169:
+  aliases: ['Shannoniana fluviatilis']
+  parents:
+  - 704168
+2872816:
+  aliases: ['Shannoniana moralesi']
+  parents:
+  - 704168
+2007223:
+  aliases: ['Shannoniana schedocyclia']
+  parents:
+  - 704168
+2730084:
+  aliases: ['Sirivanakarnius']
+  parents:
+  - 7174
+53547:
+  aliases: ['Skusea']
+  parents:
+  - 7158
+53541:
+  aliases: ['Stegomyia']
+  parents:
+  - 7158
+1608559:
+  aliases: ['Tanakaius savoryi']
+  parents:
+  - 1608558
+3453668:
+  aliases: ['Tinolestes']
+  parents:
+  - 7174
+1245370:
+  aliases: ['Topomyia houghtoni']
+  parents:
+  - 1245394
+2498891:
+  aliases: ['Topomyia yanbarensis']
+  parents:
+  - 1245394
+3122450:
+  aliases: ['Toxorhynchites (Lynchiella) sp.']
+  parents:
+  - 2624694
+2007226:
+  aliases: ['Toxorhynchites haemorrhoidalis haemorrhoidalis']
+  parents:
+  - 2007225
+2007227:
+  aliases: ['Toxorhynchites haemorrhoidalis superbus']
+  parents:
+  - 2007225
+2498890:
+  aliases: ['Toxorhynchites manicatus yaeyamae']
+  parents:
+  - 2498889
+329112:
+  aliases: ['Toxorhynchites rutilus septentrionalis']
+  parents:
+  - 53553
+2665171:
+  aliases: ['Toxorhynchites sp. 16GH 18-5']
+  parents:
+  - 2624694
+174824:
+  aliases: ['Toxorhynchites sp. AM-2001']
+  parents:
+  - 2624694
+743695:
+  aliases: ['Toxorhynchites sp. BOLD:AAC7484']
+  parents:
+  - 2624694
+2597067:
+  aliases: ['Toxorhynchites sp. CL-2019']
+  parents:
+  - 2624694
+1426900:
+  aliases: ['Toxorhynchites sp. TIP1']
+  parents:
+  - 2624694
+2108401:
+  aliases: ['Toxorhynchites sp. TOC']
+  parents:
+  - 2624694
+2038295:
+  aliases: ['Toxorhynchites sp. Toxo']
+  parents:
+  - 2624694
+2007229:
+  aliases: ['Trichoprosopon compressum']
+  parents:
+  - 704162
+704163:
+  aliases: ['Trichoprosopon digitatum']
+  parents:
+  - 704162
+1677683:
+  aliases: ['Trichoprosopon evansae']
+  parents:
+  - 704162
+2872824:
+  aliases: ['Trichoprosopon nr. brevipes BOLD:ADE5656']
+  parents:
+  - 704162
+2007230:
+  aliases: ['Trichoprosopon pallidiventer']
+  parents:
+  - 704162
+3458803:
+  aliases: ['Trichoprosopon soaresi']
+  parents:
+  - 704162
+2725259:
+  aliases: ['Trichoprosopon sp. 1 DJS-2020']
+  parents:
+  - 704162
+2725260:
+  aliases: ['Trichoprosopon sp. 2 DJS-2020']
+  parents:
+  - 704162
+2725261:
+  aliases: ['Trichoprosopon sp. 3 DJS-2020']
+  parents:
+  - 704162
+2725262:
+  aliases: ['Trichoprosopon sp. 5 DJS-2020']
+  parents:
+  - 704162
+3458804:
+  aliases: ['Trichoprosopon vonplesseni']
+  parents:
+  - 704162
+325442:
+  aliases: ['Tripteroides']
+  parents:
+  - 53567
+2587271:
+  aliases: ['Udaya argyrurus']
+  parents:
+  - 1245387
+1245355:
+  aliases: ['Udaya subsimilis']
+  parents:
+  - 1245387
+325429:
+  aliases: ['Uranotaenia']
+  parents:
+  - 139055
+317810:
+  aliases: ['Verrallina']
+  parents:
+  - 317805
+2872819:
+  aliases: ['Wyeomyia abebela']
+  parents:
+  - 174620
+2007233:
+  aliases: ['Wyeomyia albosquamata']
+  parents:
+  - 174620
+2793202:
+  aliases: ['Wyeomyia anthica']
+  parents:
+  - 174620
+1426843:
+  aliases: ['Wyeomyia aphobema']
+  parents:
+  - 174620
+2007234:
+  aliases: ['Wyeomyia aporonoma']
+  parents:
+  - 174620
+2007235:
+  aliases: ['Wyeomyia argenteorostris']
+  parents:
+  - 174620
+2007236:
+  aliases: ['Wyeomyia arthrostigma']
+  parents:
+  - 174620
+2007237:
+  aliases: ['Wyeomyia bourrouli']
+  parents:
+  - 174620
+2903343:
+  aliases: ['Wyeomyia celaenocephala']
+  parents:
+  - 174620
+2007238:
+  aliases: ['Wyeomyia complosa']
+  parents:
+  - 174620
+2007239:
+  aliases: ['Wyeomyia compta']
+  parents:
+  - 174620
+2597064:
+  aliases: ['Wyeomyia confusa']
+  parents:
+  - 174620
+2007240:
+  aliases: ['Wyeomyia forattinii']
+  parents:
+  - 174620
+2007241:
+  aliases: ['Wyeomyia lamellata']
+  parents:
+  - 174620
+1677684:
+  aliases: ['Wyeomyia luteoventralis']
+  parents:
+  - 174620
+629757:
+  aliases: ['Wyeomyia melanocephala']
+  parents:
+  - 174620
+2872820:
+  aliases: ['Wyeomyia melanopus']
+  parents:
+  - 174620
+2785384:
+  aliases: ['Wyeomyia mitchelli']
+  parents:
+  - 174620
+857316:
+  aliases: ['Wyeomyia mitchellii']
+  parents:
+  - 174620
+1426902:
+  aliases: ['Wyeomyia nr. aphobema BOLD:AAW1141']
+  parents:
+  - 174620
+2007242:
+  aliases: ['Wyeomyia oblita']
+  parents:
+  - 174620
+2007243:
+  aliases: ['Wyeomyia occulta']
+  parents:
+  - 174620
+2007244:
+  aliases: ['Wyeomyia pertinans']
+  parents:
+  - 174620
+2007245:
+  aliases: ['Wyeomyia pseudopecten']
+  parents:
+  - 174620
+2007246:
+  aliases: ['Wyeomyia robusta']
+  parents:
+  - 174620
+2706870:
+  aliases: ['Wyeomyia rorotai']
+  parents:
+  - 174620
+174621:
+  aliases: ['Wyeomyia smithii']
+  parents:
+  - 174620
+2007249:
+  aliases: ['Wyeomyia splendida']
+  parents:
+  - 174620
+2007250:
+  aliases: ['Wyeomyia surinamensis']
+  parents:
+  - 174620
+2007251:
+  aliases: ['Wyeomyia testei']
+  parents:
+  - 174620
+1426899:
+  aliases: ['Wyeomyia ulocoma']
+  parents:
+  - 174620
+857315:
+  aliases: ['Wyeomyia vanduzeei']
+  parents:
+  - 174620
+2007252:
+  aliases: ['Wyeomyia ypsipola']
+  parents:
+  - 174620
+346066:
+  aliases: ['Zavortinkius']
+  parents:
+  - 7158
+1424510:
+  aliases: ['Zeugnomyia gracilis']
+  parents:
+  - 1424509
+44544:
+  aliases: ['albimanus section']
+  parents:
+  - 44543
+44545:
+  aliases: ['argyritarsis section']
+  parents:
+  - 44543
+333811:
+  aliases: ['environmental samples']
+  parents:
+  - 7174
+1629145:
+  aliases: ['environmental samples']
+  parents:
+  - 7158
+874512:
+  aliases: ['myzorhynchella section']
+  parents:
+  - 44543
+53548:
+  aliases: ['unclassified Aedes (in: mosquitos)']
+  parents:
+  - 7158
+2853149:
+  aliases: ['unclassified Armigeres (in: mosquitos)']
+  parents:
+  - 124916
+2637621:
+  aliases: ['unclassified Coquillettidia']
+  parents:
+  - 329110
+3406907:
+  aliases: ['unclassified Culex (in: mosquitos)']
+  parents:
+  - 7174
+2619201:
+  aliases: ['unclassified Culiseta']
+  parents:
+  - 174825
+3406951:
+  aliases: ['unclassified Haemagogus (in: mosquitos)']
+  parents:
+  - 7180
+3406956:
+  aliases: ['unclassified Heizmannia (in: mosquitos)']
+  parents:
+  - 317799
+1147728:
+  aliases: ['unclassified Mansonia (in: mosquitos)']
+  parents:
+  - 149459
+3407012:
+  aliases: ['unclassified Mimomyia (in: mosquitos)']
+  parents:
+  - 308736
+54114:
+  aliases: ['unclassified Nyssorhynchus']
+  parents:
+  - 44543
+1125803:
+  aliases: ['unclassified Ochlerotatus (in: mosquitos, genus)']
+  parents:
+  - 190765
+2622204:
+  aliases: ['unclassified Onirion']
+  parents:
+  - 2007256
+2853112:
+  aliases: ['unclassified Orthopodomyia']
+  parents:
+  - 139053
+3122448:
+  aliases: ['unclassified Psorophora']
+  parents:
+  - 7182
+2647614:
+  aliases: ['unclassified Runchomyia']
+  parents:
+  - 2007258
+2646388:
+  aliases: ['unclassified Sabethes']
+  parents:
+  - 53551
+3123417:
+  aliases: ['unclassified Shannoniana']
+  parents:
+  - 704168
+2630085:
+  aliases: ['unclassified Trichoprosopon']
+  parents:
+  - 704162
+3407135:
+  aliases: ['unclassified Tripteroides (in: mosquitos)']
+  parents:
+  - 53567
+3407139:
+  aliases: ['unclassified Uranotaenia (in: mosquitos)']
+  parents:
+  - 139055
+3407142:
+  aliases: ['unclassified Verrallina (in: mosquitos)']
+  parents:
+  - 317805
+2631130:
+  aliases: ['unclassified Wyeomyia']
+  parents:
+  - 174620
+1803707:
+  aliases: ['Aedes (Aedimorphus) sp. 20974_AedimB11']
+  parents:
+  - 53540
+1803708:
+  aliases: ['Aedes (Aedimorphus) sp. 20974_AedimB12']
+  parents:
+  - 53540
+1803709:
+  aliases: ['Aedes (Aedimorphus) sp. 20974_AedimC02']
+  parents:
+  - 53540
+2014629:
+  aliases: ['Aedes (Diceromyia) sp. 1 PK-2017']
+  parents:
+  - 53539
+1263929:
+  aliases: ['Aedes abnormalis']
+  parents:
+  - 53540
+7159:
+  aliases: ['Aedes aegypti']
+  parents:
+  - 53541
+3095915:
+  aliases: ['Aedes aegypti x Aedes mascarensis']
+  parents:
+  - 53541
+1629146:
+  aliases: ['Aedes aff. notoscriptus environmental sample']
+  parents:
+  - 1629145
+667568:
+  aliases: ['Aedes africanus']
+  parents:
+  - 53541
+561254:
+  aliases: ['Aedes albiradius']
+  parents:
+  - 53544
+1806178:
+  aliases: ['Aedes alboannulatus']
+  parents:
+  - 1806171
+1234363:
+  aliases: ['Aedes albocephalus']
+  parents:
+  - 53540
+1245338:
+  aliases: ['Aedes albolateralis']
+  parents:
+  - 1245382
+1245349:
+  aliases: ['Aedes albolineatus']
+  parents:
+  - 300155
+7160:
+  aliases: ['Aedes albopictus']
+  parents:
+  - 53541
+1245337:
+  aliases: ['Aedes albotaeniatus']
+  parents:
+  - 1245381
+2563463:
+  aliases: ['Aedes alboventralis']
+  parents:
+  - 53540
+2873521:
+  aliases: ['Aedes allotecnon']
+  parents:
+  - 190766
+569587:
+  aliases: ['Aedes alternans']
+  parents:
+  - 53543
+1424563:
+  aliases: ['Aedes amesii']
+  parents:
+  - 300153
+1245350:
+  aliases: ['Aedes annandalei']
+  parents:
+  - 53541
+3402264:
+  aliases: ['Aedes antuensis']
+  parents:
+  - 300148
+2007260:
+  aliases: ['Aedes arborealis']
+  parents:
+  - 190766
+28624:
+  aliases: ['Aedes atropalpus']
+  parents:
+  - 1866276
+1424564:
+  aliases: ['Aedes aurantius']
+  parents:
+  - 53543
+1214259:
+  aliases: ['Aedes aureostriatus']
+  parents:
+  - 1245277
+2761509:
+  aliases: ['Aedes aurovenatus']
+  parents:
+  - 53544
+188699:
+  aliases: ['Aedes bahamensis']
+  parents:
+  - 190766
+498394:
+  aliases: ['Aedes barraudi']
+  parents:
+  - 300154
+1451302:
+  aliases: ['Aedes bekkui']
+  parents:
+  - 300148
+561250:
+  aliases: ['Aedes belleci']
+  parents:
+  - 53544
+2748776:
+  aliases: ['Aedes bhutanensis']
+  parents:
+  - 1245384
+1397682:
+  aliases: ['Aedes bromeliae']
+  parents:
+  - 53541
+2696053:
+  aliases: ['Aedes busckii']
+  parents:
+  - 190766
+2918770:
+  aliases: ['Aedes capensis']
+  parents:
+  - 300144
+2067445:
+  aliases: ['Aedes centropunctatus']
+  parents:
+  - 53540
+2722874:
+  aliases: ['Aedes cf. denderensis FANP37.H11']
+  parents:
+  - 53541
+2722875:
+  aliases: ['Aedes cf. luteocephalus SENP19.A2']
+  parents:
+  - 53541
+2722876:
+  aliases: ['Aedes cf. simpsoni MAFP6.G8']
+  parents:
+  - 53541
+3076078:
+  aliases: ['Aedes chemulpoensis']
+  parents:
+  - 53541
+498395:
+  aliases: ['Aedes chrysolineatus']
+  parents:
+  - 53542
+120872:
+  aliases: ['Aedes cinereus']
+  parents:
+  - 149531
+503349:
+  aliases: ['Aedes circumluteolus']
+  parents:
+  - 53544
+1424566:
+  aliases: ['Aedes collessi']
+  parents:
+  - 300154
+2989690:
+  aliases: ['Aedes contiguus']
+  parents:
+  - 53541
+2014625:
+  aliases: ['Aedes coulangesi']
+  parents:
+  - 53539
+2067446:
+  aliases: ['Aedes cozi']
+  parents:
+  - 53541
+2903341:
+  aliases: ['Aedes cozumelensis']
+  parents:
+  - 190766
+1245351:
+  aliases: ['Aedes craggi']
+  parents:
+  - 53541
+240003:
+  aliases: ['Aedes cretinus']
+  parents:
+  - 53541
+503354:
+  aliases: ['Aedes cumminsii']
+  parents:
+  - 53540
+1263930:
+  aliases: ['Aedes curtipes']
+  parents:
+  - 300146
+742472:
+  aliases: ['Aedes daitensis']
+  parents:
+  - 53541
+3114448:
+  aliases: ['Aedes daliensis']
+  parents:
+  - 1806188
+503350:
+  aliases: ['Aedes dalzieli']
+  parents:
+  - 53540
+667561:
+  aliases: ['Aedes denderensis']
+  parents:
+  - 53541
+1799673:
+  aliases: ['Aedes dentatus']
+  parents:
+  - 53540
+2806239:
+  aliases: ['Aedes dentatus group sp.']
+  parents:
+  - 53540
+1245352:
+  aliases: ['Aedes desmotes']
+  parents:
+  - 53541
+2761504:
+  aliases: ['Aedes durbanensis']
+  parents:
+  - 53540
+373847:
+  aliases: ['Aedes dybasi']
+  parents:
+  - 53541
+2575619:
+  aliases: ['Aedes echinus']
+  parents:
+  - 2575618
+159648:
+  aliases: ['Aedes elsiae']
+  parents:
+  - 53542
+3461570:
+  aliases: ['Aedes embuensis']
+  parents:
+  - 53542
+2761505:
+  aliases: ['Aedes eritreae']
+  parents:
+  - 53540
+373843:
+  aliases: ['Aedes esoensis']
+  parents:
+  - 149531
+2563464:
+  aliases: ['Aedes fascipalpis']
+  parents:
+  - 53539
+1245345:
+  aliases: ['Aedes fengi']
+  parents:
+  - 1245385
+3043750:
+  aliases: ['Aedes flavipennis']
+  parents:
+  - 53542
+166586:
+  aliases: ['Aedes flavopictus']
+  parents:
+  - 53541
+561256:
+  aliases: ['Aedes fontenillei']
+  parents:
+  - 53544
+1245343:
+  aliases: ['Aedes formosensis']
+  parents:
+  - 1245384
+2067448:
+  aliases: ['Aedes fowleri']
+  parents:
+  - 53540
+2339220:
+  aliases: ['Aedes fryeri']
+  parents:
+  - 2339219
+1828538:
+  aliases: ['Aedes fulvithorax']
+  parents:
+  - 190766
+308709:
+  aliases: ['Aedes fumidus']
+  parents:
+  - 300153
+299627:
+  aliases: ['Aedes furcifer']
+  parents:
+  - 53539
+2814731:
+  aliases: ['Aedes futunae']
+  parents:
+  - 53541
+373852:
+  aliases: ['Aedes galloisi']
+  parents:
+  - 53541
+2587272:
+  aliases: ['Aedes ganapathi']
+  parents:
+  - 1245382
+2603928:
+  aliases: ['Aedes gardnerii']
+  parents:
+  - 53541
+401424:
+  aliases: ['Aedes geminus']
+  parents:
+  - 149531
+120874:
+  aliases: ['Aedes geniculatus']
+  parents:
+  - 53542
+1245342:
+  aliases: ['Aedes gilli']
+  parents:
+  - 1245383
+1245278:
+  aliases: ['Aedes greenii']
+  parents:
+  - 1245277
+2872823:
+  aliases: ['Aedes guatemala']
+  parents:
+  - 190766
+2785374:
+  aliases: ['Aedes guerrero']
+  parents:
+  - 190766
+2126761:
+  aliases: ['Aedes hansfordi']
+  parents:
+  - 53541
+498396:
+  aliases: ['Aedes harveyi']
+  parents:
+  - 53542
+2761507:
+  aliases: ['Aedes haworthi']
+  parents:
+  - 300144
+569588:
+  aliases: ['Aedes hebrideus']
+  parents:
+  - 53541
+1055893:
+  aliases: ['Aedes helenae']
+  parents:
+  - 346052
+373851:
+  aliases: ['Aedes hensilli']
+  parents:
+  - 53541
+1799674:
+  aliases: ['Aedes hirsutus']
+  parents:
+  - 53540
+376794:
+  aliases: ['Aedes iyengari']
+  parents:
+  - 53539
+140438:
+  aliases: ['Aedes japonicus']
+  parents:
+  - 53542
+508664:
+  aliases: ['Aedes katherinensis']
+  parents:
+  - 53541
+1055894:
+  aliases: ['Aedes kleini']
+  parents:
+  - 346052
+3014957:
+  aliases: ['Aedes kochi']
+  parents:
+  - 53542
+2865750:
+  aliases: ['Aedes koreicoides']
+  parents:
+  - 1806188
+586676:
+  aliases: ['Aedes koreicus']
+  parents:
+  - 1245384
+1579483:
+  aliases: ['Aedes krombeini']
+  parents:
+  - 53541
+3112733:
+  aliases: ['Aedes laniger']
+  parents:
+  - 53543
+2761511:
+  aliases: ['Aedes ledgeri']
+  parents:
+  - 53541
+3461571:
+  aliases: ['Aedes leesoni']
+  parents:
+  - 53540
+1769045:
+  aliases: ['Aedes lilii']
+  parents:
+  - 53541
+869251:
+  aliases: ['Aedes lineatopennis']
+  parents:
+  - 53544
+1328033:
+  aliases: ['Aedes longipalpis']
+  parents:
+  - 346066
+2891960:
+  aliases: ['Aedes lorraineae']
+  parents:
+  - 190766
+299629:
+  aliases: ['Aedes luteocephalus']
+  parents:
+  - 53541
+1806180:
+  aliases: ['Aedes macmillani']
+  parents:
+  - 346061
+2014626:
+  aliases: ['Aedes madagascarensis']
+  parents:
+  - 53539
+373846:
+  aliases: ['Aedes maehleri']
+  parents:
+  - 53541
+1424567:
+  aliases: ['Aedes malayensis']
+  parents:
+  - 53541
+1245353:
+  aliases: ['Aedes malikuli']
+  parents:
+  - 53541
+1806183:
+  aliases: ['Aedes mallochi']
+  parents:
+  - 1806188
+1055895:
+  aliases: ['Aedes manhi']
+  parents:
+  - 346052
+590165:
+  aliases: ['Aedes mascarensis']
+  parents:
+  - 53541
+503348:
+  aliases: ['Aedes mcintoshi']
+  parents:
+  - 53544
+1245335:
+  aliases: ['Aedes mediolineatus']
+  parents:
+  - 53540
+686388:
+  aliases: ['Aedes metallicus']
+  parents:
+  - 53541
+3014958:
+  aliases: ['Aedes milsoni']
+  parents:
+  - 1806171
+3014959:
+  aliases: ['Aedes monocellatus']
+  parents:
+  - 1806188
+3402265:
+  aliases: ['Aedes mubiensis']
+  parents:
+  - 149531
+3014976:
+  aliases: ['Aedes muelleri']
+  parents:
+  - 3014974
+3367304:
+  aliases: ['Aedes natronius']
+  parents:
+  - 53540
+2943528:
+  aliases: ['Aedes nigricephalus']
+  parents:
+  - 53540
+561251:
+  aliases: ['Aedes nigropterum']
+  parents:
+  - 53544
+373844:
+  aliases: ['Aedes nipponicus']
+  parents:
+  - 53542
+1214261:
+  aliases: ['Aedes nishikawai']
+  parents:
+  - 53542
+1245339:
+  aliases: ['Aedes niveoides']
+  parents:
+  - 1245382
+2022598:
+  aliases: ['Aedes niveus']
+  parents:
+  - 1245382
+508665:
+  aliases: ['Aedes notoscriptus']
+  parents:
+  - 1919242
+1579489:
+  aliases: ['Aedes novalbopictus']
+  parents:
+  - 53541
+1245340:
+  aliases: ['Aedes novoniveus']
+  parents:
+  - 1245382
+2686120:
+  aliases: ['Aedes nr. cinereus APHA-10-2015E05']
+  parents:
+  - 149531
+2686118:
+  aliases: ['Aedes nr. cinereus APHA-10-2015E06']
+  parents:
+  - 149531
+2686119:
+  aliases: ['Aedes nr. cinereus APHA-11-2015A09']
+  parents:
+  - 149531
+2793865:
+  aliases: ['Aedes nr. fumidus S49_101']
+  parents:
+  - 300153
+2793867:
+  aliases: ['Aedes nr. fumidus S50_103A']
+  parents:
+  - 300153
+2793866:
+  aliases: ['Aedes nr. fumidus S50_104A']
+  parents:
+  - 300153
+450822:
+  aliases: ['Aedes ochraceus']
+  parents:
+  - 53540
+1245341:
+  aliases: ['Aedes omorii']
+  parents:
+  - 1245382
+2761506:
+  aliases: ['Aedes pachyurus']
+  parents:
+  - 53540
+373848:
+  aliases: ['Aedes palauensis']
+  parents:
+  - 53541
+1929008:
+  aliases: ['Aedes pallidostriatus']
+  parents:
+  - 53540
+508666:
+  aliases: ['Aedes palmarum']
+  parents:
+  - 53542
+561253:
+  aliases: ['Aedes palpalae']
+  parents:
+  - 53544
+3114450:
+  aliases: ['Aedes pecuniosus']
+  parents:
+  - 53542
+1914964:
+  aliases: ['Aedes pembaensis']
+  parents:
+  - 53547
+3137930:
+  aliases: ['Aedes penghuensis']
+  parents:
+  - 300146
+2793098:
+  aliases: ['Aedes pexus']
+  parents:
+  - 1245382
+1397683:
+  aliases: ['Aedes pia']
+  parents:
+  - 53541
+2773399:
+  aliases: ['Aedes poicilius']
+  parents:
+  - 53542
+188700:
+  aliases: ['Aedes polynesiensis']
+  parents:
+  - 53541
+1245354:
+  aliases: ['Aedes pseudalbopictus']
+  parents:
+  - 53541
+2793099:
+  aliases: ['Aedes pseudoniveus']
+  parents:
+  - 1245382
+316597:
+  aliases: ['Aedes pseudoscutellaris']
+  parents:
+  - 53541
+2321093:
+  aliases: ['Aedes quadrivittatus']
+  parents:
+  - 190766
+2563465:
+  aliases: ['Aedes quasiunivittatus']
+  parents:
+  - 53540
+3014960:
+  aliases: ['Aedes quinquelineatus']
+  parents:
+  - 1919242
+2785375:
+  aliases: ['Aedes ramirezi']
+  parents:
+  - 346054
+373849:
+  aliases: ['Aedes riversi']
+  parents:
+  - 53541
+761982:
+  aliases: ['Aedes rossicus']
+  parents:
+  - 149531
+1806179:
+  aliases: ['Aedes rubrithorax']
+  parents:
+  - 1806171
+3014961:
+  aliases: ['Aedes rupestris']
+  parents:
+  - 1806171
+3402266:
+  aliases: ['Aedes sasai']
+  parents:
+  - 149531
+2587273:
+  aliases: ['Aedes saxicola']
+  parents:
+  - 1245384
+2563466:
+  aliases: ['Aedes scatophagoides']
+  parents:
+  - 53543
+373850:
+  aliases: ['Aedes scutellaris']
+  parents:
+  - 53541
+3383095:
+  aliases: ['Aedes sexlineatus']
+  parents:
+  - 190766
+7161:
+  aliases: ['Aedes simpsoni']
+  parents:
+  - 53541
+2879502:
+  aliases: ['Aedes simpsoni sensu lato KV_BF4']
+  parents:
+  - 53541
+2879503:
+  aliases: ['Aedes simpsoni sensu lato KV_BF6']
+  parents:
+  - 53541
+2879501:
+  aliases: ['Aedes simpsoni sensu lato KV_BF7']
+  parents:
+  - 53541
+2879500:
+  aliases: ['Aedes simpsoni sensu lato RAB_BF11']
+  parents:
+  - 53541
+2879499:
+  aliases: ['Aedes simpsoni sensu lato RAB_BF13']
+  parents:
+  - 53541
+2879497:
+  aliases: ['Aedes simpsoni sensu lato RAB_BF14']
+  parents:
+  - 53541
+2879498:
+  aliases: ['Aedes simpsoni sensu lato RAB_BF18']
+  parents:
+  - 53541
+37951:
+  aliases: ['Aedes sp.']
+  parents:
+  - 53548
+2314892:
+  aliases: ['Aedes sp. 07PROBE-04097']
+  parents:
+  - 53548
+507997:
+  aliases: ['Aedes sp. 1 NDD-2008']
+  parents:
+  - 53548
+2972445:
+  aliases: ['Aedes sp. 1 NPK-2022a']
+  parents:
+  - 53548
+1406126:
+  aliases: ['Aedes sp. 1 pk']
+  parents:
+  - 53548
+1406127:
+  aliases: ['Aedes sp. 2 pk']
+  parents:
+  - 53548
+1406128:
+  aliases: ['Aedes sp. 3 pk']
+  parents:
+  - 53548
+2022599:
+  aliases: ['Aedes sp. A KIY-2017']
+  parents:
+  - 53548
+2314948:
+  aliases: ['Aedes sp. AS-02-03']
+  parents:
+  - 53548
+2022600:
+  aliases: ['Aedes sp. B KIY-2017']
+  parents:
+  - 53548
+2314960:
+  aliases: ['Aedes sp. BARS_2015_34_077']
+  parents:
+  - 53548
+2326390:
+  aliases: ['Aedes sp. BBDCN128-10']
+  parents:
+  - 53548
+2326391:
+  aliases: ['Aedes sp. BBDCN544-10']
+  parents:
+  - 53548
+2326392:
+  aliases: ['Aedes sp. BBDCP552-10']
+  parents:
+  - 53548
+2326393:
+  aliases: ['Aedes sp. BBDCP557-10']
+  parents:
+  - 53548
+2326394:
+  aliases: ['Aedes sp. BBDCP565-10']
+  parents:
+  - 53548
+2326395:
+  aliases: ['Aedes sp. BBDCP566-10']
+  parents:
+  - 53548
+2326396:
+  aliases: ['Aedes sp. BBDCP567-10']
+  parents:
+  - 53548
+2326397:
+  aliases: ['Aedes sp. BBDCP568-10']
+  parents:
+  - 53548
+2326398:
+  aliases: ['Aedes sp. BBDCP578-10']
+  parents:
+  - 53548
+2326399:
+  aliases: ['Aedes sp. BBDCP584-10']
+  parents:
+  - 53548
+2326400:
+  aliases: ['Aedes sp. BBDCP587-10']
+  parents:
+  - 53548
+2326401:
+  aliases: ['Aedes sp. BBDCP588-10']
+  parents:
+  - 53548
+2326402:
+  aliases: ['Aedes sp. BBDCP597-10']
+  parents:
+  - 53548
+2326403:
+  aliases: ['Aedes sp. BBDCP603-10']
+  parents:
+  - 53548
+2314915:
+  aliases: ['Aedes sp. BIOUG01408-B05']
+  parents:
+  - 53548
+2314990:
+  aliases: ['Aedes sp. BIOUG01408-D12']
+  parents:
+  - 53548
+2314891:
+  aliases: ['Aedes sp. BIOUG01475-H07']
+  parents:
+  - 53548
+2206921:
+  aliases: ['Aedes sp. BIOUG03120-A05']
+  parents:
+  - 53548
+2206922:
+  aliases: ['Aedes sp. BIOUG03120-C06']
+  parents:
+  - 53548
+2206923:
+  aliases: ['Aedes sp. BIOUG06197-H09']
+  parents:
+  - 53548
+2206924:
+  aliases: ['Aedes sp. BIOUG06197-H11']
+  parents:
+  - 53548
+2206925:
+  aliases: ['Aedes sp. BIOUG06330-D06']
+  parents:
+  - 53548
+2206926:
+  aliases: ['Aedes sp. BIOUG06334-H02']
+  parents:
+  - 53548
+2206927:
+  aliases: ['Aedes sp. BIOUG08455-C11']
+  parents:
+  - 53548
+2206928:
+  aliases: ['Aedes sp. BIOUG08614-H02']
+  parents:
+  - 53548
+2206929:
+  aliases: ['Aedes sp. BIOUG11231-H06']
+  parents:
+  - 53548
+2557251:
+  aliases: ['Aedes sp. BIOUG11377-C03']
+  parents:
+  - 53548
+2557252:
+  aliases: ['Aedes sp. BIOUG11377-D10']
+  parents:
+  - 53548
+2206930:
+  aliases: ['Aedes sp. BIOUG11989-C10']
+  parents:
+  - 53548
+2206931:
+  aliases: ['Aedes sp. BIOUG14847-C09']
+  parents:
+  - 53548
+2206932:
+  aliases: ['Aedes sp. BIOUG14847-C11']
+  parents:
+  - 53548
+2206933:
+  aliases: ['Aedes sp. BIOUG14847-C12']
+  parents:
+  - 53548
+2206934:
+  aliases: ['Aedes sp. BIOUG14847-D01']
+  parents:
+  - 53548
+2206935:
+  aliases: ['Aedes sp. BIOUG14847-D02']
+  parents:
+  - 53548
+2206936:
+  aliases: ['Aedes sp. BIOUG14847-D09']
+  parents:
+  - 53548
+2206937:
+  aliases: ['Aedes sp. BIOUG14847-D10']
+  parents:
+  - 53548
+2206938:
+  aliases: ['Aedes sp. BIOUG14847-D11']
+  parents:
+  - 53548
+2206939:
+  aliases: ['Aedes sp. BIOUG14847-D12']
+  parents:
+  - 53548
+2206940:
+  aliases: ['Aedes sp. BIOUG14847-E02']
+  parents:
+  - 53548
+2206941:
+  aliases: ['Aedes sp. BIOUG14848-G02']
+  parents:
+  - 53548
+2206942:
+  aliases: ['Aedes sp. BIOUG14848-G06']
+  parents:
+  - 53548
+2206943:
+  aliases: ['Aedes sp. BIOUG14848-G10']
+  parents:
+  - 53548
+2206944:
+  aliases: ['Aedes sp. BIOUG14848-G11']
+  parents:
+  - 53548
+2206945:
+  aliases: ['Aedes sp. BIOUG14917-C05']
+  parents:
+  - 53548
+2206946:
+  aliases: ['Aedes sp. BIOUG14917-C06']
+  parents:
+  - 53548
+2206947:
+  aliases: ['Aedes sp. BIOUG14917-C07']
+  parents:
+  - 53548
+2206948:
+  aliases: ['Aedes sp. BIOUG14917-C10']
+  parents:
+  - 53548
+2206949:
+  aliases: ['Aedes sp. BIOUG14917-D01']
+  parents:
+  - 53548
+2206950:
+  aliases: ['Aedes sp. BIOUG14917-D03']
+  parents:
+  - 53548
+2206951:
+  aliases: ['Aedes sp. BIOUG14917-D04']
+  parents:
+  - 53548
+2206952:
+  aliases: ['Aedes sp. BIOUG14917-D05']
+  parents:
+  - 53548
+2206953:
+  aliases: ['Aedes sp. BIOUG14917-D06']
+  parents:
+  - 53548
+2206954:
+  aliases: ['Aedes sp. BIOUG14917-D07']
+  parents:
+  - 53548
+2206955:
+  aliases: ['Aedes sp. BIOUG15689-F04']
+  parents:
+  - 53548
+2206956:
+  aliases: ['Aedes sp. BIOUG15986-E12']
+  parents:
+  - 53548
+2206957:
+  aliases: ['Aedes sp. BIOUG15989-A02']
+  parents:
+  - 53548
+2206958:
+  aliases: ['Aedes sp. BIOUG16992-G12']
+  parents:
+  - 53548
+2206959:
+  aliases: ['Aedes sp. BIOUG17185-D06']
+  parents:
+  - 53548
+2206960:
+  aliases: ['Aedes sp. BIOUG17326-H10']
+  parents:
+  - 53548
+2206961:
+  aliases: ['Aedes sp. BIOUG17581-B12']
+  parents:
+  - 53548
+2206962:
+  aliases: ['Aedes sp. BIOUG17655-G11']
+  parents:
+  - 53548
+2206963:
+  aliases: ['Aedes sp. BIOUG17774-F01']
+  parents:
+  - 53548
+2557253:
+  aliases: ['Aedes sp. BIOUG17782-E07']
+  parents:
+  - 53548
+2206964:
+  aliases: ['Aedes sp. BIOUG18930-B01']
+  parents:
+  - 53548
+2206965:
+  aliases: ['Aedes sp. BIOUG18930-C07']
+  parents:
+  - 53548
+2206966:
+  aliases: ['Aedes sp. BIOUG18930-C09']
+  parents:
+  - 53548
+2206967:
+  aliases: ['Aedes sp. BIOUG18930-E05']
+  parents:
+  - 53548
+2206968:
+  aliases: ['Aedes sp. BIOUG18930-E06']
+  parents:
+  - 53548
+2206969:
+  aliases: ['Aedes sp. BIOUG19675-E04']
+  parents:
+  - 53548
+2206970:
+  aliases: ['Aedes sp. BIOUG19689-A04']
+  parents:
+  - 53548
+2206971:
+  aliases: ['Aedes sp. BIOUG20086-G12']
+  parents:
+  - 53548
+2206972:
+  aliases: ['Aedes sp. BIOUG20086-H01']
+  parents:
+  - 53548
+2206973:
+  aliases: ['Aedes sp. BIOUG20086-H05']
+  parents:
+  - 53548
+2206974:
+  aliases: ['Aedes sp. BIOUG20086-H09']
+  parents:
+  - 53548
+2206975:
+  aliases: ['Aedes sp. BIOUG20257-C10']
+  parents:
+  - 53548
+2206976:
+  aliases: ['Aedes sp. BIOUG20323-A05']
+  parents:
+  - 53548
+2206977:
+  aliases: ['Aedes sp. BIOUG20323-A06']
+  parents:
+  - 53548
+2206978:
+  aliases: ['Aedes sp. BIOUG20323-A07']
+  parents:
+  - 53548
+2206979:
+  aliases: ['Aedes sp. BIOUG20323-A11']
+  parents:
+  - 53548
+2206980:
+  aliases: ['Aedes sp. BIOUG20494-D02']
+  parents:
+  - 53548
+2206981:
+  aliases: ['Aedes sp. BIOUG20494-F03']
+  parents:
+  - 53548
+2206982:
+  aliases: ['Aedes sp. BIOUG20506-B02']
+  parents:
+  - 53548
+2206983:
+  aliases: ['Aedes sp. BIOUG20506-D11']
+  parents:
+  - 53548
+2206984:
+  aliases: ['Aedes sp. BIOUG20509-E11']
+  parents:
+  - 53548
+2206985:
+  aliases: ['Aedes sp. BIOUG20509-F05']
+  parents:
+  - 53548
+2206986:
+  aliases: ['Aedes sp. BIOUG20510-A05']
+  parents:
+  - 53548
+2206987:
+  aliases: ['Aedes sp. BIOUG20512-F07']
+  parents:
+  - 53548
+2206988:
+  aliases: ['Aedes sp. BIOUG20513-C07']
+  parents:
+  - 53548
+2206989:
+  aliases: ['Aedes sp. BIOUG20532-A07']
+  parents:
+  - 53548
+2206990:
+  aliases: ['Aedes sp. BIOUG20533-A12']
+  parents:
+  - 53548
+2206991:
+  aliases: ['Aedes sp. BIOUG20533-G05']
+  parents:
+  - 53548
+2206992:
+  aliases: ['Aedes sp. BIOUG20540-A02']
+  parents:
+  - 53548
+2206993:
+  aliases: ['Aedes sp. BIOUG20540-D11']
+  parents:
+  - 53548
+2206994:
+  aliases: ['Aedes sp. BIOUG20540-D12']
+  parents:
+  - 53548
+2206995:
+  aliases: ['Aedes sp. BIOUG20628-H09']
+  parents:
+  - 53548
+2206996:
+  aliases: ['Aedes sp. BIOUG20666-F05']
+  parents:
+  - 53548
+2206997:
+  aliases: ['Aedes sp. BIOUG20666-F06']
+  parents:
+  - 53548
+2206998:
+  aliases: ['Aedes sp. BIOUG20728-A04']
+  parents:
+  - 53548
+2206999:
+  aliases: ['Aedes sp. BIOUG20732-H08']
+  parents:
+  - 53548
+2207000:
+  aliases: ['Aedes sp. BIOUG20763-C01']
+  parents:
+  - 53548
+2207001:
+  aliases: ['Aedes sp. BIOUG20768-H05']
+  parents:
+  - 53548
+2207002:
+  aliases: ['Aedes sp. BIOUG20769-E12']
+  parents:
+  - 53548
+2207003:
+  aliases: ['Aedes sp. BIOUG20771-H10']
+  parents:
+  - 53548
+2207004:
+  aliases: ['Aedes sp. BIOUG20798-C10']
+  parents:
+  - 53548
+2207005:
+  aliases: ['Aedes sp. BIOUG20798-D03']
+  parents:
+  - 53548
+2207006:
+  aliases: ['Aedes sp. BIOUG20798-D12']
+  parents:
+  - 53548
+2207007:
+  aliases: ['Aedes sp. BIOUG20810-C02']
+  parents:
+  - 53548
+2207008:
+  aliases: ['Aedes sp. BIOUG20812-E07']
+  parents:
+  - 53548
+2207009:
+  aliases: ['Aedes sp. BIOUG20842-F04']
+  parents:
+  - 53548
+2207010:
+  aliases: ['Aedes sp. BIOUG20867-F11']
+  parents:
+  - 53548
+2207011:
+  aliases: ['Aedes sp. BIOUG20935-D03']
+  parents:
+  - 53548
+2207012:
+  aliases: ['Aedes sp. BIOUG21104-D11']
+  parents:
+  - 53548
+2207013:
+  aliases: ['Aedes sp. BIOUG21162-C03']
+  parents:
+  - 53548
+2207014:
+  aliases: ['Aedes sp. BIOUG21404-A05']
+  parents:
+  - 53548
+2207015:
+  aliases: ['Aedes sp. BIOUG21450-A09']
+  parents:
+  - 53548
+2207016:
+  aliases: ['Aedes sp. BIOUG21513-F03']
+  parents:
+  - 53548
+2207017:
+  aliases: ['Aedes sp. BIOUG21637-D04']
+  parents:
+  - 53548
+2207018:
+  aliases: ['Aedes sp. BIOUG21637-G06']
+  parents:
+  - 53548
+2314932:
+  aliases: ['Aedes sp. BIOUG21924-E02']
+  parents:
+  - 53548
+2314995:
+  aliases: ['Aedes sp. BIOUG22016-E06']
+  parents:
+  - 53548
+2314890:
+  aliases: ['Aedes sp. BIOUG22112-B02']
+  parents:
+  - 53548
+2314878:
+  aliases: ['Aedes sp. BIOUG22112-B11']
+  parents:
+  - 53548
+2314899:
+  aliases: ['Aedes sp. BIOUG22112-C05']
+  parents:
+  - 53548
+2314993:
+  aliases: ['Aedes sp. BIOUG22112-D01']
+  parents:
+  - 53548
+2314923:
+  aliases: ['Aedes sp. BIOUG22112-F06']
+  parents:
+  - 53548
+2314992:
+  aliases: ['Aedes sp. BIOUG22112-G01']
+  parents:
+  - 53548
+2314882:
+  aliases: ['Aedes sp. BIOUG22116-A04']
+  parents:
+  - 53548
+2314986:
+  aliases: ['Aedes sp. BIOUG22116-A12']
+  parents:
+  - 53548
+2314908:
+  aliases: ['Aedes sp. BIOUG22116-B01']
+  parents:
+  - 53548
+2314920:
+  aliases: ['Aedes sp. BIOUG22116-D11']
+  parents:
+  - 53548
+2314953:
+  aliases: ['Aedes sp. BIOUG22116-E06']
+  parents:
+  - 53548
+2314981:
+  aliases: ['Aedes sp. BIOUG22116-E12']
+  parents:
+  - 53548
+2314938:
+  aliases: ['Aedes sp. BIOUG22116-F05']
+  parents:
+  - 53548
+2314904:
+  aliases: ['Aedes sp. BIOUG22116-H03']
+  parents:
+  - 53548
+2314954:
+  aliases: ['Aedes sp. BIOUG22117-A09']
+  parents:
+  - 53548
+2314918:
+  aliases: ['Aedes sp. BIOUG22117-A11']
+  parents:
+  - 53548
+2314974:
+  aliases: ['Aedes sp. BIOUG22117-C04']
+  parents:
+  - 53548
+2314897:
+  aliases: ['Aedes sp. BIOUG22117-C06']
+  parents:
+  - 53548
+2314944:
+  aliases: ['Aedes sp. BIOUG22117-F02']
+  parents:
+  - 53548
+2314927:
+  aliases: ['Aedes sp. BIOUG22117-G10']
+  parents:
+  - 53548
+2314926:
+  aliases: ['Aedes sp. BIOUG22117-H04']
+  parents:
+  - 53548
+2314909:
+  aliases: ['Aedes sp. BIOUG22119-A02']
+  parents:
+  - 53548
+2314895:
+  aliases: ['Aedes sp. BIOUG22119-A06']
+  parents:
+  - 53548
+2314901:
+  aliases: ['Aedes sp. BIOUG22119-A07']
+  parents:
+  - 53548
+2314872:
+  aliases: ['Aedes sp. BIOUG22119-C05']
+  parents:
+  - 53548
+2314911:
+  aliases: ['Aedes sp. BIOUG22119-D05']
+  parents:
+  - 53548
+2314955:
+  aliases: ['Aedes sp. BIOUG22119-G02']
+  parents:
+  - 53548
+2314921:
+  aliases: ['Aedes sp. BIOUG22119-G04']
+  parents:
+  - 53548
+2314984:
+  aliases: ['Aedes sp. BIOUG22119-H03']
+  parents:
+  - 53548
+2314913:
+  aliases: ['Aedes sp. BIOUG22119-H11']
+  parents:
+  - 53548
+2314903:
+  aliases: ['Aedes sp. BIOUG22283-D12']
+  parents:
+  - 53548
+2314874:
+  aliases: ['Aedes sp. BIOUG22386-A01']
+  parents:
+  - 53548
+2314869:
+  aliases: ['Aedes sp. BIOUG22386-A08']
+  parents:
+  - 53548
+2314893:
+  aliases: ['Aedes sp. BIOUG22386-A10']
+  parents:
+  - 53548
+2314951:
+  aliases: ['Aedes sp. BIOUG22386-B07']
+  parents:
+  - 53548
+2314967:
+  aliases: ['Aedes sp. BIOUG22386-C03']
+  parents:
+  - 53548
+2314945:
+  aliases: ['Aedes sp. BIOUG22386-C09']
+  parents:
+  - 53548
+2314979:
+  aliases: ['Aedes sp. BIOUG22386-D03']
+  parents:
+  - 53548
+2314916:
+  aliases: ['Aedes sp. BIOUG22432-C12']
+  parents:
+  - 53548
+2314902:
+  aliases: ['Aedes sp. BIOUG22432-D09']
+  parents:
+  - 53548
+2314933:
+  aliases: ['Aedes sp. BIOUG22432-D10']
+  parents:
+  - 53548
+2314870:
+  aliases: ['Aedes sp. BIOUG22432-E04']
+  parents:
+  - 53548
+2314985:
+  aliases: ['Aedes sp. BIOUG22432-E07']
+  parents:
+  - 53548
+2314896:
+  aliases: ['Aedes sp. BIOUG22432-E12']
+  parents:
+  - 53548
+2314940:
+  aliases: ['Aedes sp. BIOUG22432-H03']
+  parents:
+  - 53548
+2314930:
+  aliases: ['Aedes sp. BIOUG22438-D08']
+  parents:
+  - 53548
+2314867:
+  aliases: ['Aedes sp. BIOUG22438-E03']
+  parents:
+  - 53548
+2314887:
+  aliases: ['Aedes sp. BIOUG22438-E06']
+  parents:
+  - 53548
+2314965:
+  aliases: ['Aedes sp. BIOUG22438-G07']
+  parents:
+  - 53548
+2314905:
+  aliases: ['Aedes sp. BIOUG22440-A12']
+  parents:
+  - 53548
+2314910:
+  aliases: ['Aedes sp. BIOUG22440-C05']
+  parents:
+  - 53548
+2314912:
+  aliases: ['Aedes sp. BIOUG22440-C09']
+  parents:
+  - 53548
+2314983:
+  aliases: ['Aedes sp. BIOUG22440-D03']
+  parents:
+  - 53548
+2314943:
+  aliases: ['Aedes sp. BIOUG22440-E01']
+  parents:
+  - 53548
+2314889:
+  aliases: ['Aedes sp. BIOUG22440-E06']
+  parents:
+  - 53548
+2314956:
+  aliases: ['Aedes sp. BIOUG22440-G12']
+  parents:
+  - 53548
+2314866:
+  aliases: ['Aedes sp. BIOUG22440-H10']
+  parents:
+  - 53548
+2314975:
+  aliases: ['Aedes sp. BIOUG22515-C04']
+  parents:
+  - 53548
+2314977:
+  aliases: ['Aedes sp. BIOUG22515-E03']
+  parents:
+  - 53548
+2314994:
+  aliases: ['Aedes sp. BIOUG22515-E05']
+  parents:
+  - 53548
+2314972:
+  aliases: ['Aedes sp. BIOUG22515-F01']
+  parents:
+  - 53548
+2314976:
+  aliases: ['Aedes sp. BIOUG22515-G05']
+  parents:
+  - 53548
+2314917:
+  aliases: ['Aedes sp. BIOUG22518-A03']
+  parents:
+  - 53548
+2314879:
+  aliases: ['Aedes sp. BIOUG22518-F05']
+  parents:
+  - 53548
+2314888:
+  aliases: ['Aedes sp. BIOUG22518-F11']
+  parents:
+  - 53548
+2314961:
+  aliases: ['Aedes sp. BIOUG22519-A05']
+  parents:
+  - 53548
+2314941:
+  aliases: ['Aedes sp. BIOUG22519-C03']
+  parents:
+  - 53548
+2314883:
+  aliases: ['Aedes sp. BIOUG22519-E09']
+  parents:
+  - 53548
+2314894:
+  aliases: ['Aedes sp. BIOUG22519-G04']
+  parents:
+  - 53548
+2314868:
+  aliases: ['Aedes sp. BIOUG22521-B04']
+  parents:
+  - 53548
+2314924:
+  aliases: ['Aedes sp. BIOUG22521-B08']
+  parents:
+  - 53548
+2314996:
+  aliases: ['Aedes sp. BIOUG22521-B10']
+  parents:
+  - 53548
+2314959:
+  aliases: ['Aedes sp. BIOUG22653-H07']
+  parents:
+  - 53548
+2314971:
+  aliases: ['Aedes sp. BIOUG22653-H10']
+  parents:
+  - 53548
+2314907:
+  aliases: ['Aedes sp. BIOUG22656-E12']
+  parents:
+  - 53548
+2314968:
+  aliases: ['Aedes sp. BIOUG22658-B12']
+  parents:
+  - 53548
+2314973:
+  aliases: ['Aedes sp. BIOUG22658-C07']
+  parents:
+  - 53548
+2314937:
+  aliases: ['Aedes sp. BIOUG22658-C10']
+  parents:
+  - 53548
+2314884:
+  aliases: ['Aedes sp. BIOUG22658-D03']
+  parents:
+  - 53548
+2314877:
+  aliases: ['Aedes sp. BIOUG22658-D10']
+  parents:
+  - 53548
+2314881:
+  aliases: ['Aedes sp. BIOUG22658-F09']
+  parents:
+  - 53548
+2314871:
+  aliases: ['Aedes sp. BIOUG22658-H05']
+  parents:
+  - 53548
+2314898:
+  aliases: ['Aedes sp. BIOUG22660-A02']
+  parents:
+  - 53548
+2314922:
+  aliases: ['Aedes sp. BIOUG22660-A05']
+  parents:
+  - 53548
+2314980:
+  aliases: ['Aedes sp. BIOUG22660-D11']
+  parents:
+  - 53548
+2314885:
+  aliases: ['Aedes sp. BIOUG22660-F12']
+  parents:
+  - 53548
+2314950:
+  aliases: ['Aedes sp. BIOUG22708-B11']
+  parents:
+  - 53548
+2314880:
+  aliases: ['Aedes sp. BIOUG22708-D10']
+  parents:
+  - 53548
+2314942:
+  aliases: ['Aedes sp. BIOUG22708-F10']
+  parents:
+  - 53548
+2314991:
+  aliases: ['Aedes sp. BIOUG22708-G08']
+  parents:
+  - 53548
+2314970:
+  aliases: ['Aedes sp. BIOUG22709-A08']
+  parents:
+  - 53548
+2314966:
+  aliases: ['Aedes sp. BIOUG22709-A11']
+  parents:
+  - 53548
+2314947:
+  aliases: ['Aedes sp. BIOUG22709-B03']
+  parents:
+  - 53548
+2314919:
+  aliases: ['Aedes sp. BIOUG22709-C11']
+  parents:
+  - 53548
+2314929:
+  aliases: ['Aedes sp. BIOUG22709-H09']
+  parents:
+  - 53548
+2314998:
+  aliases: ['Aedes sp. BIOUG22764-D12']
+  parents:
+  - 53548
+2314957:
+  aliases: ['Aedes sp. BIOUG22929-D08']
+  parents:
+  - 53548
+2314876:
+  aliases: ['Aedes sp. BIOUG22938-G09']
+  parents:
+  - 53548
+2314931:
+  aliases: ['Aedes sp. BIOUG22961-E01']
+  parents:
+  - 53548
+2314873:
+  aliases: ['Aedes sp. BIOUG23190-C07']
+  parents:
+  - 53548
+2314906:
+  aliases: ['Aedes sp. BIOUG23198-F10']
+  parents:
+  - 53548
+2314949:
+  aliases: ['Aedes sp. BIOUG23204-G07']
+  parents:
+  - 53548
+2314988:
+  aliases: ['Aedes sp. BIOUG23305-A07']
+  parents:
+  - 53548
+2314958:
+  aliases: ['Aedes sp. BIOUG23682-G01']
+  parents:
+  - 53548
+2314875:
+  aliases: ['Aedes sp. BIOUG24298-H09']
+  parents:
+  - 53548
+2314969:
+  aliases: ['Aedes sp. BIOUG24511-F11']
+  parents:
+  - 53548
+2314963:
+  aliases: ['Aedes sp. BIOUG24556-C01']
+  parents:
+  - 53548
+2314886:
+  aliases: ['Aedes sp. BIOUG24556-C02']
+  parents:
+  - 53548
+2314934:
+  aliases: ['Aedes sp. BIOUG24556-C03']
+  parents:
+  - 53548
+2207019:
+  aliases: ['Aedes sp. BIOUG24582-F05']
+  parents:
+  - 53548
+2207020:
+  aliases: ['Aedes sp. BIOUG24639-G06']
+  parents:
+  - 53548
+2207021:
+  aliases: ['Aedes sp. BIOUG24722-F10']
+  parents:
+  - 53548
+2207022:
+  aliases: ['Aedes sp. BIOUG24729-H01']
+  parents:
+  - 53548
+2207023:
+  aliases: ['Aedes sp. BIOUG24729-H03']
+  parents:
+  - 53548
+2207024:
+  aliases: ['Aedes sp. BIOUG24729-H05']
+  parents:
+  - 53548
+2207025:
+  aliases: ['Aedes sp. BIOUG24729-H07']
+  parents:
+  - 53548
+2207026:
+  aliases: ['Aedes sp. BIOUG24729-H09']
+  parents:
+  - 53548
+2207027:
+  aliases: ['Aedes sp. BIOUG24729-H10']
+  parents:
+  - 53548
+2314936:
+  aliases: ['Aedes sp. BIOUG25044-D07']
+  parents:
+  - 53548
+2314928:
+  aliases: ['Aedes sp. BIOUG25044-D08']
+  parents:
+  - 53548
+2314900:
+  aliases: ['Aedes sp. BIOUG25044-G02']
+  parents:
+  - 53548
+2314925:
+  aliases: ['Aedes sp. BIOUG25044-G11']
+  parents:
+  - 53548
+2314978:
+  aliases: ['Aedes sp. BIOUG25128-G10']
+  parents:
+  - 53548
+2314946:
+  aliases: ['Aedes sp. BIOUG25294-E08']
+  parents:
+  - 53548
+2207028:
+  aliases: ['Aedes sp. BIOUG25382-C03']
+  parents:
+  - 53548
+2314997:
+  aliases: ['Aedes sp. BIOUG25546-E02']
+  parents:
+  - 53548
+2314964:
+  aliases: ['Aedes sp. BIOUG25708-A11']
+  parents:
+  - 53548
+2207029:
+  aliases: ['Aedes sp. BIOUG26184-D09']
+  parents:
+  - 53548
+2207030:
+  aliases: ['Aedes sp. BIOUG26185-A02']
+  parents:
+  - 53548
+2207031:
+  aliases: ['Aedes sp. BIOUG26185-A03']
+  parents:
+  - 53548
+2207032:
+  aliases: ['Aedes sp. BIOUG26185-A04']
+  parents:
+  - 53548
+2207033:
+  aliases: ['Aedes sp. BIOUG26185-A05']
+  parents:
+  - 53548
+2207034:
+  aliases: ['Aedes sp. BIOUG26185-A10']
+  parents:
+  - 53548
+2207035:
+  aliases: ['Aedes sp. BIOUG26185-B02']
+  parents:
+  - 53548
+2207036:
+  aliases: ['Aedes sp. BIOUG26185-B07']
+  parents:
+  - 53548
+2207037:
+  aliases: ['Aedes sp. BIOUG26185-B09']
+  parents:
+  - 53548
+2207038:
+  aliases: ['Aedes sp. BIOUG26185-B11']
+  parents:
+  - 53548
+2207039:
+  aliases: ['Aedes sp. BIOUG26185-C01']
+  parents:
+  - 53548
+2207040:
+  aliases: ['Aedes sp. BIOUG26185-C03']
+  parents:
+  - 53548
+2207041:
+  aliases: ['Aedes sp. BIOUG26185-D09']
+  parents:
+  - 53548
+2207042:
+  aliases: ['Aedes sp. BIOUG26185-D11']
+  parents:
+  - 53548
+2207043:
+  aliases: ['Aedes sp. BIOUG26185-D12']
+  parents:
+  - 53548
+2207044:
+  aliases: ['Aedes sp. BIOUG26185-E01']
+  parents:
+  - 53548
+2207045:
+  aliases: ['Aedes sp. BIOUG26185-E02']
+  parents:
+  - 53548
+2207046:
+  aliases: ['Aedes sp. BIOUG26185-E03']
+  parents:
+  - 53548
+2207047:
+  aliases: ['Aedes sp. BIOUG26185-E04']
+  parents:
+  - 53548
+2207048:
+  aliases: ['Aedes sp. BIOUG26185-E10']
+  parents:
+  - 53548
+2207049:
+  aliases: ['Aedes sp. BIOUG26185-G05']
+  parents:
+  - 53548
+2207050:
+  aliases: ['Aedes sp. BIOUG26185-G06']
+  parents:
+  - 53548
+2207051:
+  aliases: ['Aedes sp. BIOUG26185-G10']
+  parents:
+  - 53548
+2207052:
+  aliases: ['Aedes sp. BIOUG26185-H01']
+  parents:
+  - 53548
+2207053:
+  aliases: ['Aedes sp. BIOUG26185-H02']
+  parents:
+  - 53548
+2207054:
+  aliases: ['Aedes sp. BIOUG26185-H03']
+  parents:
+  - 53548
+2207055:
+  aliases: ['Aedes sp. BIOUG26185-H05']
+  parents:
+  - 53548
+2207056:
+  aliases: ['Aedes sp. BIOUG26185-H09']
+  parents:
+  - 53548
+2207057:
+  aliases: ['Aedes sp. BIOUG26185-H11']
+  parents:
+  - 53548
+2207058:
+  aliases: ['Aedes sp. BIOUG26186-B10']
+  parents:
+  - 53548
+2207059:
+  aliases: ['Aedes sp. BIOUG26190-A01']
+  parents:
+  - 53548
+2207060:
+  aliases: ['Aedes sp. BIOUG26190-A02']
+  parents:
+  - 53548
+2207061:
+  aliases: ['Aedes sp. BIOUG26190-A03']
+  parents:
+  - 53548
+2207062:
+  aliases: ['Aedes sp. BIOUG26190-A04']
+  parents:
+  - 53548
+2207063:
+  aliases: ['Aedes sp. BIOUG26190-A05']
+  parents:
+  - 53548
+2207064:
+  aliases: ['Aedes sp. BIOUG26190-A07']
+  parents:
+  - 53548
+2207065:
+  aliases: ['Aedes sp. BIOUG26190-E01']
+  parents:
+  - 53548
+2207066:
+  aliases: ['Aedes sp. BIOUG26190-E09']
+  parents:
+  - 53548
+2207067:
+  aliases: ['Aedes sp. BIOUG26261-A01']
+  parents:
+  - 53548
+2207068:
+  aliases: ['Aedes sp. BIOUG26261-B10']
+  parents:
+  - 53548
+2207069:
+  aliases: ['Aedes sp. BIOUG26264-C05']
+  parents:
+  - 53548
+2207070:
+  aliases: ['Aedes sp. BIOUG26264-C06']
+  parents:
+  - 53548
+2207071:
+  aliases: ['Aedes sp. BIOUG26622-H08']
+  parents:
+  - 53548
+2207072:
+  aliases: ['Aedes sp. BIOUG26623-A05']
+  parents:
+  - 53548
+2207073:
+  aliases: ['Aedes sp. BIOUG26660-D11']
+  parents:
+  - 53548
+2207074:
+  aliases: ['Aedes sp. BIOUG26660-F01']
+  parents:
+  - 53548
+2207075:
+  aliases: ['Aedes sp. BIOUG26660-H03']
+  parents:
+  - 53548
+2207076:
+  aliases: ['Aedes sp. BIOUG26660-H06']
+  parents:
+  - 53548
+2207077:
+  aliases: ['Aedes sp. BIOUG26664-A08']
+  parents:
+  - 53548
+2207078:
+  aliases: ['Aedes sp. BIOUG26749-G02']
+  parents:
+  - 53548
+2207079:
+  aliases: ['Aedes sp. BIOUG26776-A03']
+  parents:
+  - 53548
+2207080:
+  aliases: ['Aedes sp. BIOUG26781-C10']
+  parents:
+  - 53548
+2207081:
+  aliases: ['Aedes sp. BIOUG26781-D07']
+  parents:
+  - 53548
+2207082:
+  aliases: ['Aedes sp. BIOUG26781-E12']
+  parents:
+  - 53548
+2207083:
+  aliases: ['Aedes sp. BIOUG26781-G06']
+  parents:
+  - 53548
+2207084:
+  aliases: ['Aedes sp. BIOUG26782-A07']
+  parents:
+  - 53548
+2207085:
+  aliases: ['Aedes sp. BIOUG26782-C01']
+  parents:
+  - 53548
+2207086:
+  aliases: ['Aedes sp. BIOUG26782-C04']
+  parents:
+  - 53548
+2207087:
+  aliases: ['Aedes sp. BIOUG26782-C07']
+  parents:
+  - 53548
+2207088:
+  aliases: ['Aedes sp. BIOUG26782-G03']
+  parents:
+  - 53548
+2207089:
+  aliases: ['Aedes sp. BIOUG26782-G10']
+  parents:
+  - 53548
+2207090:
+  aliases: ['Aedes sp. BIOUG26789-C02']
+  parents:
+  - 53548
+2207091:
+  aliases: ['Aedes sp. BIOUG26792-F04']
+  parents:
+  - 53548
+2207092:
+  aliases: ['Aedes sp. BIOUG26807-B01']
+  parents:
+  - 53548
+2207093:
+  aliases: ['Aedes sp. BIOUG26810-C02']
+  parents:
+  - 53548
+2207094:
+  aliases: ['Aedes sp. BIOUG26832-E05']
+  parents:
+  - 53548
+2207095:
+  aliases: ['Aedes sp. BIOUG26948-C09']
+  parents:
+  - 53548
+2207096:
+  aliases: ['Aedes sp. BIOUG26948-G05']
+  parents:
+  - 53548
+2207097:
+  aliases: ['Aedes sp. BIOUG26981-F09']
+  parents:
+  - 53548
+2207098:
+  aliases: ['Aedes sp. BIOUG26982-H03']
+  parents:
+  - 53548
+2207099:
+  aliases: ['Aedes sp. BIOUG26983-B06']
+  parents:
+  - 53548
+2207100:
+  aliases: ['Aedes sp. BIOUG26984-H10']
+  parents:
+  - 53548
+2207101:
+  aliases: ['Aedes sp. BIOUG26987-C08']
+  parents:
+  - 53548
+2207102:
+  aliases: ['Aedes sp. BIOUG26988-A03']
+  parents:
+  - 53548
+2207103:
+  aliases: ['Aedes sp. BIOUG27050-C08']
+  parents:
+  - 53548
+2207104:
+  aliases: ['Aedes sp. BIOUG27066-A12']
+  parents:
+  - 53548
+2207105:
+  aliases: ['Aedes sp. BIOUG27066-E12']
+  parents:
+  - 53548
+2207106:
+  aliases: ['Aedes sp. BIOUG27067-A11']
+  parents:
+  - 53548
+2207107:
+  aliases: ['Aedes sp. BIOUG27068-H07']
+  parents:
+  - 53548
+2207108:
+  aliases: ['Aedes sp. BIOUG27079-A10']
+  parents:
+  - 53548
+2207109:
+  aliases: ['Aedes sp. BIOUG27079-F01']
+  parents:
+  - 53548
+2207110:
+  aliases: ['Aedes sp. BIOUG27079-F08']
+  parents:
+  - 53548
+2207111:
+  aliases: ['Aedes sp. BIOUG27093-G03']
+  parents:
+  - 53548
+2207112:
+  aliases: ['Aedes sp. BIOUG27097-E10']
+  parents:
+  - 53548
+2207113:
+  aliases: ['Aedes sp. BIOUG27097-G10']
+  parents:
+  - 53548
+2207114:
+  aliases: ['Aedes sp. BIOUG27097-H09']
+  parents:
+  - 53548
+2207115:
+  aliases: ['Aedes sp. BIOUG27101-D02']
+  parents:
+  - 53548
+2207116:
+  aliases: ['Aedes sp. BIOUG27102-B05']
+  parents:
+  - 53548
+2207117:
+  aliases: ['Aedes sp. BIOUG27104-A07']
+  parents:
+  - 53548
+2207118:
+  aliases: ['Aedes sp. BIOUG27104-A10']
+  parents:
+  - 53548
+2207119:
+  aliases: ['Aedes sp. BIOUG27104-B10']
+  parents:
+  - 53548
+2207120:
+  aliases: ['Aedes sp. BIOUG27104-C04']
+  parents:
+  - 53548
+2207121:
+  aliases: ['Aedes sp. BIOUG27104-D03']
+  parents:
+  - 53548
+2207122:
+  aliases: ['Aedes sp. BIOUG27104-D09']
+  parents:
+  - 53548
+2207123:
+  aliases: ['Aedes sp. BIOUG27104-F02']
+  parents:
+  - 53548
+2207124:
+  aliases: ['Aedes sp. BIOUG27104-G10']
+  parents:
+  - 53548
+2207125:
+  aliases: ['Aedes sp. BIOUG27105-A10']
+  parents:
+  - 53548
+2207126:
+  aliases: ['Aedes sp. BIOUG27105-A11']
+  parents:
+  - 53548
+2207127:
+  aliases: ['Aedes sp. BIOUG27105-B01']
+  parents:
+  - 53548
+2207128:
+  aliases: ['Aedes sp. BIOUG27105-B06']
+  parents:
+  - 53548
+2207129:
+  aliases: ['Aedes sp. BIOUG27105-D03']
+  parents:
+  - 53548
+2207130:
+  aliases: ['Aedes sp. BIOUG27157-H11']
+  parents:
+  - 53548
+2207131:
+  aliases: ['Aedes sp. BIOUG27158-D07']
+  parents:
+  - 53548
+2207132:
+  aliases: ['Aedes sp. BIOUG27173-D12']
+  parents:
+  - 53548
+2207133:
+  aliases: ['Aedes sp. BIOUG27226-D10']
+  parents:
+  - 53548
+2207134:
+  aliases: ['Aedes sp. BIOUG27355-D10']
+  parents:
+  - 53548
+2207135:
+  aliases: ['Aedes sp. BIOUG27357-F02']
+  parents:
+  - 53548
+2207136:
+  aliases: ['Aedes sp. BIOUG27360-A07']
+  parents:
+  - 53548
+2207137:
+  aliases: ['Aedes sp. BIOUG27360-B08']
+  parents:
+  - 53548
+2207138:
+  aliases: ['Aedes sp. BIOUG27360-C07']
+  parents:
+  - 53548
+2207139:
+  aliases: ['Aedes sp. BIOUG27362-H01']
+  parents:
+  - 53548
+2207140:
+  aliases: ['Aedes sp. BIOUG27391-E04']
+  parents:
+  - 53548
+2207141:
+  aliases: ['Aedes sp. BIOUG27454-G03']
+  parents:
+  - 53548
+2207142:
+  aliases: ['Aedes sp. BIOUG27473-F08']
+  parents:
+  - 53548
+2207143:
+  aliases: ['Aedes sp. BIOUG27485-D03']
+  parents:
+  - 53548
+2207144:
+  aliases: ['Aedes sp. BIOUG27485-E11']
+  parents:
+  - 53548
+2207145:
+  aliases: ['Aedes sp. BIOUG27485-G07']
+  parents:
+  - 53548
+2207146:
+  aliases: ['Aedes sp. BIOUG27486-G12']
+  parents:
+  - 53548
+2207147:
+  aliases: ['Aedes sp. BIOUG27488-F10']
+  parents:
+  - 53548
+2207148:
+  aliases: ['Aedes sp. BIOUG27593-H01']
+  parents:
+  - 53548
+1887054:
+  aliases: ['Aedes sp. BOLD-2016']
+  parents:
+  - 53548
+1052690:
+  aliases: ['Aedes sp. BOLD:AAA3748']
+  parents:
+  - 53548
+1214559:
+  aliases: ['Aedes sp. BOLD:AAA3750']
+  parents:
+  - 53548
+1052688:
+  aliases: ['Aedes sp. BOLD:AAA3751']
+  parents:
+  - 53548
+1695049:
+  aliases: ['Aedes sp. BOLD:AAA7067']
+  parents:
+  - 53548
+1052687:
+  aliases: ['Aedes sp. BOLD:AAB1098']
+  parents:
+  - 53548
+1823607:
+  aliases: ['Aedes sp. BOLD:AAB5696']
+  parents:
+  - 53548
+1754994:
+  aliases: ['Aedes sp. BOLD:AAC1238']
+  parents:
+  - 53548
+1725037:
+  aliases: ['Aedes sp. BOLD:AAC5210']
+  parents:
+  - 53548
+1214558:
+  aliases: ['Aedes sp. BOLD:AAC9062']
+  parents:
+  - 53548
+1725038:
+  aliases: ['Aedes sp. BOLD:AAC9476']
+  parents:
+  - 53548
+1725039:
+  aliases: ['Aedes sp. BOLD:AAC9486']
+  parents:
+  - 53548
+1823608:
+  aliases: ['Aedes sp. BOLD:AAD4355']
+  parents:
+  - 53548
+1081110:
+  aliases: ['Aedes sp. BOLD:AAF2904']
+  parents:
+  - 53548
+1214560:
+  aliases: ['Aedes sp. BOLD:AAT9839']
+  parents:
+  - 53548
+2657465:
+  aliases: ['Aedes sp. BOLD:AAV4154']
+  parents:
+  - 53548
+1695050:
+  aliases: ['Aedes sp. BOLD:ABY6840']
+  parents:
+  - 53548
+1754995:
+  aliases: ['Aedes sp. BOLD:ACE3097']
+  parents:
+  - 53548
+1665014:
+  aliases: ['Aedes sp. BOLD:ACG8854']
+  parents:
+  - 53548
+1829911:
+  aliases: ['Aedes sp. BOLD:ACI4651']
+  parents:
+  - 53548
+1578835:
+  aliases: ['Aedes sp. BTLHVDV-2014']
+  parents:
+  - 53548
+2326404:
+  aliases: ['Aedes sp. DARC222-10']
+  parents:
+  - 53548
+2326405:
+  aliases: ['Aedes sp. DARC225-10']
+  parents:
+  - 53548
+2326406:
+  aliases: ['Aedes sp. DARC228-10']
+  parents:
+  - 53548
+2326407:
+  aliases: ['Aedes sp. DARC233-10']
+  parents:
+  - 53548
+2326408:
+  aliases: ['Aedes sp. DARC257-11']
+  parents:
+  - 53548
+681643:
+  aliases: ['Aedes sp. EH-2009']
+  parents:
+  - 53548
+1907893:
+  aliases: ['Aedes sp. GM-2016']
+  parents:
+  - 53548
+2596824:
+  aliases: ['Aedes sp. GW76']
+  parents:
+  - 53548
+2314914:
+  aliases: ['Aedes sp. HC-12-01']
+  parents:
+  - 53548
+2314935:
+  aliases: ['Aedes sp. HC-15-04']
+  parents:
+  - 53548
+2326409:
+  aliases: ['Aedes sp. JSDIP336-10']
+  parents:
+  - 53548
+2326410:
+  aliases: ['Aedes sp. JSDIP444-10']
+  parents:
+  - 53548
+2326411:
+  aliases: ['Aedes sp. JSDIP620-10']
+  parents:
+  - 53548
+2326412:
+  aliases: ['Aedes sp. JSDIP740-10']
+  parents:
+  - 53548
+2326413:
+  aliases: ['Aedes sp. JSDIP917-10']
+  parents:
+  - 53548
+2326414:
+  aliases: ['Aedes sp. JWDCA312-10']
+  parents:
+  - 53548
+2326415:
+  aliases: ['Aedes sp. JWDCA317-10']
+  parents:
+  - 53548
+2326416:
+  aliases: ['Aedes sp. JWDCB144-10']
+  parents:
+  - 53548
+2326417:
+  aliases: ['Aedes sp. JWDCB148-10']
+  parents:
+  - 53548
+2326418:
+  aliases: ['Aedes sp. JWDCC056-10']
+  parents:
+  - 53548
+2326419:
+  aliases: ['Aedes sp. JWDCC057-10']
+  parents:
+  - 53548
+2326420:
+  aliases: ['Aedes sp. JWDCC058-10']
+  parents:
+  - 53548
+2326421:
+  aliases: ['Aedes sp. JWDCC070-10']
+  parents:
+  - 53548
+2326422:
+  aliases: ['Aedes sp. JWDCC071-10']
+  parents:
+  - 53548
+2326423:
+  aliases: ['Aedes sp. JWDCC110-10']
+  parents:
+  - 53548
+2326424:
+  aliases: ['Aedes sp. JWDCC111-10']
+  parents:
+  - 53548
+2326425:
+  aliases: ['Aedes sp. JWDCC112-10']
+  parents:
+  - 53548
+2326426:
+  aliases: ['Aedes sp. JWDCC113-10']
+  parents:
+  - 53548
+2326427:
+  aliases: ['Aedes sp. JWDCC133-10']
+  parents:
+  - 53548
+2326428:
+  aliases: ['Aedes sp. JWDCC134-10']
+  parents:
+  - 53548
+2326429:
+  aliases: ['Aedes sp. JWDCC137-10']
+  parents:
+  - 53548
+2326430:
+  aliases: ['Aedes sp. JWDCC179-10']
+  parents:
+  - 53548
+2326431:
+  aliases: ['Aedes sp. JWDCC181-10']
+  parents:
+  - 53548
+2326432:
+  aliases: ['Aedes sp. JWDCC202-10']
+  parents:
+  - 53548
+2326433:
+  aliases: ['Aedes sp. JWDCC224-10']
+  parents:
+  - 53548
+2326434:
+  aliases: ['Aedes sp. JWDCC226-10']
+  parents:
+  - 53548
+2326435:
+  aliases: ['Aedes sp. JWDCC268-10']
+  parents:
+  - 53548
+2326436:
+  aliases: ['Aedes sp. JWDCC271-10']
+  parents:
+  - 53548
+2326437:
+  aliases: ['Aedes sp. JWDCC432-10']
+  parents:
+  - 53548
+2326438:
+  aliases: ['Aedes sp. JWDCC434-10']
+  parents:
+  - 53548
+2326439:
+  aliases: ['Aedes sp. JWDCC435-10']
+  parents:
+  - 53548
+2326440:
+  aliases: ['Aedes sp. JWDCC436-10']
+  parents:
+  - 53548
+2326441:
+  aliases: ['Aedes sp. JWDCC437-10']
+  parents:
+  - 53548
+2326442:
+  aliases: ['Aedes sp. JWDCC444-10']
+  parents:
+  - 53548
+2326443:
+  aliases: ['Aedes sp. JWDCC446-10']
+  parents:
+  - 53548
+2326444:
+  aliases: ['Aedes sp. JWDCC449-10']
+  parents:
+  - 53548
+2326445:
+  aliases: ['Aedes sp. JWDCC453-10']
+  parents:
+  - 53548
+2326446:
+  aliases: ['Aedes sp. JWDCC454-10']
+  parents:
+  - 53548
+2326447:
+  aliases: ['Aedes sp. JWDCC455-10']
+  parents:
+  - 53548
+2326448:
+  aliases: ['Aedes sp. JWDCC456-10']
+  parents:
+  - 53548
+2326449:
+  aliases: ['Aedes sp. JWDCC461-10']
+  parents:
+  - 53548
+2326450:
+  aliases: ['Aedes sp. JWDCC462-10']
+  parents:
+  - 53548
+2326451:
+  aliases: ['Aedes sp. JWDCC463-10']
+  parents:
+  - 53548
+2326452:
+  aliases: ['Aedes sp. JWDCC464-10']
+  parents:
+  - 53548
+2326453:
+  aliases: ['Aedes sp. JWDCC469-10']
+  parents:
+  - 53548
+2326454:
+  aliases: ['Aedes sp. JWDCC471-10']
+  parents:
+  - 53548
+2326455:
+  aliases: ['Aedes sp. JWDCC475-10']
+  parents:
+  - 53548
+2326456:
+  aliases: ['Aedes sp. JWDCC777-10']
+  parents:
+  - 53548
+2326457:
+  aliases: ['Aedes sp. JWDCC778-10']
+  parents:
+  - 53548
+2326458:
+  aliases: ['Aedes sp. JWDCC779-10']
+  parents:
+  - 53548
+2326459:
+  aliases: ['Aedes sp. JWDCC780-10']
+  parents:
+  - 53548
+2326460:
+  aliases: ['Aedes sp. JWDCC878-10']
+  parents:
+  - 53548
+2326461:
+  aliases: ['Aedes sp. JWDCC901-10']
+  parents:
+  - 53548
+2326462:
+  aliases: ['Aedes sp. JWDCD001-10']
+  parents:
+  - 53548
+2326463:
+  aliases: ['Aedes sp. JWDCD097-10']
+  parents:
+  - 53548
+2326464:
+  aliases: ['Aedes sp. JWDCD100-10']
+  parents:
+  - 53548
+2326465:
+  aliases: ['Aedes sp. JWDCD104-10']
+  parents:
+  - 53548
+2326466:
+  aliases: ['Aedes sp. JWDCD106-10']
+  parents:
+  - 53548
+2326467:
+  aliases: ['Aedes sp. JWDCD123-10']
+  parents:
+  - 53548
+2326468:
+  aliases: ['Aedes sp. JWDCD135-10']
+  parents:
+  - 53548
+2326469:
+  aliases: ['Aedes sp. JWDCD177-10']
+  parents:
+  - 53548
+2326470:
+  aliases: ['Aedes sp. JWDCE528-10']
+  parents:
+  - 53548
+2326471:
+  aliases: ['Aedes sp. JWDCE529-10']
+  parents:
+  - 53548
+2326472:
+  aliases: ['Aedes sp. JWDCE530-10']
+  parents:
+  - 53548
+2326473:
+  aliases: ['Aedes sp. JWDCE549-10']
+  parents:
+  - 53548
+2326474:
+  aliases: ['Aedes sp. JWDCE649-10']
+  parents:
+  - 53548
+2326475:
+  aliases: ['Aedes sp. JWDCE650-10']
+  parents:
+  - 53548
+2326476:
+  aliases: ['Aedes sp. JWDCE651-10']
+  parents:
+  - 53548
+2326477:
+  aliases: ['Aedes sp. JWDCE703-10']
+  parents:
+  - 53548
+2326478:
+  aliases: ['Aedes sp. JWDCE781-10']
+  parents:
+  - 53548
+2326479:
+  aliases: ['Aedes sp. JWDCE793-10']
+  parents:
+  - 53548
+2326480:
+  aliases: ['Aedes sp. JWDCE794-10']
+  parents:
+  - 53548
+2326481:
+  aliases: ['Aedes sp. JWDCE795-10']
+  parents:
+  - 53548
+2326482:
+  aliases: ['Aedes sp. JWDCE798-10']
+  parents:
+  - 53548
+2326483:
+  aliases: ['Aedes sp. JWDCE799-10']
+  parents:
+  - 53548
+2326484:
+  aliases: ['Aedes sp. JWDCE800-10']
+  parents:
+  - 53548
+2326485:
+  aliases: ['Aedes sp. JWDCE831-10']
+  parents:
+  - 53548
+2326486:
+  aliases: ['Aedes sp. JWDCE832-10']
+  parents:
+  - 53548
+2326487:
+  aliases: ['Aedes sp. JWDCE851-10']
+  parents:
+  - 53548
+2326488:
+  aliases: ['Aedes sp. JWDCE853-10']
+  parents:
+  - 53548
+2326489:
+  aliases: ['Aedes sp. JWDCE865-10']
+  parents:
+  - 53548
+2326490:
+  aliases: ['Aedes sp. JWDCE866-10']
+  parents:
+  - 53548
+2326491:
+  aliases: ['Aedes sp. JWDCE903-10']
+  parents:
+  - 53548
+2326492:
+  aliases: ['Aedes sp. JWDCE922-10']
+  parents:
+  - 53548
+2326493:
+  aliases: ['Aedes sp. JWDCE923-10']
+  parents:
+  - 53548
+2326494:
+  aliases: ['Aedes sp. JWDCE927-10']
+  parents:
+  - 53548
+2326495:
+  aliases: ['Aedes sp. JWDCE928-10']
+  parents:
+  - 53548
+2326496:
+  aliases: ['Aedes sp. JWDCE929-10']
+  parents:
+  - 53548
+2326497:
+  aliases: ['Aedes sp. JWDCF060-10']
+  parents:
+  - 53548
+2326498:
+  aliases: ['Aedes sp. JWDCF061-10']
+  parents:
+  - 53548
+2326499:
+  aliases: ['Aedes sp. JWDCF062-10']
+  parents:
+  - 53548
+2326500:
+  aliases: ['Aedes sp. JWDCF139-10']
+  parents:
+  - 53548
+2326501:
+  aliases: ['Aedes sp. JWDCF172-10']
+  parents:
+  - 53548
+2326502:
+  aliases: ['Aedes sp. JWDCF335-10']
+  parents:
+  - 53548
+2326503:
+  aliases: ['Aedes sp. JWDCF370-10']
+  parents:
+  - 53548
+2326504:
+  aliases: ['Aedes sp. JWDCF372-10']
+  parents:
+  - 53548
+2326505:
+  aliases: ['Aedes sp. JWDCF380-10']
+  parents:
+  - 53548
+2326506:
+  aliases: ['Aedes sp. JWDCF382-10']
+  parents:
+  - 53548
+2326507:
+  aliases: ['Aedes sp. JWDCF431-10']
+  parents:
+  - 53548
+2326508:
+  aliases: ['Aedes sp. JWDCF443-10']
+  parents:
+  - 53548
+2326509:
+  aliases: ['Aedes sp. JWDCF445-10']
+  parents:
+  - 53548
+2326510:
+  aliases: ['Aedes sp. JWDCF466-10']
+  parents:
+  - 53548
+2326511:
+  aliases: ['Aedes sp. JWDCF487-10']
+  parents:
+  - 53548
+2326512:
+  aliases: ['Aedes sp. JWDCF488-10']
+  parents:
+  - 53548
+2326513:
+  aliases: ['Aedes sp. JWDCF489-10']
+  parents:
+  - 53548
+2326514:
+  aliases: ['Aedes sp. JWDCF491-10']
+  parents:
+  - 53548
+2326515:
+  aliases: ['Aedes sp. JWDCF512-10']
+  parents:
+  - 53548
+2326516:
+  aliases: ['Aedes sp. JWDCF534-10']
+  parents:
+  - 53548
+2326517:
+  aliases: ['Aedes sp. JWDCF536-10']
+  parents:
+  - 53548
+2326518:
+  aliases: ['Aedes sp. JWDCF571-10']
+  parents:
+  - 53548
+2326519:
+  aliases: ['Aedes sp. JWDCF572-10']
+  parents:
+  - 53548
+2326520:
+  aliases: ['Aedes sp. JWDCF583-10']
+  parents:
+  - 53548
+2326521:
+  aliases: ['Aedes sp. JWDCF584-10']
+  parents:
+  - 53548
+2326522:
+  aliases: ['Aedes sp. JWDCF585-10']
+  parents:
+  - 53548
+2326523:
+  aliases: ['Aedes sp. JWDCF602-10']
+  parents:
+  - 53548
+2326524:
+  aliases: ['Aedes sp. JWDCF603-10']
+  parents:
+  - 53548
+2326525:
+  aliases: ['Aedes sp. JWDCF625-10']
+  parents:
+  - 53548
+2326526:
+  aliases: ['Aedes sp. JWDCF626-10']
+  parents:
+  - 53548
+2326527:
+  aliases: ['Aedes sp. JWDCF644-10']
+  parents:
+  - 53548
+2326528:
+  aliases: ['Aedes sp. JWDCF676-10']
+  parents:
+  - 53548
+2326529:
+  aliases: ['Aedes sp. JWDCF678-10']
+  parents:
+  - 53548
+2326530:
+  aliases: ['Aedes sp. JWDCF713-10']
+  parents:
+  - 53548
+2326531:
+  aliases: ['Aedes sp. JWDCG126-10']
+  parents:
+  - 53548
+2326532:
+  aliases: ['Aedes sp. JWDCG210-10']
+  parents:
+  - 53548
+2326533:
+  aliases: ['Aedes sp. JWDCG211-10']
+  parents:
+  - 53548
+2326534:
+  aliases: ['Aedes sp. JWDCG624-10']
+  parents:
+  - 53548
+2326535:
+  aliases: ['Aedes sp. JWDCG626-10']
+  parents:
+  - 53548
+2326536:
+  aliases: ['Aedes sp. JWDCG695-10']
+  parents:
+  - 53548
+2326537:
+  aliases: ['Aedes sp. JWDCH008-10']
+  parents:
+  - 53548
+2326538:
+  aliases: ['Aedes sp. JWDCH047-10']
+  parents:
+  - 53548
+2326539:
+  aliases: ['Aedes sp. JWDCH263-10']
+  parents:
+  - 53548
+2326540:
+  aliases: ['Aedes sp. JWDCH389-10']
+  parents:
+  - 53548
+2326541:
+  aliases: ['Aedes sp. JWDCH390-10']
+  parents:
+  - 53548
+2326542:
+  aliases: ['Aedes sp. JWDCH441-10']
+  parents:
+  - 53548
+2326543:
+  aliases: ['Aedes sp. JWDCH738-10']
+  parents:
+  - 53548
+2326544:
+  aliases: ['Aedes sp. JWDCH815-10']
+  parents:
+  - 53548
+2326545:
+  aliases: ['Aedes sp. JWDCH966-10']
+  parents:
+  - 53548
+2326546:
+  aliases: ['Aedes sp. JWDCH967-10']
+  parents:
+  - 53548
+2326547:
+  aliases: ['Aedes sp. JWDCI048-10']
+  parents:
+  - 53548
+2326548:
+  aliases: ['Aedes sp. JWDCI275-10']
+  parents:
+  - 53548
+2326549:
+  aliases: ['Aedes sp. JWDCI310-10']
+  parents:
+  - 53548
+2326550:
+  aliases: ['Aedes sp. JWDCI326-10']
+  parents:
+  - 53548
+2326551:
+  aliases: ['Aedes sp. JWDCI375-10']
+  parents:
+  - 53548
+2326552:
+  aliases: ['Aedes sp. JWDCI583-10']
+  parents:
+  - 53548
+2326553:
+  aliases: ['Aedes sp. JWDCI613-10']
+  parents:
+  - 53548
+2326554:
+  aliases: ['Aedes sp. JWDCI669-11']
+  parents:
+  - 53548
+2326555:
+  aliases: ['Aedes sp. JWDCI716-11']
+  parents:
+  - 53548
+2326556:
+  aliases: ['Aedes sp. JWDCI812-11']
+  parents:
+  - 53548
+2326557:
+  aliases: ['Aedes sp. JWDCI856-11']
+  parents:
+  - 53548
+2326558:
+  aliases: ['Aedes sp. JWDCJ1002-11']
+  parents:
+  - 53548
+2326559:
+  aliases: ['Aedes sp. JWDCJ1301-11']
+  parents:
+  - 53548
+2326560:
+  aliases: ['Aedes sp. JWDCJ150-11']
+  parents:
+  - 53548
+2326561:
+  aliases: ['Aedes sp. JWDCJ1520-11']
+  parents:
+  - 53548
+2326562:
+  aliases: ['Aedes sp. JWDCJ218-11']
+  parents:
+  - 53548
+2326563:
+  aliases: ['Aedes sp. JWDCJ276-11']
+  parents:
+  - 53548
+2326564:
+  aliases: ['Aedes sp. JWDCJ277-11']
+  parents:
+  - 53548
+2326565:
+  aliases: ['Aedes sp. JWDCJ362-11']
+  parents:
+  - 53548
+2326566:
+  aliases: ['Aedes sp. JWDCJ363-11']
+  parents:
+  - 53548
+2326567:
+  aliases: ['Aedes sp. JWDCJ407-11']
+  parents:
+  - 53548
+2326568:
+  aliases: ['Aedes sp. JWDCJ408-11']
+  parents:
+  - 53548
+2326569:
+  aliases: ['Aedes sp. JWDCL361-11']
+  parents:
+  - 53548
+2326570:
+  aliases: ['Aedes sp. JWDCL363-11']
+  parents:
+  - 53548
+1803710:
+  aliases: ['Aedes sp. M11YA']
+  parents:
+  - 53548
+1803711:
+  aliases: ['Aedes sp. M21YA']
+  parents:
+  - 53548
+1529941:
+  aliases: ['Aedes sp. MA02']
+  parents:
+  - 53548
+3014952:
+  aliases: ['Aedes sp. Madagascar BC-2022a']
+  parents:
+  - 53548
+3048046:
+  aliases: ['Aedes sp. Marks No 51']
+  parents:
+  - 53548
+2665660:
+  aliases: ['Aedes sp. Mm-99']
+  parents:
+  - 53548
+2853122:
+  aliases: ['Aedes sp. P_142_FSTST']
+  parents:
+  - 53548
+2853121:
+  aliases: ['Aedes sp. P_273_FSTHT']
+  parents:
+  - 53548
+1723311:
+  aliases: ['Aedes sp. RRSSA3765-15']
+  parents:
+  - 53548
+1723312:
+  aliases: ['Aedes sp. RRSSA583-15']
+  parents:
+  - 53548
+1742201:
+  aliases: ['Aedes sp. SSJAE10225-13']
+  parents:
+  - 53548
+1742202:
+  aliases: ['Aedes sp. SSJAE10368-13']
+  parents:
+  - 53548
+1742203:
+  aliases: ['Aedes sp. SSJAE3215-13']
+  parents:
+  - 53548
+1742204:
+  aliases: ['Aedes sp. SSJAE8301-13']
+  parents:
+  - 53548
+1742205:
+  aliases: ['Aedes sp. SSJAE8302-13']
+  parents:
+  - 53548
+1742206:
+  aliases: ['Aedes sp. SSJAE8684-13']
+  parents:
+  - 53548
+1742207:
+  aliases: ['Aedes sp. SSJAE8693-13']
+  parents:
+  - 53548
+1742208:
+  aliases: ['Aedes sp. SSJAE8711-13']
+  parents:
+  - 53548
+1742209:
+  aliases: ['Aedes sp. SSJAE8755-13']
+  parents:
+  - 53548
+1742210:
+  aliases: ['Aedes sp. SSJAE9080-13']
+  parents:
+  - 53548
+1742211:
+  aliases: ['Aedes sp. SSJAE9156-13']
+  parents:
+  - 53548
+1742212:
+  aliases: ['Aedes sp. SSJAE9174-13']
+  parents:
+  - 53548
+1742213:
+  aliases: ['Aedes sp. SSJAE9245-13']
+  parents:
+  - 53548
+1742214:
+  aliases: ['Aedes sp. SSJAE9941-13']
+  parents:
+  - 53548
+1742215:
+  aliases: ['Aedes sp. SSJAE9999-13']
+  parents:
+  - 53548
+2314939:
+  aliases: ['Aedes sp. SW-01-04']
+  parents:
+  - 53548
+2314989:
+  aliases: ['Aedes sp. SW-01-08']
+  parents:
+  - 53548
+2326571:
+  aliases: ['Aedes sp. SWSWP011-09']
+  parents:
+  - 53548
+2326572:
+  aliases: ['Aedes sp. SWSWP013-09']
+  parents:
+  - 53548
+2326573:
+  aliases: ['Aedes sp. SWSWP016-09']
+  parents:
+  - 53548
+2326574:
+  aliases: ['Aedes sp. SWSWP023-09']
+  parents:
+  - 53548
+2326575:
+  aliases: ['Aedes sp. SWSWP026-09']
+  parents:
+  - 53548
+2326576:
+  aliases: ['Aedes sp. SWSWP027-09']
+  parents:
+  - 53548
+2326577:
+  aliases: ['Aedes sp. SWSWP028-09']
+  parents:
+  - 53548
+2326578:
+  aliases: ['Aedes sp. SWSWP036-09']
+  parents:
+  - 53548
+2326579:
+  aliases: ['Aedes sp. SWSWP048-09']
+  parents:
+  - 53548
+2326580:
+  aliases: ['Aedes sp. SWSWP055-09']
+  parents:
+  - 53548
+2326581:
+  aliases: ['Aedes sp. SWSWP056-09']
+  parents:
+  - 53548
+2326582:
+  aliases: ['Aedes sp. SWSWP058-09']
+  parents:
+  - 53548
+2326583:
+  aliases: ['Aedes sp. SWSWP059-09']
+  parents:
+  - 53548
+2326584:
+  aliases: ['Aedes sp. SWSWP061-09']
+  parents:
+  - 53548
+2326585:
+  aliases: ['Aedes sp. SWSWP063-09']
+  parents:
+  - 53548
+2326586:
+  aliases: ['Aedes sp. SWSWP065-09']
+  parents:
+  - 53548
+2326587:
+  aliases: ['Aedes sp. SWSWP067-09']
+  parents:
+  - 53548
+2326588:
+  aliases: ['Aedes sp. SWSWP072-09']
+  parents:
+  - 53548
+2326589:
+  aliases: ['Aedes sp. SWSWP074-09']
+  parents:
+  - 53548
+2326590:
+  aliases: ['Aedes sp. SWSWP075-09']
+  parents:
+  - 53548
+2326591:
+  aliases: ['Aedes sp. SWSWP076-09']
+  parents:
+  - 53548
+2326592:
+  aliases: ['Aedes sp. SWSWP082-09']
+  parents:
+  - 53548
+3682668:
+  aliases: ['Aedes sp. T76722-1']
+  parents:
+  - 53548
+3687342:
+  aliases: ['Aedes sp. T77541-1']
+  parents:
+  - 53548
+1929009:
+  aliases: ['Aedes sp. TCW-2016']
+  parents:
+  - 53548
+2314952:
+  aliases: ['Aedes sp. WP-04-01']
+  parents:
+  - 53548
+2314987:
+  aliases: ['Aedes sp. WP-04-02']
+  parents:
+  - 53548
+2314962:
+  aliases: ['Aedes sp. WP-04-08']
+  parents:
+  - 53548
+2314982:
+  aliases: ['Aedes sp. WP-04-09']
+  parents:
+  - 53548
+2292408:
+  aliases: ['Aedes sp. n. RPC135']
+  parents:
+  - 53548
+2792259:
+  aliases: ['Aedes sp. sls25']
+  parents:
+  - 53548
+3014962:
+  aliases: ['Aedes spinosipes']
+  parents:
+  - 346061
+498397:
+  aliases: ['Aedes subalbopictus']
+  parents:
+  - 53541
+2732660:
+  aliases: ['Aedes subargenteus']
+  parents:
+  - 53541
+3014963:
+  aliases: ['Aedes subbasalis']
+  parents:
+  - 1806171
+2793100:
+  aliases: ['Aedes subniveus']
+  parents:
+  - 1245382
+2067460:
+  aliases: ['Aedes sudanensis']
+  parents:
+  - 53543
+2773401:
+  aliases: ['Aedes suffusus']
+  parents:
+  - 1806188
+2880926:
+  aliases: ['Aedes suzannae']
+  parents:
+  - 53540
+561252:
+  aliases: ['Aedes sylvaticum']
+  parents:
+  - 53544
+667567:
+  aliases: ['Aedes tarsalis']
+  parents:
+  - 53540
+299628:
+  aliases: ['Aedes taylori']
+  parents:
+  - 53539
+2014627:
+  aliases: ['Aedes tiptoni']
+  parents:
+  - 53539
+55967:
+  aliases: ['Aedes togoi']
+  parents:
+  - 53542
+316598:
+  aliases: ['Aedes tongae']
+  parents:
+  - 53541
+1806181:
+  aliases: ['Aedes tremulus']
+  parents:
+  - 346061
+3043245:
+  aliases: ['Aedes unalom']
+  parents:
+  - 53541
+2761510:
+  aliases: ['Aedes unidentatus']
+  parents:
+  - 53544
+1328038:
+  aliases: ['Aedes unilineatus']
+  parents:
+  - 53541
+7163:
+  aliases: ['Aedes vexans']
+  parents:
+  - 53540
+317808:
+  aliases: ['Aedes vittatus']
+  parents:
+  - 300149
+69821:
+  aliases: ['Aedes w-albus']
+  parents:
+  - 53541
+373845:
+  aliases: ['Aedes wadai']
+  parents:
+  - 53541
+1214262:
+  aliases: ['Aedes watasei']
+  parents:
+  - 53542
+1806182:
+  aliases: ['Aedes wattensis']
+  parents:
+  - 346061
+149332:
+  aliases: ['Aedes xinjiangensis']
+  parents:
+  - 1806188
+1652501:
+  aliases: ['Aedes yamadai']
+  parents:
+  - 149531
+2998957:
+  aliases: ['Aedes yunnanensis']
+  parents:
+  - 1245384
+44484:
+  aliases: ['Anopheles']
+  parents:
+  - 44483
+2510662:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 107KON']
+  parents:
+  - 54114
+2510663:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 110KON']
+  parents:
+  - 54114
+2510664:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 114KON']
+  parents:
+  - 54114
+2510665:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 115KON']
+  parents:
+  - 54114
+2510666:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 116KON']
+  parents:
+  - 54114
+2510667:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 117KON']
+  parents:
+  - 54114
+2510668:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 118KON']
+  parents:
+  - 54114
+2510669:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 119KON']
+  parents:
+  - 54114
+2510670:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 120KON']
+  parents:
+  - 54114
+2510671:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 121KON']
+  parents:
+  - 54114
+2510672:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 122KON']
+  parents:
+  - 54114
+2510673:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 123KON']
+  parents:
+  - 54114
+2510674:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 124KON']
+  parents:
+  - 54114
+2510675:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 125KON']
+  parents:
+  - 54114
+2510676:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 126KON']
+  parents:
+  - 54114
+2510677:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 127KON']
+  parents:
+  - 54114
+2510678:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 128KON']
+  parents:
+  - 54114
+2510679:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 129KON']
+  parents:
+  - 54114
+2510680:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 130KON']
+  parents:
+  - 54114
+2510681:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 131KON']
+  parents:
+  - 54114
+2510682:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 132KON']
+  parents:
+  - 54114
+2510683:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 133KON']
+  parents:
+  - 54114
+2510684:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 134KON']
+  parents:
+  - 54114
+2510685:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 135KON']
+  parents:
+  - 54114
+2510686:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 136KON']
+  parents:
+  - 54114
+2510687:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 137KON']
+  parents:
+  - 54114
+2510688:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 138KON']
+  parents:
+  - 54114
+2510689:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 139KON']
+  parents:
+  - 54114
+2510690:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 140KON']
+  parents:
+  - 54114
+2510691:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 141KON']
+  parents:
+  - 54114
+2510692:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 142KON']
+  parents:
+  - 54114
+2510693:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 143KON']
+  parents:
+  - 54114
+2510694:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 144KON']
+  parents:
+  - 54114
+2510695:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 145KON']
+  parents:
+  - 54114
+2510696:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 146KON']
+  parents:
+  - 54114
+2510697:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 147KON']
+  parents:
+  - 54114
+2510698:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 148KON']
+  parents:
+  - 54114
+2510699:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 149KON']
+  parents:
+  - 54114
+2510700:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 150KON']
+  parents:
+  - 54114
+2510701:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 151KON']
+  parents:
+  - 54114
+2510702:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 152KON']
+  parents:
+  - 54114
+2510660:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 36KON']
+  parents:
+  - 54114
+2510661:
+  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 38KON']
+  parents:
+  - 54114
+2841942:
+  aliases: ['Anopheles aff. albimanus B YML-2021a']
+  parents:
+  - 54114
+622773:
+  aliases: ['Anopheles ainshamsi']
+  parents:
+  - 44535
+59117:
+  aliases: ['Anopheles amictus']
+  parents:
+  - 44536
+59162:
+  aliases: ['Anopheles annularis group']
+  parents:
+  - 44535
+1387143:
+  aliases: ['Anopheles apicimacula']
+  parents:
+  - 190374
+262008:
+  aliases: ['Anopheles apoci']
+  parents:
+  - 59140
+1291063:
+  aliases: ['Anopheles argyropus']
+  parents:
+  - 190374
+3061999:
+  aliases: ['Anopheles atratipes']
+  parents:
+  - 190374
+2912046:
+  aliases: ['Anopheles baezai']
+  parents:
+  - 190374
+2918032:
+  aliases: ['Anopheles barberi']
+  parents:
+  - 190374
+927784:
+  aliases: ['Anopheles calderoni']
+  parents:
+  - 190374
+176099:
+  aliases: ["Anopheles cf. dthali 'Bluchistan'"]
+  parents:
+  - 59140
+43041:
+  aliases: ['Anopheles christyi']
+  parents:
+  - 44537
+1521112:
+  aliases: ['Anopheles cinctus']
+  parents:
+  - 44536
+3017357:
+  aliases: ['Anopheles cinereus hispaniola']
+  parents:
+  - 1632206
+2748955:
+  aliases: ['Anopheles concolor']
+  parents:
+  - 190374
+925981:
+  aliases: ['Anopheles costai']
+  parents:
+  - 190374
+869064:
+  aliases: ['Anopheles crucians']
+  parents:
+  - 190374
+1521113:
+  aliases: ['Anopheles demeilloni']
+  parents:
+  - 59140
+2745526:
+  aliases: ['Anopheles donaldi']
+  parents:
+  - 190374
+262009:
+  aliases: ['Anopheles dthali']
+  parents:
+  - 59140
+3241325:
+  aliases: ['Anopheles flavicosta']
+  parents:
+  - 59140
+1426903:
+  aliases: ['Anopheles forattinii']
+  parents:
+  - 190374
+1424568:
+  aliases: ['Anopheles fragilis']
+  parents:
+  - 190374
+2785382:
+  aliases: ['Anopheles franciscanus']
+  parents:
+  - 190374
+1521114:
+  aliases: ['Anopheles gabonensis']
+  parents:
+  - 59140
+3014964:
+  aliases: ['Anopheles grabhamii']
+  parents:
+  - 190374
+1521115:
+  aliases: ['Anopheles hancocki']
+  parents:
+  - 59140
+27470:
+  aliases: ['Anopheles hilli']
+  parents:
+  - 44536
+3062582:
+  aliases: ['Anopheles hodgkini']
+  parents:
+  - 190374
+758766:
+  aliases: ['Anopheles insulaeflorum']
+  parents:
+  - 190374
+308710:
+  aliases: ['Anopheles jamesii']
+  parents:
+  - 44535
+59148:
+  aliases: ['Anopheles karwari']
+  parents:
+  - 44535
+59150:
+  aliases: ['Anopheles kochi']
+  parents:
+  - 44536
+59151:
+  aliases: ['Anopheles litoralis']
+  parents:
+  - 44537
+74868:
+  aliases: ['Anopheles maculatus group']
+  parents:
+  - 44535
+1496333:
+  aliases: ['Anopheles maculipalpis']
+  parents:
+  - 44535
+1521116:
+  aliases: ['Anopheles marshallii']
+  parents:
+  - 59140
+2756213:
+  aliases: ['Anopheles maverlius']
+  parents:
+  - 190374
+59157:
+  aliases: ['Anopheles meraukensis']
+  parents:
+  - 44536
+186751:
+  aliases: ['Anopheles moucheti']
+  parents:
+  - 59140
+1199414:
+  aliases: ['Anopheles neomaculipalpus']
+  parents:
+  - 190374
+59158:
+  aliases: ['Anopheles novaguinensis']
+  parents:
+  - 44536
+2419668:
+  aliases: ['Anopheles nr. costai G1 MAMS-2018']
+  parents:
+  - 190374
+2419669:
+  aliases: ['Anopheles nr. costai G2 MAMS-2018']
+  parents:
+  - 190374
+2419670:
+  aliases: ['Anopheles nr. costai G3 MAMS-2018']
+  parents:
+  - 190374
+2419671:
+  aliases: ['Anopheles nr. costai G4 MAMS-2018']
+  parents:
+  - 190374
+2419672:
+  aliases: ['Anopheles nr. costai G5 MAMS-2018']
+  parents:
+  - 190374
+2171939:
+  aliases: ['Anopheles nr. costai SP02_17_3']
+  parents:
+  - 190374
+1426910:
+  aliases: ['Anopheles nr. konderi FR2013']
+  parents:
+  - 44544
+2875525:
+  aliases: ['Anopheles omorii']
+  parents:
+  - 190374
+622774:
+  aliases: ['Anopheles paltrinierii']
+  parents:
+  - 44535
+333671:
+  aliases: ['Anopheles pattoni']
+  parents:
+  - 44535
+874513:
+  aliases: ['Anopheles pristinus']
+  parents:
+  - 874512
+159154:
+  aliases: ['Anopheles pulcherrimus']
+  parents:
+  - 44535
+1291064:
+  aliases: ['Anopheles pursati']
+  parents:
+  - 190374
+3241326:
+  aliases: ['Anopheles radama']
+  parents:
+  - 44536
+1632232:
+  aliases: ['Anopheles rhodesiensis rupicola']
+  parents:
+  - 1632207
+325436:
+  aliases: ['Anopheles splendidus']
+  parents:
+  - 44535
+30069:
+  aliases: ['Anopheles stephensi']
+  parents:
+  - 44535
+3014965:
+  aliases: ['Anopheles stigmaticus']
+  parents:
+  - 190374
+262673:
+  aliases: ['Anopheles superpictus']
+  parents:
+  - 44535
+59161:
+  aliases: ['Anopheles tessellatus']
+  parents:
+  - 44536
+142887:
+  aliases: ['Anopheles vagus']
+  parents:
+  - 44537
+2903342:
+  aliases: ['Anopheles veruslanei']
+  parents:
+  - 190374
+869065:
+  aliases: ['Anopheles vestitipennis']
+  parents:
+  - 190374
+1245358:
+  aliases: ['Anopheles xui']
+  parents:
+  - 190374
+2968253:
+  aliases: ['Armigeres aureolineatus']
+  parents:
+  - 317811
+1245359:
+  aliases: ['Armigeres durhami']
+  parents:
+  - 317811
+1245360:
+  aliases: ['Armigeres flavus']
+  parents:
+  - 317812
+753891:
+  aliases: ['Armigeres kesseli']
+  parents:
+  - 317811
+2587274:
+  aliases: ['Armigeres longipalpis']
+  parents:
+  - 317812
+3137931:
+  aliases: ['Armigeres magnus']
+  parents:
+  - 317812
+2067461:
+  aliases: ['Armigeres malayi']
+  parents:
+  - 317811
+149458:
+  aliases: ['Armigeres obturbans']
+  parents:
+  - 317811
+3569224:
+  aliases: ['Armigeres omissus']
+  parents:
+  - 317812
+2853132:
+  aliases: ['Armigeres sp. P_141_FSTST']
+  parents:
+  - 2853149
+2853123:
+  aliases: ['Armigeres sp. P_195_FSTJD']
+  parents:
+  - 2853149
+2853136:
+  aliases: ['Armigeres sp. P_199_FSTHD']
+  parents:
+  - 2853149
+2853135:
+  aliases: ['Armigeres sp. P_201_FSTJD']
+  parents:
+  - 2853149
+2853134:
+  aliases: ['Armigeres sp. P_206_FSTAT']
+  parents:
+  - 2853149
+2853133:
+  aliases: ['Armigeres sp. P_209_FSTAT']
+  parents:
+  - 2853149
+2853127:
+  aliases: ['Armigeres sp. P_263_FSTHT']
+  parents:
+  - 2853149
+2853128:
+  aliases: ['Armigeres sp. P_264_FSTHT']
+  parents:
+  - 2853149
+2853129:
+  aliases: ['Armigeres sp. P_265_FSTHT']
+  parents:
+  - 2853149
+2853131:
+  aliases: ['Armigeres sp. P_271_FSTHT']
+  parents:
+  - 2853149
+2853130:
+  aliases: ['Armigeres sp. P_312_FSTCO']
+  parents:
+  - 2853149
+2853126:
+  aliases: ['Armigeres sp. P_322_FSTCO']
+  parents:
+  - 2853149
+2853125:
+  aliases: ['Armigeres sp. P_325_FSTCO']
+  parents:
+  - 2853149
+2853124:
+  aliases: ['Armigeres sp. P_328_FSTCO']
+  parents:
+  - 2853149
+124917:
+  aliases: ['Armigeres subalbatus']
+  parents:
+  - 317811
+58248:
+  aliases: ['Arribalzagia']
+  parents:
+  - 58247
+2729127:
+  aliases: ['Choroterpides apiculata (nomen nudum)']
+  parents:
+  - 1125803
+58249:
+  aliases: ['Christya']
+  parents:
+  - 58247
+2989696:
+  aliases: ['Coquillettidia sp.']
+  parents:
+  - 2637621
+1822822:
+  aliases: ['Coquillettidia sp. BOLD:AAB2539']
+  parents:
+  - 2637621
+2232092:
+  aliases: ['Culex (Anoedioporpa) sp. CA1']
+  parents:
+  - 1426913
+2232093:
+  aliases: ['Culex (Anoedioporpa) sp. CA2']
+  parents:
+  - 1426913
+2496364:
+  aliases: ['Culex (Culex) sp. 407 CSS-2018']
+  parents:
+  - 53527
+1899480:
+  aliases: ['Culex (Melanoconion) nr. aliciae PM1_6']
+  parents:
+  - 53535
+1899479:
+  aliases: ['Culex (Melanoconion) nr. aliciae PM1_7']
+  parents:
+  - 53535
+1899267:
+  aliases: ['Culex (Melanoconion) nr. aureonotatus TO1_12_1']
+  parents:
+  - 53535
+1899268:
+  aliases: ['Culex (Melanoconion) nr. aureonotatus TO1_12_2']
+  parents:
+  - 53535
+1899269:
+  aliases: ['Culex (Melanoconion) nr. aureonotatus TO1_3']
+  parents:
+  - 53535
+1899270:
+  aliases: ['Culex (Melanoconion) nr. gnomatos gnomat_AC']
+  parents:
+  - 53535
+1899271:
+  aliases: ['Culex (Melanoconion) nr. inhibitator 1g']
+  parents:
+  - 53535
+1899481:
+  aliases: ['Culex (Melanoconion) nr. pedroi AC153_1']
+  parents:
+  - 53535
+1899272:
+  aliases: ['Culex (Melanoconion) nr. pedroi ped1']
+  parents:
+  - 53535
+1899273:
+  aliases: ['Culex (Melanoconion) nr. pedroi ped2']
+  parents:
+  - 53535
+1899482:
+  aliases: ['Culex (Melanoconion) nr. portesi AC312_8']
+  parents:
+  - 53535
+1899274:
+  aliases: ['Culex (Melanoconion) nr. rabelloi 1A']
+  parents:
+  - 53535
+1899277:
+  aliases: ['Culex (Melanoconion) nr. rabelloi 1H']
+  parents:
+  - 53535
+1899275:
+  aliases: ['Culex (Melanoconion) nr. rabelloi 1c']
+  parents:
+  - 53535
+1899276:
+  aliases: ['Culex (Melanoconion) nr. rabelloi 1e']
+  parents:
+  - 53535
+1899483:
+  aliases: ['Culex (Melanoconion) nr. spissipes spi_AC']
+  parents:
+  - 53535
+1899484:
+  aliases: ['Culex (Melanoconion) nr. theobaldi AC127_1']
+  parents:
+  - 53535
+1899278:
+  aliases: ['Culex (Melanoconion) nr. vomerifer AC322_1']
+  parents:
+  - 53535
+2725248:
+  aliases: ['Culex (Melanoconion) sp. 1 DJS-2020']
+  parents:
+  - 53535
+2725249:
+  aliases: ['Culex (Melanoconion) sp. 2 DJS-2020']
+  parents:
+  - 53535
+2496361:
+  aliases: ['Culex (Melanoconion) sp. 274 CSS-2018']
+  parents:
+  - 53535
+2725250:
+  aliases: ['Culex (Melanoconion) sp. 3 DJS-2020']
+  parents:
+  - 53535
+2725251:
+  aliases: ['Culex (Melanoconion) sp. 4 DJS-2020']
+  parents:
+  - 53535
+2725252:
+  aliases: ['Culex (Melanoconion) sp. 5 DJS-2020']
+  parents:
+  - 53535
+2725253:
+  aliases: ['Culex (Melanoconion) sp. 6 DJS-2020']
+  parents:
+  - 53535
+2725254:
+  aliases: ['Culex (Melanoconion) sp. 7 DJS-2020']
+  parents:
+  - 53535
+2233863:
+  aliases: ['Culex (Microculex) sp. CX1']
+  parents:
+  - 707272
+2233864:
+  aliases: ['Culex (Microculex) sp. CX2']
+  parents:
+  - 707272
+1085687:
+  aliases: ['Culex abominator']
+  parents:
+  - 53535
+3453671:
+  aliases: ['Culex abonnenci']
+  parents:
+  - 53535
+1640511:
+  aliases: ['Culex accelerans']
+  parents:
+  - 1640510
+1461355:
+  aliases: ['Culex acharistus']
+  parents:
+  - 53527
+284557:
+  aliases: ['Culex adamesi']
+  parents:
+  - 53535
+1799685:
+  aliases: ['Culex adersianus']
+  parents:
+  - 53531
+2171936:
+  aliases: ['Culex aff. dolosus CJForm PGF-2018']
+  parents:
+  - 53527
+1899234:
+  aliases: ['Culex akritos']
+  parents:
+  - 53535
+3014966:
+  aliases: ['Culex albinensis']
+  parents:
+  - 53535
+707274:
+  aliases: ['Culex aliciae']
+  parents:
+  - 53535
+3128999:
+  aliases: ['Culex alienus']
+  parents:
+  - 53527
+3453672:
+  aliases: ['Culex alinkios']
+  parents:
+  - 53535
+1899235:
+  aliases: ['Culex alogistus']
+  parents:
+  - 53535
+2719872:
+  aliases: ['Culex amazonensis']
+  parents:
+  - 1640510
+2918767:
+  aliases: ['Culex andersoni']
+  parents:
+  - 53527
+667566:
+  aliases: ['Culex annulioris']
+  parents:
+  - 667565
+162997:
+  aliases: ['Culex annulirostris']
+  parents:
+  - 53527
+182211:
+  aliases: ['Culex annulus']
+  parents:
+  - 53527
+911293:
+  aliases: ['Culex antennatus']
+  parents:
+  - 53527
+3014967:
+  aliases: ['Culex antillummagnorum']
+  parents:
+  - 2891964
+3453698:
+  aliases: ['Culex antunesi']
+  parents:
+  - 794814
+3423903:
+  aliases: ['Culex aphyllus']
+  parents:
+  - 53535
+1206046:
+  aliases: ['Culex apicalis']
+  parents:
+  - 53537
+571207:
+  aliases: ['Culex apicinus']
+  parents:
+  - 53527
+3017358:
+  aliases: ['Culex arbieeni']
+  parents:
+  - 53534
+2563467:
+  aliases: ['Culex argenteopunctatus']
+  parents:
+  - 53527
+1206308:
+  aliases: ['Culex arizonensis']
+  parents:
+  - 53537
+2292406:
+  aliases: ['Culex asteliae']
+  parents:
+  - 53527
+1085685:
+  aliases: ['Culex atratus']
+  parents:
+  - 53535
+1085686:
+  aliases: ['Culex atratus B Williams & Savage (2009)']
+  parents:
+  - 53535
+2563468:
+  aliases: ['Culex aurantapex']
+  parents:
+  - 667565
+1899236:
+  aliases: ['Culex aureonotatus']
+  parents:
+  - 53535
+1206047:
+  aliases: ['Culex bahamensis']
+  parents:
+  - 53527
+1899237:
+  aliases: ['Culex bastagarius']
+  parents:
+  - 53535
+3453673:
+  aliases: ['Culex batesi']
+  parents:
+  - 53535
+2803069:
+  aliases: ['Culex bhutanensis']
+  parents:
+  - 53527
+3453674:
+  aliases: ['Culex bibulus']
+  parents:
+  - 53535
+1214264:
+  aliases: ['Culex bicornutus']
+  parents:
+  - 308715
+707279:
+  aliases: ['Culex bidens']
+  parents:
+  - 53527
+2891963:
+  aliases: ['Culex bihaicola']
+  parents:
+  - 794814
+2171672:
+  aliases: ['Culex bilineatus']
+  parents:
+  - 53527
+3014968:
+  aliases: ['Culex biscaynensis']
+  parents:
+  - 2891964
+69822:
+  aliases: ['Culex bitaeniorhynchus']
+  parents:
+  - 667565
+2730085:
+  aliases: ['Culex boninensis']
+  parents:
+  - 2730084
+3453699:
+  aliases: ['Culex bonneae']
+  parents:
+  - 53527
+794815:
+  aliases: ['Culex bonnei']
+  parents:
+  - 794814
+3453675:
+  aliases: ['Culex brachiatus']
+  parents:
+  - 53535
+2171673:
+  aliases: ['Culex brami']
+  parents:
+  - 53527
+1091053:
+  aliases: ['Culex brethesi']
+  parents:
+  - 53527
+3453704:
+  aliases: ['Culex breviculus']
+  parents:
+  - 3453668
+317797:
+  aliases: ['Culex brevipalpis']
+  parents:
+  - 53531
+3453700:
+  aliases: ['Culex brevispinosus']
+  parents:
+  - 53527
+1426904:
+  aliases: ['Culex browni']
+  parents:
+  - 1426913
+2943529:
+  aliases: ['Culex cambournaci']
+  parents:
+  - 53530
+1461356:
+  aliases: ['Culex camposi']
+  parents:
+  - 53527
+3453676:
+  aliases: ['Culex carincii']
+  parents:
+  - 53535
+3014969:
+  aliases: ['Culex castroi']
+  parents:
+  - 1091057
+3453677:
+  aliases: ['Culex cauchensis']
+  parents:
+  - 53535
+3453678:
+  aliases: ['Culex caudatus']
+  parents:
+  - 53535
+707275:
+  aliases: ['Culex caudelli']
+  parents:
+  - 53535
+1085688:
+  aliases: ['Culex cedecei']
+  parents:
+  - 53535
+3018960:
+  aliases: ['Culex cf. perexiguus']
+  parents:
+  - 53527
+3239031:
+  aliases: ['Culex cf. sitiens']
+  parents:
+  - 53527
+2722877:
+  aliases: ['Culex cf. sitiens MAFP8.E9']
+  parents:
+  - 53527
+2722878:
+  aliases: ['Culex cf. watti MAFP5.C5']
+  parents:
+  - 53527
+707280:
+  aliases: ['Culex chidesteri']
+  parents:
+  - 53527
+1214265:
+  aliases: ['Culex cinctellus']
+  parents:
+  - 308715
+667563:
+  aliases: ['Culex cinereus']
+  parents:
+  - 53530
+1899238:
+  aliases: ['Culex clarki']
+  parents:
+  - 53535
+3382158:
+  aliases: ['Culex comatus']
+  parents:
+  - 53535
+1899239:
+  aliases: ['Culex commevynensis']
+  parents:
+  - 53535
+2758409:
+  aliases: ['Culex comminutor']
+  parents:
+  - 53535
+1426905:
+  aliases: ['Culex conservator']
+  parents:
+  - 1426913
+1677685:
+  aliases: ['Culex conspirator']
+  parents:
+  - 53535
+3449754:
+  aliases: ['Culex contei']
+  parents:
+  - 53535
+1899240:
+  aliases: ['Culex corentynensis']
+  parents:
+  - 53535
+707271:
+  aliases: ['Culex corniger']
+  parents:
+  - 707270
+317804:
+  aliases: ['Culex cornutus']
+  parents:
+  - 53527
+526217:
+  aliases: ['Culex coronator']
+  parents:
+  - 53527
+3382159:
+  aliases: ['Culex creole']
+  parents:
+  - 53535
+2821046:
+  aliases: ['Culex crinicauda']
+  parents:
+  - 53527
+3453679:
+  aliases: ['Culex cristovaoi']
+  parents:
+  - 53535
+1899241:
+  aliases: ['Culex crybda']
+  parents:
+  - 53535
+3014970:
+  aliases: ['Culex cubiculi']
+  parents:
+  - 308715
+1808015:
+  aliases: ['Culex cylindricus']
+  parents:
+  - 308715
+299630:
+  aliases: ['Culex decens']
+  parents:
+  - 53527
+707281:
+  aliases: ['Culex declarator']
+  parents:
+  - 53527
+1795353:
+  aliases: ['Culex deserticola']
+  parents:
+  - 53534
+2742860:
+  aliases: ['Culex diengensis']
+  parents:
+  - 53527
+707282:
+  aliases: ['Culex dolosus']
+  parents:
+  - 53527
+3014971:
+  aliases: ['Culex douglasi']
+  parents:
+  - 53537
+1273079:
+  aliases: ['Culex dunni']
+  parents:
+  - 53535
+1799675:
+  aliases: ['Culex duttoni']
+  parents:
+  - 53527
+707276:
+  aliases: ['Culex dyius']
+  parents:
+  - 53535
+1899242:
+  aliases: ['Culex eastor']
+  parents:
+  - 53535
+1091055:
+  aliases: ['Culex eduardoi']
+  parents:
+  - 53527
+1677686:
+  aliases: ['Culex educator']
+  parents:
+  - 53535
+1041092:
+  aliases: ['Culex edwardsi']
+  parents:
+  - 53527
+1899243:
+  aliases: ['Culex eknomios']
+  parents:
+  - 53535
+1206309:
+  aliases: ['Culex elevator']
+  parents:
+  - 53535
+1899244:
+  aliases: ['Culex ensiformis']
+  parents:
+  - 53535
+333812:
+  aliases: ['Culex environmental sample']
+  parents:
+  - 333811
+1821542:
+  aliases: ['Culex epanatasis']
+  parents:
+  - 53535
+471289:
+  aliases: ['Culex epidesmus']
+  parents:
+  - 53527
+1899245:
+  aliases: ['Culex equinoxialis']
+  parents:
+  - 53535
+2891966:
+  aliases: ['Culex erethyzonfer']
+  parents:
+  - 2891964
+3453680:
+  aliases: ['Culex ernanii']
+  parents:
+  - 53535
+3453681:
+  aliases: ['Culex ernsti']
+  parents:
+  - 53535
+42427:
+  aliases: ['Culex erraticus']
+  parents:
+  - 53535
+42428:
+  aliases: ['Culex erythrothorax']
+  parents:
+  - 53527
+1464558:
+  aliases: ['Culex europaeus']
+  parents:
+  - 53537
+1899246:
+  aliases: ['Culex evansae']
+  parents:
+  - 53535
+3453682:
+  aliases: ['Culex extenuatus']
+  parents:
+  - 53535
+1899247:
+  aliases: ['Culex faurani']
+  parents:
+  - 53535
+2792477:
+  aliases: ['Culex fergusoni']
+  parents:
+  - 53537
+3453683:
+  aliases: ['Culex flabellifer']
+  parents:
+  - 53535
+498398:
+  aliases: ['Culex flavicornis']
+  parents:
+  - 308715
+3453684:
+  aliases: ['Culex foliafer']
+  parents:
+  - 53535
+1245361:
+  aliases: ['Culex foliatus']
+  parents:
+  - 53531
+2853104:
+  aliases: ['Culex fragilis']
+  parents:
+  - 53530
+345740:
+  aliases: ['Culex fuscocephala']
+  parents:
+  - 53527
+3453685:
+  aliases: ['Culex galindoi']
+  parents:
+  - 53535
+569590:
+  aliases: ['Culex gaufini']
+  parents:
+  - 53537
+2793200:
+  aliases: ['Culex gaugleri']
+  parents:
+  - 53527
+308713:
+  aliases: ['Culex gelidus']
+  parents:
+  - 53527
+1806176:
+  aliases: ['Culex globocoxitus']
+  parents:
+  - 53527
+284516:
+  aliases: ['Culex gnomatos']
+  parents:
+  - 53535
+1206310:
+  aliases: ['Culex habilitator']
+  parents:
+  - 53527
+1214266:
+  aliases: ['Culex hayashii']
+  parents:
+  - 53531
+3114454:
+  aliases: ['Culex hilli']
+  parents:
+  - 308715
+1464559:
+  aliases: ['Culex hortensis']
+  parents:
+  - 53534
+3453686:
+  aliases: ['Culex hutchingsae']
+  parents:
+  - 53535
+345742:
+  aliases: ['Culex hutchinsoni']
+  parents:
+  - 53527
+1899248:
+  aliases: ['Culex idottus']
+  parents:
+  - 53535
+707273:
+  aliases: ['Culex imitator']
+  parents:
+  - 707272
+1464560:
+  aliases: ['Culex impudicus']
+  parents:
+  - 53537
+3453687:
+  aliases: ['Culex inadmirabilis']
+  parents:
+  - 53535
+1131596:
+  aliases: ['Culex inatomii']
+  parents:
+  - 53528
+2918769:
+  aliases: ['Culex inconspicuosus']
+  parents:
+  - 53531
+308717:
+  aliases: ['Culex infantulus']
+  parents:
+  - 308715
+2007261:
+  aliases: ['Culex infoliatus']
+  parents:
+  - 794814
+308720:
+  aliases: ['Culex infula']
+  parents:
+  - 53527
+1206048:
+  aliases: ['Culex inhibitator']
+  parents:
+  - 53535
+3383093:
+  aliases: ['Culex innovator']
+  parents:
+  - 53535
+571208:
+  aliases: ['Culex interfor']
+  parents:
+  - 53527
+556016:
+  aliases: ['Culex interrogator']
+  parents:
+  - 53527
+1899249:
+  aliases: ['Culex intrincatus']
+  parents:
+  - 53535
+1085689:
+  aliases: ['Culex iolambdis']
+  parents:
+  - 53535
+376793:
+  aliases: ['Culex iyengari']
+  parents:
+  - 53527
+2742861:
+  aliases: ['Culex jacksoni']
+  parents:
+  - 53527
+1206311:
+  aliases: ['Culex janitor']
+  parents:
+  - 53527
+3453688:
+  aliases: ['Culex johnnyi']
+  parents:
+  - 53535
+3453689:
+  aliases: ['Culex johnsoni']
+  parents:
+  - 53535
+1652503:
+  aliases: ['Culex kyotoensis']
+  parents:
+  - 53530
+1899250:
+  aliases: ['Culex lacertosus']
+  parents:
+  - 53535
+871896:
+  aliases: ['Culex lactator']
+  parents:
+  - 707270
+1464561:
+  aliases: ['Culex laticinctus']
+  parents:
+  - 53527
+3114455:
+  aliases: ['Culex latus']
+  parents:
+  - 53537
+3461572:
+  aliases: ['Culex litwakae']
+  parents:
+  - 53527
+3453690:
+  aliases: ['Culex longistriatus']
+  parents:
+  - 53535
+2807044:
+  aliases: ['Culex longitubus']
+  parents:
+  - 53527
+3453691:
+  aliases: ['Culex lucackermanni']
+  parents:
+  - 53535
+1677687:
+  aliases: ['Culex lucifugus']
+  parents:
+  - 53535
+1461354:
+  aliases: ['Culex lygrus']
+  parents:
+  - 53527
+1461374:
+  aliases: ['Culex lygrus s.l. SP56_25']
+  parents:
+  - 53527
+1461375:
+  aliases: ['Culex lygrus s.l. SP56_26']
+  parents:
+  - 53527
+345741:
+  aliases: ['Culex malayi']
+  parents:
+  - 53531
+2306907:
+  aliases: ['Culex martinii']
+  parents:
+  - 53537
+549330:
+  aliases: ['Culex maxi']
+  parents:
+  - 53527
+421623:
+  aliases: ['Culex mimeticus']
+  parents:
+  - 53527
+498399:
+  aliases: ['Culex mimuloides']
+  parents:
+  - 53527
+308722:
+  aliases: ['Culex mimulus']
+  parents:
+  - 53527
+2587280:
+  aliases: ['Culex mimulus complex sp. NN1189']
+  parents:
+  - 53527
+2587281:
+  aliases: ['Culex mimulus complex sp. NN912']
+  parents:
+  - 53527
+325443:
+  aliases: ['Culex minor']
+  parents:
+  - 308715
+345743:
+  aliases: ['Culex minutissimus']
+  parents:
+  - 308715
+2563469:
+  aliases: ['Culex mirificus']
+  parents:
+  - 53527
+1899251:
+  aliases: ['Culex misionensis']
+  parents:
+  - 53535
+545656:
+  aliases: ['Culex modestus']
+  parents:
+  - 53528
+549331:
+  aliases: ['Culex mollis']
+  parents:
+  - 53527
+2989692:
+  aliases: ['Culex moucheti']
+  parents:
+  - 2989691
+1085690:
+  aliases: ['Culex mulrennani']
+  parents:
+  - 53535
+314561:
+  aliases: ['Culex murrelli']
+  parents:
+  - 53527
+864528:
+  aliases: ['Culex neavei']
+  parents:
+  - 53527
+562834:
+  aliases: ['Culex nebulosus']
+  parents:
+  - 53530
+2007262:
+  aliases: ['Culex nigrimacula']
+  parents:
+  - 2007271
+42429:
+  aliases: ['Culex nigripalpus']
+  parents:
+  - 53527
+308723:
+  aliases: ['Culex nigropunctatus']
+  parents:
+  - 53530
+2793868:
+  aliases: ['Culex nr. alis KR26_A_1']
+  parents:
+  - 53527
+2793869:
+  aliases: ['Culex nr. alis KR39_L2_3']
+  parents:
+  - 53527
+3422312:
+  aliases: ['Culex nr. commevynensis']
+  parents:
+  - 53535
+284559:
+  aliases: ['Culex nr. pedroi MIR-01']
+  parents:
+  - 53535
+284561:
+  aliases: ['Culex nr. pedroi PER']
+  parents:
+  - 53535
+284560:
+  aliases: ['Culex nr. pedroi PER-05']
+  parents:
+  - 53535
+284568:
+  aliases: ['Culex nr. pedroi PERU-02']
+  parents:
+  - 53535
+284562:
+  aliases: ['Culex nr. pedroi Per4-3']
+  parents:
+  - 53535
+2803070:
+  aliases: ['Culex nr. tianpingensis MG21']
+  parents:
+  - 53527
+2803071:
+  aliases: ['Culex nr. tianpingensis MG22']
+  parents:
+  - 53527
+2803072:
+  aliases: ['Culex nr. tianpingensis SPTP1']
+  parents:
+  - 53527
+2803074:
+  aliases: ['Culex nr. tsengi JbTG-1']
+  parents:
+  - 53527
+2803073:
+  aliases: ['Culex nr. tsengi TPTG']
+  parents:
+  - 53527
+3422311:
+  aliases: ['Culex nr. vaxus']
+  parents:
+  - 53535
+2007263:
+  aliases: ['Culex ocellatus']
+  parents:
+  - 2007271
+2047781:
+  aliases: ['Culex ocossa']
+  parents:
+  - 53535
+1899252:
+  aliases: ['Culex oedipus']
+  parents:
+  - 53535
+1214267:
+  aliases: ['Culex okinawae']
+  parents:
+  - 53531
+1806177:
+  aliases: ['Culex orbostiensis']
+  parents:
+  - 308715
+3077182:
+  aliases: ['Culex organaboensis']
+  parents:
+  - 53535
+1131597:
+  aliases: ['Culex orientalis']
+  parents:
+  - 53527
+2758410:
+  aliases: ['Culex originator']
+  parents:
+  - 1426913
+345924:
+  aliases: ['Culex pallidothorax']
+  parents:
+  - 53530
+163000:
+  aliases: ['Culex palpalis']
+  parents:
+  - 53527
+3014972:
+  aliases: ['Culex panocossa']
+  parents:
+  - 53535
+2795829:
+  aliases: ['Culex pavlovskyi']
+  parents:
+  - 53535
+1085691:
+  aliases: ['Culex peccator']
+  parents:
+  - 53535
+284558:
+  aliases: ['Culex pedroi']
+  parents:
+  - 53535
+943103:
+  aliases: ['Culex perexiguus']
+  parents:
+  - 53527
+1899253:
+  aliases: ['Culex pereyrai']
+  parents:
+  - 53535
+864588:
+  aliases: ['Culex perfuscus']
+  parents:
+  - 53527
+260109:
+  aliases: ['Culex pervigilans']
+  parents:
+  - 53527
+1245362:
+  aliases: ['Culex peytoni']
+  parents:
+  - 308715
+3438412:
+  aliases: ['Culex phlogistus']
+  parents:
+  - 53535
+42430:
+  aliases: ['Culex pilosus']
+  parents:
+  - 53536
+2910795:
+  aliases: ['Culex pinarocampa']
+  parents:
+  - 53527
+518105:
+  aliases: ['Culex pipiens complex']
+  parents:
+  - 53527
+2007264:
+  aliases: ['Culex pleuristriatus']
+  parents:
+  - 707272
+363521:
+  aliases: ['Culex pluvialis']
+  parents:
+  - 53531
+450823:
+  aliases: ['Culex poicilipes']
+  parents:
+  - 53527
+284563:
+  aliases: ['Culex portesi']
+  parents:
+  - 53535
+3383094:
+  aliases: ['Culex productus']
+  parents:
+  - 53535
+2785383:
+  aliases: ['Culex pseudostigmatosoma']
+  parents:
+  - 53527
+100677:
+  aliases: ['Culex pseudovishnui']
+  parents:
+  - 53527
+1905332:
+  aliases: ['Culex pullus']
+  parents:
+  - 53527
+2860240:
+  aliases: ['Culex pusillus']
+  parents:
+  - 53528
+1899254:
+  aliases: ['Culex putumayensis']
+  parents:
+  - 53535
+3162573:
+  aliases: ['Culex rabanicolus']
+  parents:
+  - 53535
+1899255:
+  aliases: ['Culex rabelloi']
+  parents:
+  - 53535
+2785376:
+  aliases: ['Culex rejector']
+  parents:
+  - 707272
+1091054:
+  aliases: ['Culex renatoi']
+  parents:
+  - 1091057
+2785381:
+  aliases: ['Culex restrictor']
+  parents:
+  - 1426913
+38742:
+  aliases: ['Culex restuans']
+  parents:
+  - 53527
+284564:
+  aliases: ['Culex ribeirensis']
+  parents:
+  - 53535
+1245363:
+  aliases: ['Culex richei']
+  parents:
+  - 53531
+1799686:
+  aliases: ['Culex rima']
+  parents:
+  - 53531
+3453692:
+  aliases: ['Culex rorotaensis']
+  parents:
+  - 53535
+2292407:
+  aliases: ['Culex rotoruae']
+  parents:
+  - 53527
+1652502:
+  aliases: ['Culex rubensis']
+  parents:
+  - 53537
+1678250:
+  aliases: ['Culex rubinotus']
+  parents:
+  - 53531
+308724:
+  aliases: ['Culex rubithoracis']
+  parents:
+  - 308715
+1214268:
+  aliases: ['Culex ryukyensis']
+  parents:
+  - 53530
+284556:
+  aliases: ['Culex sacchettae']
+  parents:
+  - 53535
+38743:
+  aliases: ['Culex salinarius']
+  parents:
+  - 53527
+1631549:
+  aliases: ['Culex salinarius group sp. RHL-2015']
+  parents:
+  - 53527
+3453693:
+  aliases: ['Culex sallumae']
+  parents:
+  - 53535
+1461357:
+  aliases: ['Culex saltanensis']
+  parents:
+  - 53527
+3453694:
+  aliases: ['Culex saramaccensis']
+  parents:
+  - 53535
+1131598:
+  aliases: ['Culex sasai']
+  parents:
+  - 53530
+2758408:
+  aliases: ['Culex secundus']
+  parents:
+  - 794814
+1206312:
+  aliases: ['Culex secutor']
+  parents:
+  - 53527
+1426906:
+  aliases: ['Culex serratimarge']
+  parents:
+  - 53535
+2006700:
+  aliases: ['Culex shebbearei']
+  parents:
+  - 53530
+1406360:
+  aliases: ['Culex simpliciforceps']
+  parents:
+  - 53531
+1799676:
+  aliases: ['Culex simpsoni']
+  parents:
+  - 53527
+3453695:
+  aliases: ['Culex simulator']
+  parents:
+  - 53535
+1799677:
+  aliases: ['Culex sinaiticus']
+  parents:
+  - 53527
+162998:
+  aliases: ['Culex sitiens']
+  parents:
+  - 53527
+2912049:
+  aliases: ['Culex sp.']
+  parents:
+  - 3406907
+2448724:
+  aliases: ['Culex sp. 1 CLJ-2018']
+  parents:
+  - 3406907
+507998:
+  aliases: ['Culex sp. 1 NDD-2008']
+  parents:
+  - 3406907
+1803713:
+  aliases: ['Culex sp. 14702-CulexA07']
+  parents:
+  - 3406907
+1803714:
+  aliases: ['Culex sp. 14702-CulexA08']
+  parents:
+  - 3406907
+2665172:
+  aliases: ['Culex sp. 16GH 23-A']
+  parents:
+  - 3406907
+2665173:
+  aliases: ['Culex sp. 16GH 30-2']
+  parents:
+  - 3406907
+2665174:
+  aliases: ['Culex sp. 16GH 30-3']
+  parents:
+  - 3406907
+1803715:
+  aliases: ['Culex sp. 20974_CulexE01']
+  parents:
+  - 3406907
+1874919:
+  aliases: ['Culex sp. 20974_CulicF09']
+  parents:
+  - 3406907
+1803716:
+  aliases: ['Culex sp. 20974_CxwatA04']
+  parents:
+  - 3406907
+1133092:
+  aliases: ['Culex sp. A CMJ-2012']
+  parents:
+  - 3406907
+2665380:
+  aliases: ['Culex sp. APHA162017D12']
+  parents:
+  - 3406907
+2665381:
+  aliases: ['Culex sp. APHA162017E01']
+  parents:
+  - 3406907
+2665385:
+  aliases: ['Culex sp. APHA162017E02']
+  parents:
+  - 3406907
+2665376:
+  aliases: ['Culex sp. APHA162017E03']
+  parents:
+  - 3406907
+2665374:
+  aliases: ['Culex sp. APHA162017E04']
+  parents:
+  - 3406907
+2665375:
+  aliases: ['Culex sp. APHA162017E05']
+  parents:
+  - 3406907
+2665383:
+  aliases: ['Culex sp. APHA162017E06']
+  parents:
+  - 3406907
+2665386:
+  aliases: ['Culex sp. APHA162017E07']
+  parents:
+  - 3406907
+2665379:
+  aliases: ['Culex sp. APHA162017E08']
+  parents:
+  - 3406907
+2665378:
+  aliases: ['Culex sp. APHA162017E09']
+  parents:
+  - 3406907
+2665384:
+  aliases: ['Culex sp. APHA162017E10']
+  parents:
+  - 3406907
+2665382:
+  aliases: ['Culex sp. APHA162017E11']
+  parents:
+  - 3406907
+2665377:
+  aliases: ['Culex sp. APHA162017E12']
+  parents:
+  - 3406907
+1133093:
+  aliases: ['Culex sp. B CMJ-2012']
+  parents:
+  - 3406907
+2315011:
+  aliases: ['Culex sp. BIOUG01402-C08']
+  parents:
+  - 3406907
+2315008:
+  aliases: ['Culex sp. BIOUG01422-D05']
+  parents:
+  - 3406907
+2315005:
+  aliases: ['Culex sp. BIOUG01459-H08']
+  parents:
+  - 3406907
+2315006:
+  aliases: ['Culex sp. BIOUG08803-A08']
+  parents:
+  - 3406907
+2208999:
+  aliases: ['Culex sp. BIOUG17326-G03']
+  parents:
+  - 3406907
+2315004:
+  aliases: ['Culex sp. BIOUG21226-C09']
+  parents:
+  - 3406907
+2315002:
+  aliases: ['Culex sp. BIOUG21357-A11']
+  parents:
+  - 3406907
+2315009:
+  aliases: ['Culex sp. BIOUG25469-C05']
+  parents:
+  - 3406907
+2315012:
+  aliases: ['Culex sp. BIOUG25512-F06']
+  parents:
+  - 3406907
+2315001:
+  aliases: ['Culex sp. BIOUG25514-G02']
+  parents:
+  - 3406907
+2209000:
+  aliases: ['Culex sp. BIOUG26829-A11']
+  parents:
+  - 3406907
+2209001:
+  aliases: ['Culex sp. BIOUG27459-G03']
+  parents:
+  - 3406907
+2315003:
+  aliases: ['Culex sp. BIOUG27632-H09']
+  parents:
+  - 3406907
+2315007:
+  aliases: ['Culex sp. BIOUG28268-A01']
+  parents:
+  - 3406907
+2315010:
+  aliases: ['Culex sp. BIOUG28268-E06']
+  parents:
+  - 3406907
+1888157:
+  aliases: ['Culex sp. BOLD-2016']
+  parents:
+  - 3406907
+1754997:
+  aliases: ['Culex sp. BOLD:AAA7661']
+  parents:
+  - 3406907
+1695053:
+  aliases: ['Culex sp. BOLD:AAB6943']
+  parents:
+  - 3406907
+2658575:
+  aliases: ['Culex sp. BOLD:AAF1735']
+  parents:
+  - 3406907
+1578837:
+  aliases: ['Culex sp. BTLHVDV-2014']
+  parents:
+  - 3406907
+1795401:
+  aliases: ['Culex sp. Boussalem_2']
+  parents:
+  - 3406907
+1795402:
+  aliases: ['Culex sp. Boussalem_4']
+  parents:
+  - 3406907
+1795403:
+  aliases: ['Culex sp. Boussalem_6']
+  parents:
+  - 3406907
+1133094:
+  aliases: ['Culex sp. C CMJ-2012']
+  parents:
+  - 3406907
+1795404:
+  aliases: ['Culex sp. Corsica_1']
+  parents:
+  - 3406907
+1795405:
+  aliases: ['Culex sp. Corsica_2']
+  parents:
+  - 3406907
+1795406:
+  aliases: ['Culex sp. Corsica_3']
+  parents:
+  - 3406907
+2853138:
+  aliases: ['Culex sp. Cx_JM009']
+  parents:
+  - 3406907
+2853137:
+  aliases: ['Culex sp. Cx_JM884']
+  parents:
+  - 3406907
+1133095:
+  aliases: ['Culex sp. D CMJ-2012']
+  parents:
+  - 3406907
+2918772:
+  aliases: ['Culex sp. EM_331']
+  parents:
+  - 3406907
+1233179:
+  aliases: ['Culex sp. EP-2012a']
+  parents:
+  - 3406907
+1233180:
+  aliases: ['Culex sp. EP-2012b']
+  parents:
+  - 3406907
+1795407:
+  aliases: ['Culex sp. Field_2']
+  parents:
+  - 3406907
+1795408:
+  aliases: ['Culex sp. Field_4']
+  parents:
+  - 3406907
+1795409:
+  aliases: ['Culex sp. Field_7']
+  parents:
+  - 3406907
+1874920:
+  aliases: ['Culex sp. GP-A']
+  parents:
+  - 3406907
+1874921:
+  aliases: ['Culex sp. GP-B']
+  parents:
+  - 3406907
+1874922:
+  aliases: ['Culex sp. GP-C']
+  parents:
+  - 3406907
+1795410:
+  aliases: ['Culex sp. Kef_2']
+  parents:
+  - 3406907
+1795411:
+  aliases: ['Culex sp. Kef_3']
+  parents:
+  - 3406907
+1795412:
+  aliases: ['Culex sp. Kef_4']
+  parents:
+  - 3406907
+1795413:
+  aliases: ['Culex sp. Kef_6']
+  parents:
+  - 3406907
+2931914:
+  aliases: ['Culex sp. M15']
+  parents:
+  - 3406907
+2931916:
+  aliases: ['Culex sp. M17']
+  parents:
+  - 3406907
+2931917:
+  aliases: ['Culex sp. M2A']
+  parents:
+  - 3406907
+2931918:
+  aliases: ['Culex sp. M2B']
+  parents:
+  - 3406907
+342877:
+  aliases: ['Culex sp. M42']
+  parents:
+  - 3406907
+342878:
+  aliases: ['Culex sp. M43']
+  parents:
+  - 3406907
+342879:
+  aliases: ['Culex sp. M44']
+  parents:
+  - 3406907
+342880:
+  aliases: ['Culex sp. M45']
+  parents:
+  - 3406907
+342881:
+  aliases: ['Culex sp. M46']
+  parents:
+  - 3406907
+342882:
+  aliases: ['Culex sp. M47']
+  parents:
+  - 3406907
+1803717:
+  aliases: ['Culex sp. M47YA']
+  parents:
+  - 3406907
+342883:
+  aliases: ['Culex sp. M54']
+  parents:
+  - 3406907
+342884:
+  aliases: ['Culex sp. M58']
+  parents:
+  - 3406907
+1803718:
+  aliases: ['Culex sp. M63YA']
+  parents:
+  - 3406907
+342885:
+  aliases: ['Culex sp. M67']
+  parents:
+  - 3406907
+342886:
+  aliases: ['Culex sp. M68']
+  parents:
+  - 3406907
+342887:
+  aliases: ['Culex sp. M69']
+  parents:
+  - 3406907
+1803719:
+  aliases: ['Culex sp. M70YA']
+  parents:
+  - 3406907
+342888:
+  aliases: ['Culex sp. M71']
+  parents:
+  - 3406907
+1803720:
+  aliases: ['Culex sp. M71YA']
+  parents:
+  - 3406907
+1803721:
+  aliases: ['Culex sp. M75YA']
+  parents:
+  - 3406907
+2931913:
+  aliases: ['Culex sp. M9']
+  parents:
+  - 3406907
+2821152:
+  aliases: ['Culex sp. Marks #32']
+  parents:
+  - 3406907
+1795414:
+  aliases: ['Culex sp. Mateur_1']
+  parents:
+  - 3406907
+1795415:
+  aliases: ['Culex sp. Mateur_2']
+  parents:
+  - 3406907
+1795416:
+  aliases: ['Culex sp. Mateur_3']
+  parents:
+  - 3406907
+2715101:
+  aliases: ['Culex sp. Na591']
+  parents:
+  - 3406907
+2292623:
+  aliases: ['Culex sp. O103']
+  parents:
+  - 3406907
+1795417:
+  aliases: ['Culex sp. Quest_1']
+  parents:
+  - 3406907
+1795418:
+  aliases: ['Culex sp. Quest_2']
+  parents:
+  - 3406907
+1795419:
+  aliases: ['Culex sp. Quest_3']
+  parents:
+  - 3406907
+1803722:
+  aliases: ['Culex sp. R32']
+  parents:
+  - 3406907
+1803723:
+  aliases: ['Culex sp. R33']
+  parents:
+  - 3406907
+1803724:
+  aliases: ['Culex sp. R34']
+  parents:
+  - 3406907
+1803725:
+  aliases: ['Culex sp. R73']
+  parents:
+  - 3406907
+2609014:
+  aliases: ['Culex sp. RDC6']
+  parents:
+  - 3406907
+2588652:
+  aliases: ['Culex sp. RP-2019-10']
+  parents:
+  - 3406907
+2588653:
+  aliases: ['Culex sp. RP-2019-11']
+  parents:
+  - 3406907
+2588654:
+  aliases: ['Culex sp. RP-2019-12']
+  parents:
+  - 3406907
+2588655:
+  aliases: ['Culex sp. RP-2019-15']
+  parents:
+  - 3406907
+2588645:
+  aliases: ['Culex sp. RP-2019-3']
+  parents:
+  - 3406907
+2588646:
+  aliases: ['Culex sp. RP-2019-4']
+  parents:
+  - 3406907
+2588647:
+  aliases: ['Culex sp. RP-2019-5']
+  parents:
+  - 3406907
+2588648:
+  aliases: ['Culex sp. RP-2019-6']
+  parents:
+  - 3406907
+2588649:
+  aliases: ['Culex sp. RP-2019-7']
+  parents:
+  - 3406907
+2588650:
+  aliases: ['Culex sp. RP-2019-8']
+  parents:
+  - 3406907
+2588651:
+  aliases: ['Culex sp. RP-2019-9']
+  parents:
+  - 3406907
+2562605:
+  aliases: ['Culex sp. S59']
+  parents:
+  - 3406907
+1576577:
+  aliases: ['Culex sp. SOKN051']
+  parents:
+  - 3406907
+1750489:
+  aliases: ['Culex sp. SSEIA4880-13']
+  parents:
+  - 3406907
+1795420:
+  aliases: ['Culex sp. Souala_1']
+  parents:
+  - 3406907
+1795421:
+  aliases: ['Culex sp. Souala_2']
+  parents:
+  - 3406907
+1795422:
+  aliases: ['Culex sp. Souala_3']
+  parents:
+  - 3406907
+1803726:
+  aliases: ['Culex sp. T15']
+  parents:
+  - 3406907
+1803727:
+  aliases: ['Culex sp. T16']
+  parents:
+  - 3406907
+2827231:
+  aliases: ['Culex sp. ZCCK 015']
+  parents:
+  - 3406907
+2827232:
+  aliases: ['Culex sp. ZCRK 181']
+  parents:
+  - 3406907
+1677834:
+  aliases: ['Culex sp. ZFMK PR011-Colombia']
+  parents:
+  - 3406907
+1677835:
+  aliases: ['Culex sp. ZFMK PR024-Colombia']
+  parents:
+  - 3406907
+1677836:
+  aliases: ['Culex sp. ZFMK PR028-Colombia']
+  parents:
+  - 3406907
+1677837:
+  aliases: ['Culex sp. ZFMK PR031-Colombia']
+  parents:
+  - 3406907
+1677838:
+  aliases: ['Culex sp. ZFMK PR033-Colombia']
+  parents:
+  - 3406907
+1677839:
+  aliases: ['Culex sp. ZFMK PR035-Colombia']
+  parents:
+  - 3406907
+1677840:
+  aliases: ['Culex sp. ZFMK PR036-Colombia']
+  parents:
+  - 3406907
+1677841:
+  aliases: ['Culex sp. ZFMK PR041-Colombia']
+  parents:
+  - 3406907
+1677842:
+  aliases: ['Culex sp. ZFMK PR043-Colombia']
+  parents:
+  - 3406907
+1677843:
+  aliases: ['Culex sp. ZFMK PR045-Colombia']
+  parents:
+  - 3406907
+1677844:
+  aliases: ['Culex sp. ZFMK PR075-Colombia']
+  parents:
+  - 3406907
+3018959:
+  aliases: ['Culex sp. n.']
+  parents:
+  - 3406907
+2814812:
+  aliases: ['Culex sp. n. 1 DS-2021']
+  parents:
+  - 3406907
+2007265:
+  aliases: ['Culex sp. stI']
+  parents:
+  - 3406907
+2007266:
+  aliases: ['Culex sp. stJ']
+  parents:
+  - 3406907
+2007267:
+  aliases: ['Culex sp. stK']
+  parents:
+  - 3406907
+2007268:
+  aliases: ['Culex sp. stL']
+  parents:
+  - 3406907
+1245364:
+  aliases: ['Culex spiculosus']
+  parents:
+  - 308715
+3382162:
+  aliases: ['Culex spinifer']
+  parents:
+  - 53535
+1461358:
+  aliases: ['Culex spinosus']
+  parents:
+  - 53527
+284565:
+  aliases: ['Culex spissipes']
+  parents:
+  - 53535
+1905333:
+  aliases: ['Culex squamosus']
+  parents:
+  - 53527
+2884703:
+  aliases: ['Culex starckeae']
+  parents:
+  - 667565
+1481111:
+  aliases: ['Culex stigmatosoma']
+  parents:
+  - 53527
+2007269:
+  aliases: ['Culex stonei']
+  parents:
+  - 707272
+1799678:
+  aliases: ['Culex striatipes']
+  parents:
+  - 53527
+3137932:
+  aliases: ['Culex sumatranus']
+  parents:
+  - 308715
+1461359:
+  aliases: ['Culex surinamensis']
+  parents:
+  - 53527
+284566:
+  aliases: ['Culex taeniopus']
+  parents:
+  - 53535
+7177:
+  aliases: ['Culex tarsalis']
+  parents:
+  - 53527
+1461360:
+  aliases: ['Culex tatoi']
+  parents:
+  - 53527
+1406361:
+  aliases: ['Culex telesilla']
+  parents:
+  - 53527
+1799679:
+  aliases: ['Culex tenagius']
+  parents:
+  - 53527
+42431:
+  aliases: ['Culex territans']
+  parents:
+  - 53537
+1799680:
+  aliases: ['Culex terzii']
+  parents:
+  - 53527
+1799681:
+  aliases: ['Culex thalassius']
+  parents:
+  - 53527
+561267:
+  aliases: ['Culex theileri']
+  parents:
+  - 53527
+1677688:
+  aliases: ['Culex theobaldi']
+  parents:
+  - 53535
+871895:
+  aliases: ['Culex thriambus']
+  parents:
+  - 53527
+42433:
+  aliases: ['Culex torrentium']
+  parents:
+  - 53527
+3453696:
+  aliases: ['Culex tournieri']
+  parents:
+  - 53535
+2918768:
+  aliases: ['Culex trifilatus']
+  parents:
+  - 53527
+1899256:
+  aliases: ['Culex trigeminatus']
+  parents:
+  - 53535
+7178:
+  aliases: ['Culex tritaeniorhynchus']
+  parents:
+  - 53527
+1214269:
+  aliases: ['Culex tuberis']
+  parents:
+  - 308715
+3453697:
+  aliases: ['Culex unicornis']
+  parents:
+  - 53535
+498400:
+  aliases: ['Culex uniformis']
+  parents:
+  - 308715
+420550:
+  aliases: ['Culex univittatus']
+  parents:
+  - 53527
+1426907:
+  aliases: ['Culex urichii']
+  parents:
+  - 794814
+2037950:
+  aliases: ['Culex usquatissimus']
+  parents:
+  - 53527
+707283:
+  aliases: ['Culex usquatus']
+  parents:
+  - 53527
+1144254:
+  aliases: ['Culex vagans']
+  parents:
+  - 53527
+1799682:
+  aliases: ['Culex vansomereni']
+  parents:
+  - 53527
+1899257:
+  aliases: ['Culex vaxus']
+  parents:
+  - 53535
+100678:
+  aliases: ['Culex vishnui']
+  parents:
+  - 53527
+1879284:
+  aliases: ['Culex vishnui group sp. GY-2016']
+  parents:
+  - 53527
+284567:
+  aliases: ['Culex vomerifer']
+  parents:
+  - 53535
+1799683:
+  aliases: ['Culex watti']
+  parents:
+  - 53527
+346051:
+  aliases: ['Culex whitmorei']
+  parents:
+  - 53527
+707277:
+  aliases: ['Culex ybarmis']
+  parents:
+  - 53535
+3077183:
+  aliases: ['Culex zabanicus']
+  parents:
+  - 53535
+707278:
+  aliases: ['Culex zeteki']
+  parents:
+  - 53535
+503353:
+  aliases: ['Culex zombaensis']
+  parents:
+  - 53527
+2907304:
+  aliases: ['Culiseta alaskaensis indica']
+  parents:
+  - 1788509
+3025212:
+  aliases: ['Culiseta sp.']
+  parents:
+  - 2619201
+2327011:
+  aliases: ['Culiseta sp. BBDCP560-10']
+  parents:
+  - 2619201
+2327012:
+  aliases: ['Culiseta sp. BBDCP561-10']
+  parents:
+  - 2619201
+2327013:
+  aliases: ['Culiseta sp. BBDCP562-10']
+  parents:
+  - 2619201
+2208866:
+  aliases: ['Culiseta sp. BIOUG06185-C11']
+  parents:
+  - 2619201
+2308357:
+  aliases: ['Culiseta sp. BIOUG26655-D07']
+  parents:
+  - 2619201
+2208867:
+  aliases: ['Culiseta sp. BIOUG27066-F12']
+  parents:
+  - 2619201
+2308358:
+  aliases: ['Culiseta sp. BIOUG30389-D10']
+  parents:
+  - 2619201
+1887097:
+  aliases: ['Culiseta sp. BOLD-2016']
+  parents:
+  - 2619201
+1741585:
+  aliases: ['Culiseta sp. BOLD:AAD3254']
+  parents:
+  - 2619201
+1822827:
+  aliases: ['Culiseta sp. BOLD:AAM8971']
+  parents:
+  - 2619201
+2749912:
+  aliases: ['Haemagogus (Haemagogus) sp. 1 DLL-2018']
+  parents:
+  - 464954
+2800849:
+  aliases: ['Haemagogus albomaculatus']
+  parents:
+  - 464954
+2715204:
+  aliases: ['Haemagogus anastasionis']
+  parents:
+  - 464954
+3153705:
+  aliases: ['Haemagogus capricornii']
+  parents:
+  - 464954
+2715205:
+  aliases: ['Haemagogus celeste']
+  parents:
+  - 464954
+2715206:
+  aliases: ['Haemagogus chalcospilans']
+  parents:
+  - 464954
+53526:
+  aliases: ['Haemagogus equinus']
+  parents:
+  - 464954
+1677689:
+  aliases: ['Haemagogus janthinomys']
+  parents:
+  - 464954
+1170321:
+  aliases: ['Haemagogus leucocelaenus']
+  parents:
+  - 464955
+464953:
+  aliases: ['Haemagogus lucifer']
+  parents:
+  - 464954
+7181:
+  aliases: ['Haemagogus mesodentatus']
+  parents:
+  - 464954
+2772555:
+  aliases: ['Haemagogus sp.']
+  parents:
+  - 3406951
+2820889:
+  aliases: ['Haemagogus sp. Caroni_2019']
+  parents:
+  - 3406951
+2820890:
+  aliases: ['Haemagogus sp. Cumana_2019']
+  parents:
+  - 3406951
+2820893:
+  aliases: ['Haemagogus sp. PtGourde13R_2019']
+  parents:
+  - 3406951
+2820894:
+  aliases: ['Haemagogus sp. PtGourde19R_2019']
+  parents:
+  - 3406951
+2820891:
+  aliases: ['Haemagogus sp. janth3_2006']
+  parents:
+  - 3406951
+2820892:
+  aliases: ['Haemagogus sp. leuco2_2006']
+  parents:
+  - 3406951
+864587:
+  aliases: ['Haemagogus spegazzinii']
+  parents:
+  - 464954
+2800850:
+  aliases: ['Haemagogus tropicalis']
+  parents:
+  - 464954
+2587282:
+  aliases: ['Heizmannia (Mattinglyia) sp. DBNB28']
+  parents:
+  - 317802
+2587275:
+  aliases: ['Heizmannia achaetae']
+  parents:
+  - 317802
+325438:
+  aliases: ['Heizmannia chandi']
+  parents:
+  - 325437
+1245365:
+  aliases: ['Heizmannia chengi']
+  parents:
+  - 325437
+317803:
+  aliases: ['Heizmannia discrepans']
+  parents:
+  - 317802
+1245366:
+  aliases: ['Heizmannia lii']
+  parents:
+  - 325437
+1245367:
+  aliases: ['Heizmannia menglianensis']
+  parents:
+  - 325437
+1245368:
+  aliases: ['Heizmannia proxima']
+  parents:
+  - 325437
+1245369:
+  aliases: ['Heizmannia reidi']
+  parents:
+  - 325437
+2793871:
+  aliases: ['Heizmannia sp. DF34_A_1']
+  parents:
+  - 3406956
+2793872:
+  aliases: ['Heizmannia sp. KR37_U_9']
+  parents:
+  - 3406956
+2793870:
+  aliases: ['Heizmannia sp. M84_A_2']
+  parents:
+  - 3406956
+2853139:
+  aliases: ['Heizmannia sp. P_200_FSTHD']
+  parents:
+  - 3406956
+498624:
+  aliases: ['Lophoscelomyia']
+  parents:
+  - 44483
+2725255:
+  aliases: ['Mansonia (Mansonia) sp. Mu148']
+  parents:
+  - 308734
+667564:
+  aliases: ['Mansonia africana']
+  parents:
+  - 308733
+2597065:
+  aliases: ['Mansonia amazonensis']
+  parents:
+  - 308734
+1041525:
+  aliases: ['Mansonia annulata']
+  parents:
+  - 308733
+308732:
+  aliases: ['Mansonia annulifera']
+  parents:
+  - 308733
+1038078:
+  aliases: ['Mansonia bonneae']
+  parents:
+  - 308733
+149460:
+  aliases: ['Mansonia dives']
+  parents:
+  - 308733
+2663023:
+  aliases: ['Mansonia dyari']
+  parents:
+  - 308734
+1206049:
+  aliases: ['Mansonia flaveola']
+  parents:
+  - 308734
+2993638:
+  aliases: ['Mansonia fonsecai']
+  parents:
+  - 308734
+2742697:
+  aliases: ['Mansonia humeralis']
+  parents:
+  - 308734
+2993639:
+  aliases: ['Mansonia iguassuensis']
+  parents:
+  - 308734
+2035320:
+  aliases: ['Mansonia indiana']
+  parents:
+  - 308733
+2232091:
+  aliases: ['Mansonia indubitans']
+  parents:
+  - 308734
+2951564:
+  aliases: ['Mansonia nr. titillans']
+  parents:
+  - 308734
+873169:
+  aliases: ['Mansonia pseudotitillans']
+  parents:
+  - 308734
+663930:
+  aliases: ['Mansonia septempunctata']
+  parents:
+  - 308733
+2046962:
+  aliases: ['Mansonia sp. (in: mosquitos)']
+  parents:
+  - 1147728
+1147729:
+  aliases: ['Mansonia sp. 1 BR-2012']
+  parents:
+  - 1147728
+1147730:
+  aliases: ['Mansonia sp. 2 BR-2012']
+  parents:
+  - 1147728
+2725256:
+  aliases: ['Mansonia sp. Ca130']
+  parents:
+  - 1147728
+2715100:
+  aliases: ['Mansonia sp. Mu148']
+  parents:
+  - 1147728
+869066:
+  aliases: ['Mansonia titillans']
+  parents:
+  - 308734
+308735:
+  aliases: ['Mansonia uniformis']
+  parents:
+  - 308733
+2027292:
+  aliases: ['Mansonia wilsoni']
+  parents:
+  - 308734
+2900300:
+  aliases: ['Mimomyia aurea']
+  parents:
+  - 308737
+308740:
+  aliases: ['Mimomyia chamberlaini']
+  parents:
+  - 308737
+2918771:
+  aliases: ['Mimomyia hispida']
+  parents:
+  - 308737
+704170:
+  aliases: ['Mimomyia luzonensis']
+  parents:
+  - 308739
+2563599:
+  aliases: ['Mimomyia mediolineata']
+  parents:
+  - 308739
+2563597:
+  aliases: ['Mimomyia mimomyiaformis']
+  parents:
+  - 308737
+2563598:
+  aliases: ['Mimomyia plumosa']
+  parents:
+  - 308737
+2912051:
+  aliases: ['Mimomyia sp.']
+  parents:
+  - 3407012
+1799684:
+  aliases: ['Mimomyia splendens']
+  parents:
+  - 308737
+58250:
+  aliases: ['Myzorhynchus']
+  parents:
+  - 58247
+2725257:
+  aliases: ['Ochlerotatus (Ochlerotatus) sp. 1 DJS-2020']
+  parents:
+  - 53545
+2725258:
+  aliases: ['Ochlerotatus (Ochlerotatus) sp. 2 DJS-2020']
+  parents:
+  - 53545
+329100:
+  aliases: ['Ochlerotatus abserratus']
+  parents:
+  - 53545
+1914896:
+  aliases: ['Ochlerotatus aculeatus']
+  parents:
+  - 53545
+571209:
+  aliases: ['Ochlerotatus albifasciatus']
+  parents:
+  - 53545
+1206301:
+  aliases: ['Ochlerotatus aloponotum']
+  parents:
+  - 53545
+1631547:
+  aliases: ['Ochlerotatus angustivittatus']
+  parents:
+  - 53545
+866103:
+  aliases: ['Ochlerotatus annulipes']
+  parents:
+  - 53545
+2292404:
+  aliases: ['Ochlerotatus antipodeus']
+  parents:
+  - 53545
+71822:
+  aliases: ['Ochlerotatus ashworthi']
+  parents:
+  - 71821
+1205936:
+  aliases: ['Ochlerotatus atlanticus']
+  parents:
+  - 53545
+329101:
+  aliases: ['Ochlerotatus aurifer']
+  parents:
+  - 53545
+71823:
+  aliases: ['Ochlerotatus australis']
+  parents:
+  - 71821
+1214260:
+  aliases: ['Ochlerotatus baisasi']
+  parents:
+  - 346056
+856742:
+  aliases: ['Ochlerotatus bancroftianus']
+  parents:
+  - 346065
+1315220:
+  aliases: ['Ochlerotatus behningi']
+  parents:
+  - 53545
+2579877:
+  aliases: ['Ochlerotatus berlandi']
+  parents:
+  - 53545
+1206034:
+  aliases: ['Ochlerotatus bicristatus']
+  parents:
+  - 190767
+3452916:
+  aliases: ['Ochlerotatus bimaculatus']
+  parents:
+  - 767021
+119226:
+  aliases: ['Ochlerotatus brelandi']
+  parents:
+  - 119225
+1206035:
+  aliases: ['Ochlerotatus burgeri']
+  parents:
+  - 119225
+3048044:
+  aliases: ['Ochlerotatus burpengaryensis']
+  parents:
+  - 53545
+1289171:
+  aliases: ['Ochlerotatus caballus']
+  parents:
+  - 1289136
+909054:
+  aliases: ['Ochlerotatus campestris']
+  parents:
+  - 53545
+644619:
+  aliases: ['Ochlerotatus camptorhynchus']
+  parents:
+  - 53545
+228917:
+  aliases: ['Ochlerotatus canadensis']
+  parents:
+  - 53545
+3014953:
+  aliases: ['Ochlerotatus candidoscutellum']
+  parents:
+  - 767021
+120869:
+  aliases: ['Ochlerotatus cantans']
+  parents:
+  - 53545
+329102:
+  aliases: ['Ochlerotatus cantator']
+  parents:
+  - 53545
+120870:
+  aliases: ['Ochlerotatus caspius']
+  parents:
+  - 53545
+120871:
+  aliases: ['Ochlerotatus cataphylla']
+  parents:
+  - 53545
+1709292:
+  aliases: ['Ochlerotatus cf. cantans/annulipes M18']
+  parents:
+  - 1125803
+1709293:
+  aliases: ['Ochlerotatus cf. cantans/annulipes M19']
+  parents:
+  - 1125803
+1709294:
+  aliases: ['Ochlerotatus cf. cantans/annulipes M20']
+  parents:
+  - 1125803
+1709295:
+  aliases: ['Ochlerotatus cf. cantans/annulipes M21']
+  parents:
+  - 1125803
+1709296:
+  aliases: ['Ochlerotatus cf. cantans/annulipes M22']
+  parents:
+  - 1125803
+1709297:
+  aliases: ['Ochlerotatus cf. cantans/annulipes M23']
+  parents:
+  - 1125803
+1709298:
+  aliases: ['Ochlerotatus cf. cantans/annulipes M25']
+  parents:
+  - 1125803
+1709299:
+  aliases: ['Ochlerotatus cf. cantans/annulipes M26']
+  parents:
+  - 1125803
+1709300:
+  aliases: ['Ochlerotatus cf. cantans/annulipes M27']
+  parents:
+  - 1125803
+1709301:
+  aliases: ['Ochlerotatus cf. cantans/annulipes M28']
+  parents:
+  - 1125803
+1709302:
+  aliases: ['Ochlerotatus cf. cantans/annulipes M29']
+  parents:
+  - 1125803
+1709303:
+  aliases: ['Ochlerotatus cf. cantans/annulipes M30']
+  parents:
+  - 1125803
+1709304:
+  aliases: ['Ochlerotatus cf. cantans/annulipes M31']
+  parents:
+  - 1125803
+1709305:
+  aliases: ['Ochlerotatus cf. cantans/annulipes M34']
+  parents:
+  - 1125803
+1709306:
+  aliases: ['Ochlerotatus cf. cantans/annulipes M35']
+  parents:
+  - 1125803
+3153704:
+  aliases: ['Ochlerotatus cf. serratus/nubilus']
+  parents:
+  - 767021
+2785378:
+  aliases: ['Ochlerotatus chionotum']
+  parents:
+  - 119225
+1315706:
+  aliases: ['Ochlerotatus churchillensis']
+  parents:
+  - 53545
+1969955:
+  aliases: ['Ochlerotatus clelandi']
+  parents:
+  - 53545
+1503992:
+  aliases: ['Ochlerotatus coluzzii']
+  parents:
+  - 53545
+329099:
+  aliases: ['Ochlerotatus communis']
+  parents:
+  - 53545
+1890520:
+  aliases: ['Ochlerotatus communis complex sp. BOLD-2016']
+  parents:
+  - 53545
+2340328:
+  aliases: ['Ochlerotatus communis complex sp. JWDCE418-10']
+  parents:
+  - 1125803
+2340329:
+  aliases: ['Ochlerotatus communis complex sp. JWDCE432-10']
+  parents:
+  - 1125803
+2340330:
+  aliases: ['Ochlerotatus communis complex sp. JWDCE433-10']
+  parents:
+  - 1125803
+2340331:
+  aliases: ['Ochlerotatus communis complex sp. JWDCI262-10']
+  parents:
+  - 1125803
+2340332:
+  aliases: ['Ochlerotatus communis complex sp. JWDCI264-10']
+  parents:
+  - 1125803
+2340333:
+  aliases: ['Ochlerotatus communis complex sp. JWDCJ451-11']
+  parents:
+  - 1125803
+2340334:
+  aliases: ['Ochlerotatus communis complex sp. JWDCJ453-11']
+  parents:
+  - 1125803
+1091056:
+  aliases: ['Ochlerotatus crinifer']
+  parents:
+  - 53545
+662895:
+  aliases: ['Ochlerotatus cyprius']
+  parents:
+  - 53545
+1205937:
+  aliases: ['Ochlerotatus deserticola']
+  parents:
+  - 767021
+120873:
+  aliases: ['Ochlerotatus detritus']
+  parents:
+  - 53545
+1129559:
+  aliases: ['Ochlerotatus diantaeus']
+  parents:
+  - 53545
+1245344:
+  aliases: ['Ochlerotatus dissimilis']
+  parents:
+  - 346058
+663928:
+  aliases: ['Ochlerotatus dorsalis']
+  parents:
+  - 53545
+2067447:
+  aliases: ['Ochlerotatus dupreei']
+  parents:
+  - 1379452
+1712862:
+  aliases: ['Ochlerotatus eatoni']
+  parents:
+  - 767021
+2654761:
+  aliases: ['Ochlerotatus eidsvoldensis']
+  parents:
+  - 767021
+3114449:
+  aliases: ['Ochlerotatus elchoensis']
+  parents:
+  - 346055
+173086:
+  aliases: ['Ochlerotatus epactius']
+  parents:
+  - 53545
+743690:
+  aliases: ['Ochlerotatus euedes']
+  parents:
+  - 53545
+1677690:
+  aliases: ['Ochlerotatus euiris']
+  parents:
+  - 767021
+2863126:
+  aliases: ['Ochlerotatus euplocamus']
+  parents:
+  - 767021
+329103:
+  aliases: ['Ochlerotatus excrucians']
+  parents:
+  - 53545
+743691:
+  aliases: ['Ochlerotatus fitchii']
+  parents:
+  - 53545
+662894:
+  aliases: ['Ochlerotatus flavescens']
+  parents:
+  - 53545
+2321073:
+  aliases: ['Ochlerotatus flavifrons']
+  parents:
+  - 53545
+658031:
+  aliases: ['Ochlerotatus fluviatilis']
+  parents:
+  - 53545
+1285602:
+  aliases: ['Ochlerotatus fulvus']
+  parents:
+  - 1285601
+2785379:
+  aliases: ['Ochlerotatus gabriel']
+  parents:
+  - 119225
+228920:
+  aliases: ['Ochlerotatus grossbecki']
+  parents:
+  - 53545
+1043727:
+  aliases: ['Ochlerotatus harrisoni']
+  parents:
+  - 767021
+2795830:
+  aliases: ['Ochlerotatus hastatus']
+  parents:
+  - 767021
+104516:
+  aliases: ['Ochlerotatus hendersoni']
+  parents:
+  - 119225
+1969954:
+  aliases: ['Ochlerotatus hesperonotius']
+  parents:
+  - 53545
+767797:
+  aliases: ['Ochlerotatus hexodontus']
+  parents:
+  - 53545
+1810856:
+  aliases: ['Ochlerotatus hungaricus']
+  parents:
+  - 53545
+1386052:
+  aliases: ['Ochlerotatus impiger']
+  parents:
+  - 53545
+743692:
+  aliases: ['Ochlerotatus implicatus']
+  parents:
+  - 53545
+1205938:
+  aliases: ['Ochlerotatus increpitus']
+  parents:
+  - 767021
+980429:
+  aliases: ['Ochlerotatus infirmatus']
+  parents:
+  - 53545
+2872821:
+  aliases: ['Ochlerotatus insolitus']
+  parents:
+  - 119225
+228921:
+  aliases: ['Ochlerotatus intrudens']
+  parents:
+  - 53545
+1289137:
+  aliases: ['Ochlerotatus juppi']
+  parents:
+  - 1289136
+1245356:
+  aliases: ['Ochlerotatus kasachstanicus']
+  parents:
+  - 767021
+1788511:
+  aliases: ['Ochlerotatus leucomelas']
+  parents:
+  - 53545
+149331:
+  aliases: ['Ochlerotatus longifilamentus']
+  parents:
+  - 53545
+2900298:
+  aliases: ['Ochlerotatus longirostris']
+  parents:
+  - 345925
+2059239:
+  aliases: ['Ochlerotatus macintoshi']
+  parents:
+  - 767021
+1206302:
+  aliases: ['Ochlerotatus mediovittatus']
+  parents:
+  - 346057
+767022:
+  aliases: ['Ochlerotatus melanimon']
+  parents:
+  - 767021
+1206303:
+  aliases: ['Ochlerotatus mitchellae']
+  parents:
+  - 767021
+1205939:
+  aliases: ['Ochlerotatus monticola']
+  parents:
+  - 767021
+1205940:
+  aliases: ['Ochlerotatus mueller']
+  parents:
+  - 767021
+2321074:
+  aliases: ['Ochlerotatus multiplex']
+  parents:
+  - 346065
+1788512:
+  aliases: ['Ochlerotatus nigrinus']
+  parents:
+  - 53545
+508662:
+  aliases: ['Ochlerotatus nigripes']
+  parents:
+  - 53545
+2792478:
+  aliases: ['Ochlerotatus nigrithorax']
+  parents:
+  - 767021
+767023:
+  aliases: ['Ochlerotatus nigromaculis']
+  parents:
+  - 767021
+1205941:
+  aliases: ['Ochlerotatus niphadopsis']
+  parents:
+  - 767021
+3014954:
+  aliases: ['Ochlerotatus nivalis']
+  parents:
+  - 767021
+666361:
+  aliases: ['Ochlerotatus normanensis']
+  parents:
+  - 53545
+1825799:
+  aliases: ['Ochlerotatus nr. cantans BOLD:AAB1098']
+  parents:
+  - 1125803
+2686177:
+  aliases: ['Ochlerotatus nr. caspius APHA-2-2015C02']
+  parents:
+  - 53545
+2686179:
+  aliases: ['Ochlerotatus nr. caspius APHA-2-2015E08']
+  parents:
+  - 53545
+2686165:
+  aliases: ['Ochlerotatus nr. caspius APHA-2-2015E09']
+  parents:
+  - 53545
+2686178:
+  aliases: ['Ochlerotatus nr. caspius APHA-2-2015E10']
+  parents:
+  - 53545
+2686159:
+  aliases: ['Ochlerotatus nr. caspius APHA-2-2015E11']
+  parents:
+  - 53545
+2686161:
+  aliases: ['Ochlerotatus nr. caspius APHA-2-2015E12']
+  parents:
+  - 53545
+2686163:
+  aliases: ['Ochlerotatus nr. caspius APHA-2-2015F01']
+  parents:
+  - 53545
+2686167:
+  aliases: ['Ochlerotatus nr. caspius APHA-2-2015F02']
+  parents:
+  - 53545
+2686164:
+  aliases: ['Ochlerotatus nr. caspius APHA-2-2015F03']
+  parents:
+  - 53545
+2686174:
+  aliases: ['Ochlerotatus nr. caspius APHA-2-2015F05']
+  parents:
+  - 53545
+2686162:
+  aliases: ['Ochlerotatus nr. caspius APHA-2-2015F06']
+  parents:
+  - 53545
+2686175:
+  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D02']
+  parents:
+  - 53545
+2686181:
+  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D03']
+  parents:
+  - 53545
+2686173:
+  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D04']
+  parents:
+  - 53545
+2686180:
+  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D05']
+  parents:
+  - 53545
+2686168:
+  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D06']
+  parents:
+  - 53545
+2686171:
+  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D07']
+  parents:
+  - 53545
+2686170:
+  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D08']
+  parents:
+  - 53545
+2686160:
+  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D09']
+  parents:
+  - 53545
+2686169:
+  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D10']
+  parents:
+  - 53545
+2686172:
+  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D11']
+  parents:
+  - 53545
+2686166:
+  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D12']
+  parents:
+  - 53545
+2686176:
+  aliases: ['Ochlerotatus nr. caspius APHA-4-2015E02']
+  parents:
+  - 53545
+1825801:
+  aliases: ['Ochlerotatus nr. detritus BOLD:AAM2826']
+  parents:
+  - 1125803
+1825800:
+  aliases: ['Ochlerotatus nr. flavescens BOLD:ACE3017']
+  parents:
+  - 1125803
+2686182:
+  aliases: ['Ochlerotatus nr. punctor APHA-1-2015F03']
+  parents:
+  - 53545
+1206304:
+  aliases: ['Ochlerotatus obturbator']
+  parents:
+  - 767021
+1652500:
+  aliases: ['Ochlerotatus oreophilus']
+  parents:
+  - 767021
+1640878:
+  aliases: ['Ochlerotatus pertinax']
+  parents:
+  - 1379452
+3153703:
+  aliases: ['Ochlerotatus perventor']
+  parents:
+  - 3153702
+1315219:
+  aliases: ['Ochlerotatus pionips']
+  parents:
+  - 53545
+2872822:
+  aliases: ['Ochlerotatus podographicus']
+  parents:
+  - 119225
+376831:
+  aliases: ['Ochlerotatus portonovoensis']
+  parents:
+  - 345925
+1197336:
+  aliases: ['Ochlerotatus procax']
+  parents:
+  - 53545
+743693:
+  aliases: ['Ochlerotatus provocans']
+  parents:
+  - 53545
+1529939:
+  aliases: ['Ochlerotatus pulcritarsis']
+  parents:
+  - 53545
+120876:
+  aliases: ['Ochlerotatus pullatus']
+  parents:
+  - 53545
+1206305:
+  aliases: ['Ochlerotatus punctodes']
+  parents:
+  - 53545
+46209:
+  aliases: ['Ochlerotatus punctor']
+  parents:
+  - 53545
+1890521:
+  aliases: ['Ochlerotatus punctor subgroup sp. BOLD-2016']
+  parents:
+  - 53545
+1829910:
+  aliases: ['Ochlerotatus punctor subgroup sp. BOLD:AAA3748']
+  parents:
+  - 53545
+2740563:
+  aliases: ['Ochlerotatus punctor subgroup sp. L48']
+  parents:
+  - 53545
+2740564:
+  aliases: ['Ochlerotatus punctor subgroup sp. L49']
+  parents:
+  - 53545
+1206306:
+  aliases: ['Ochlerotatus purpureipes']
+  parents:
+  - 346059
+3114451:
+  aliases: ['Ochlerotatus ratcliffei']
+  parents:
+  - 767021
+1788513:
+  aliases: ['Ochlerotatus refiki']
+  parents:
+  - 190767
+1891864:
+  aliases: ['Ochlerotatus rempeli']
+  parents:
+  - 767021
+743694:
+  aliases: ['Ochlerotatus riparius']
+  parents:
+  - 53545
+120877:
+  aliases: ['Ochlerotatus rusticus']
+  parents:
+  - 190767
+1806184:
+  aliases: ['Ochlerotatus sagax']
+  parents:
+  - 53545
+2015797:
+  aliases: ['Ochlerotatus sallumae']
+  parents:
+  - 767021
+2891961:
+  aliases: ['Ochlerotatus sandrae']
+  parents:
+  - 119225
+571210:
+  aliases: ['Ochlerotatus scapularis']
+  parents:
+  - 53545
+1206307:
+  aliases: ['Ochlerotatus schizopinax']
+  parents:
+  - 767021
+873164:
+  aliases: ['Ochlerotatus serratus']
+  parents:
+  - 767021
+2795835:
+  aliases: ['Ochlerotatus serratus group sp. MOSA064']
+  parents:
+  - 1125803
+2795836:
+  aliases: ['Ochlerotatus serratus group sp. MOSA119']
+  parents:
+  - 1125803
+2795837:
+  aliases: ['Ochlerotatus serratus group sp. MOSA131']
+  parents:
+  - 1125803
+1205942:
+  aliases: ['Ochlerotatus sierrensis']
+  parents:
+  - 767021
+3014955:
+  aliases: ['Ochlerotatus silvestris']
+  parents:
+  - 767021
+310513:
+  aliases: ['Ochlerotatus sollicitans']
+  parents:
+  - 53545
+2792002:
+  aliases: ['Ochlerotatus sp.']
+  parents:
+  - 1125803
+2496363:
+  aliases: ['Ochlerotatus sp. 1 CSS-2018']
+  parents:
+  - 1125803
+2715166:
+  aliases: ['Ochlerotatus sp. 15009030']
+  parents:
+  - 1125803
+2715167:
+  aliases: ['Ochlerotatus sp. 15009031']
+  parents:
+  - 1125803
+2715168:
+  aliases: ['Ochlerotatus sp. 16079095']
+  parents:
+  - 1125803
+2715169:
+  aliases: ['Ochlerotatus sp. 16079097']
+  parents:
+  - 1125803
+2715170:
+  aliases: ['Ochlerotatus sp. 16079110']
+  parents:
+  - 1125803
+2715171:
+  aliases: ['Ochlerotatus sp. 16079112']
+  parents:
+  - 1125803
+2715172:
+  aliases: ['Ochlerotatus sp. 16079120']
+  parents:
+  - 1125803
+2715173:
+  aliases: ['Ochlerotatus sp. 16142001']
+  parents:
+  - 1125803
+2715174:
+  aliases: ['Ochlerotatus sp. 16142002']
+  parents:
+  - 1125803
+2715175:
+  aliases: ['Ochlerotatus sp. 16142010']
+  parents:
+  - 1125803
+2715176:
+  aliases: ['Ochlerotatus sp. 16142023']
+  parents:
+  - 1125803
+2715177:
+  aliases: ['Ochlerotatus sp. 16149009']
+  parents:
+  - 1125803
+2496365:
+  aliases: ['Ochlerotatus sp. 2 CSS-2018']
+  parents:
+  - 1125803
+1874498:
+  aliases: ['Ochlerotatus sp. 4DS']
+  parents:
+  - 1125803
+1892536:
+  aliases: ['Ochlerotatus sp. BOLD-2016']
+  parents:
+  - 1125803
+2660540:
+  aliases: ['Ochlerotatus sp. BOLD:AAV4152']
+  parents:
+  - 1125803
+1744826:
+  aliases: ['Ochlerotatus sp. BOLD:ACA3833']
+  parents:
+  - 1125803
+1406130:
+  aliases: ['Ochlerotatus sp. BOLD:ACB9328']
+  parents:
+  - 1125803
+1406131:
+  aliases: ['Ochlerotatus sp. BOLD:ACC8488']
+  parents:
+  - 1125803
+2924065:
+  aliases: ['Ochlerotatus sp. CROBB559']
+  parents:
+  - 1125803
+1125804:
+  aliases: ['Ochlerotatus sp. HANKV_BC_Contig1']
+  parents:
+  - 1125803
+1125805:
+  aliases: ['Ochlerotatus sp. HANKV_BC_Contig2']
+  parents:
+  - 1125803
+1125806:
+  aliases: ['Ochlerotatus sp. HANKV_BC_Contig3']
+  parents:
+  - 1125803
+2751523:
+  aliases: ['Ochlerotatus sp. HK-2020']
+  parents:
+  - 1125803
+1315221:
+  aliases: ['Ochlerotatus sp. NVK-2013']
+  parents:
+  - 1125803
+2593062:
+  aliases: ['Ochlerotatus sp. PANT7-L1']
+  parents:
+  - 1125803
+2593063:
+  aliases: ['Ochlerotatus sp. PANT7-L2']
+  parents:
+  - 1125803
+2853141:
+  aliases: ['Ochlerotatus sp. P_139_FSTST']
+  parents:
+  - 1125803
+2853145:
+  aliases: ['Ochlerotatus sp. P_146_FSTST']
+  parents:
+  - 1125803
+2853144:
+  aliases: ['Ochlerotatus sp. P_194_FSTJD']
+  parents:
+  - 1125803
+2853147:
+  aliases: ['Ochlerotatus sp. P_205_FSTAT']
+  parents:
+  - 1125803
+2853140:
+  aliases: ['Ochlerotatus sp. P_211_FSTAT']
+  parents:
+  - 1125803
+2853148:
+  aliases: ['Ochlerotatus sp. P_268_FSTHT']
+  parents:
+  - 1125803
+2853142:
+  aliases: ['Ochlerotatus sp. P_318_FSTCO']
+  parents:
+  - 1125803
+2853146:
+  aliases: ['Ochlerotatus sp. P_319_FSTCO']
+  parents:
+  - 1125803
+2853143:
+  aliases: ['Ochlerotatus sp. P_327_FSTCO']
+  parents:
+  - 1125803
+1750492:
+  aliases: ['Ochlerotatus sp. SSEIC6970-13']
+  parents:
+  - 1125803
+1205943:
+  aliases: ['Ochlerotatus spencerii']
+  parents:
+  - 767021
+767024:
+  aliases: ['Ochlerotatus squamiger']
+  parents:
+  - 767021
+120878:
+  aliases: ['Ochlerotatus sticticus']
+  parents:
+  - 53545
+2795831:
+  aliases: ['Ochlerotatus stigmaticus']
+  parents:
+  - 767021
+228919:
+  aliases: ['Ochlerotatus stimulans']
+  parents:
+  - 53545
+3114452:
+  aliases: ['Ochlerotatus stricklandi']
+  parents:
+  - 767021
+2292405:
+  aliases: ['Ochlerotatus subalbirostris']
+  parents:
+  - 767021
+2996711:
+  aliases: ['Ochlerotatus surcoufi']
+  parents:
+  - 767021
+329105:
+  aliases: ['Ochlerotatus taeniorhynchus']
+  parents:
+  - 53545
+767025:
+  aliases: ['Ochlerotatus tahoensis']
+  parents:
+  - 767021
+2891962:
+  aliases: ['Ochlerotatus tehuantepec']
+  parents:
+  - 119225
+1828552:
+  aliases: ['Ochlerotatus terrens']
+  parents:
+  - 119225
+1205944:
+  aliases: ['Ochlerotatus thelcter']
+  parents:
+  - 767021
+1197337:
+  aliases: ['Ochlerotatus theobaldi']
+  parents:
+  - 53545
+1205945:
+  aliases: ['Ochlerotatus thibaulti']
+  parents:
+  - 767021
+1379453:
+  aliases: ['Ochlerotatus tormentor']
+  parents:
+  - 1379452
+1205946:
+  aliases: ['Ochlerotatus tortilis']
+  parents:
+  - 767021
+7162:
+  aliases: ['Ochlerotatus triseriatus']
+  parents:
+  - 119225
+228918:
+  aliases: ['Ochlerotatus trivittatus']
+  parents:
+  - 53545
+3114453:
+  aliases: ['Ochlerotatus turneri']
+  parents:
+  - 767021
+2785380:
+  aliases: ['Ochlerotatus vargasi']
+  parents:
+  - 119225
+1205947:
+  aliases: ['Ochlerotatus varipalpus']
+  parents:
+  - 767021
+1205948:
+  aliases: ['Ochlerotatus ventrovittis']
+  parents:
+  - 767021
+569589:
+  aliases: ['Ochlerotatus vigilax']
+  parents:
+  - 53545
+1806185:
+  aliases: ['Ochlerotatus vittiger']
+  parents:
+  - 53545
+71824:
+  aliases: ['Ochlerotatus wardangensis']
+  parents:
+  - 71821
+345926:
+  aliases: ['Ochlerotatus wardi']
+  parents:
+  - 345925
+3014956:
+  aliases: ['Ochlerotatus washinoi']
+  parents:
+  - 767021
+1206036:
+  aliases: ['Ochlerotatus zoosophus']
+  parents:
+  - 119225
+2939154:
+  aliases: ['Onirion sp.']
+  parents:
+  - 2622204
+2007257:
+  aliases: ['Onirion sp. stA']
+  parents:
+  - 2622204
+2853117:
+  aliases: ['Orthopodomyia sp. P_202_FSTJD']
+  parents:
+  - 2853112
+2853113:
+  aliases: ['Orthopodomyia sp. P_274_FSTHT']
+  parents:
+  - 2853112
+2853114:
+  aliases: ['Orthopodomyia sp. P_275_FSTHT']
+  parents:
+  - 2853112
+2853115:
+  aliases: ['Orthopodomyia sp. P_320_FSTCO']
+  parents:
+  - 2853112
+2853116:
+  aliases: ['Orthopodomyia sp. P_324_FSTCO']
+  parents:
+  - 2853112
+3122449:
+  aliases: ['Psorophora sp.']
+  parents:
+  - 3122448
+2232094:
+  aliases: ['Runchomyia sp. RU1']
+  parents:
+  - 2647614
+2927968:
+  aliases: ['Sabethes sp.']
+  parents:
+  - 2646388
+2732043:
+  aliases: ['Sabethes sp. CIST0314']
+  parents:
+  - 2646388
+2007272:
+  aliases: ['Sabethes sp. MB10781']
+  parents:
+  - 2646388
+218602:
+  aliases: ['Sabethes sp. PP-2003']
+  parents:
+  - 2646388
+2007219:
+  aliases: ['Sabethes sp. stD']
+  parents:
+  - 2646388
+2007220:
+  aliases: ['Sabethes sp. stE']
+  parents:
+  - 2646388
+2007221:
+  aliases: ['Sabethes sp. stF']
+  parents:
+  - 2646388
+3123418:
+  aliases: ['Shannoniana sp. n. LMHT-2024']
+  parents:
+  - 3123417
+2872825:
+  aliases: ['Trichoprosopon sp. BOLD:ADL4862']
+  parents:
+  - 2630085
+2007231:
+  aliases: ['Trichoprosopon sp. stG']
+  parents:
+  - 2630085
+2007232:
+  aliases: ['Trichoprosopon sp. stH']
+  parents:
+  - 2630085
+2587283:
+  aliases: ['Tripteroides (Rachionotomyia) sp. NN324']
+  parents:
+  - 325440
+2587278:
+  aliases: ['Tripteroides (Tripteroides) complex sp. 1 MTM-2019']
+  parents:
+  - 3407135
+2587279:
+  aliases: ['Tripteroides (Tripteroides) complex sp. 2 MTM-2019']
+  parents:
+  - 3407135
+1826906:
+  aliases: ['Tripteroides aff. atripes JB-2016']
+  parents:
+  - 1806189
+498401:
+  aliases: ['Tripteroides affinis']
+  parents:
+  - 325440
+325441:
+  aliases: ['Tripteroides aranoides']
+  parents:
+  - 325440
+1806186:
+  aliases: ['Tripteroides atripes']
+  parents:
+  - 1806189
+53568:
+  aliases: ['Tripteroides bambusa']
+  parents:
+  - 325442
+3048045:
+  aliases: ['Tripteroides marksae']
+  parents:
+  - 1806189
+2761493:
+  aliases: ['Tripteroides melanesiensis']
+  parents:
+  - 1806189
+3114456:
+  aliases: ['Tripteroides punctolateralis']
+  parents:
+  - 1806189
+1245371:
+  aliases: ['Tripteroides similis']
+  parents:
+  - 325442
+3435817:
+  aliases: ['Tripteroides sp.']
+  parents:
+  - 3407135
+2793850:
+  aliases: ['Tripteroides sp. 1 HY-2020']
+  parents:
+  - 3407135
+2793851:
+  aliases: ['Tripteroides sp. 2 HY-2020']
+  parents:
+  - 3407135
+2661525:
+  aliases: ['Tripteroides sp. BOLD:AAV4159']
+  parents:
+  - 3407135
+3014977:
+  aliases: ['Tripteroides sylvestris']
+  parents:
+  - 3014975
+1245372:
+  aliases: ['Tripteroides tarsalis']
+  parents:
+  - 325442
+1806187:
+  aliases: ['Tripteroides tasmaniensis']
+  parents:
+  - 1806189
+2793862:
+  aliases: ['Uranotaenia aff. macfarlanei 1 HY-2020']
+  parents:
+  - 3407139
+2793863:
+  aliases: ['Uranotaenia aff. macfarlanei 2 HY-2020']
+  parents:
+  - 3407139
+2681166:
+  aliases: ['Uranotaenia albescens']
+  parents:
+  - 325429
+2038718:
+  aliases: ['Uranotaenia alboabdominalis']
+  parents:
+  - 325429
+1206294:
+  aliases: ['Uranotaenia anhydor']
+  parents:
+  - 325427
+3137933:
+  aliases: ['Uranotaenia annandalei']
+  parents:
+  - 325429
+2795832:
+  aliases: ['Uranotaenia apicalis']
+  parents:
+  - 325429
+2563474:
+  aliases: ['Uranotaenia apicotaeniata']
+  parents:
+  - 325427
+325433:
+  aliases: ['Uranotaenia atra']
+  parents:
+  - 325427
+1551375:
+  aliases: ['Uranotaenia balfouri']
+  parents:
+  - 325429
+325435:
+  aliases: ['Uranotaenia bicolor']
+  parents:
+  - 325429
+2563475:
+  aliases: ['Uranotaenia bilineata']
+  parents:
+  - 325429
+1426908:
+  aliases: ['Uranotaenia calosomata']
+  parents:
+  - 325429
+2891967:
+  aliases: ['Uranotaenia coatzacoalcos']
+  parents:
+  - 325429
+2943530:
+  aliases: ['Uranotaenia connali']
+  parents:
+  - 325429
+2597066:
+  aliases: ['Uranotaenia geometrica']
+  parents:
+  - 325429
+1245375:
+  aliases: ['Uranotaenia jinhongensis']
+  parents:
+  - 325427
+1055898:
+  aliases: ['Uranotaenia lateralis']
+  parents:
+  - 325429
+1424569:
+  aliases: ['Uranotaenia longirostris']
+  parents:
+  - 325429
+190385:
+  aliases: ['Uranotaenia lowii']
+  parents:
+  - 325429
+1245376:
+  aliases: ['Uranotaenia lutescens']
+  parents:
+  - 325427
+1245377:
+  aliases: ['Uranotaenia macfarlanei']
+  parents:
+  - 325429
+487103:
+  aliases: ['Uranotaenia mashonaensis']
+  parents:
+  - 325427
+1424570:
+  aliases: ['Uranotaenia micans']
+  parents:
+  - 325429
+2943531:
+  aliases: ['Uranotaenia micromelas']
+  parents:
+  - 325427
+1245378:
+  aliases: ['Uranotaenia nivipleura']
+  parents:
+  - 325427
+1245379:
+  aliases: ['Uranotaenia novobscura']
+  parents:
+  - 325427
+2758658:
+  aliases: ['Uranotaenia obscura']
+  parents:
+  - 325427
+2563476:
+  aliases: ['Uranotaenia philonuxia']
+  parents:
+  - 325429
+2721572:
+  aliases: ['Uranotaenia pulcherrima']
+  parents:
+  - 325429
+325428:
+  aliases: ['Uranotaenia recondita']
+  parents:
+  - 325427
+2576294:
+  aliases: ['Uranotaenia rutherfordi']
+  parents:
+  - 325429
+3569225:
+  aliases: ['Uranotaenia ryukyuana']
+  parents:
+  - 325427
+139056:
+  aliases: ['Uranotaenia sapphirina']
+  parents:
+  - 325429
+1206054:
+  aliases: ['Uranotaenia socialis']
+  parents:
+  - 325429
+2905922:
+  aliases: ['Uranotaenia sp.']
+  parents:
+  - 3407139
+2448166:
+  aliases: ['Uranotaenia sp. 1 CLJ-2018']
+  parents:
+  - 3407139
+2793854:
+  aliases: ['Uranotaenia sp. 1 HY-2020']
+  parents:
+  - 3407139
+2576295:
+  aliases: ['Uranotaenia sp. 1 WGDC-2019']
+  parents:
+  - 3407139
+2448167:
+  aliases: ['Uranotaenia sp. 2 CLJ-2018']
+  parents:
+  - 3407139
+2793855:
+  aliases: ['Uranotaenia sp. 2 HY-2020']
+  parents:
+  - 3407139
+2576296:
+  aliases: ['Uranotaenia sp. 2 WGDC-2019']
+  parents:
+  - 3407139
+2931912:
+  aliases: ['Uranotaenia sp. M1']
+  parents:
+  - 3407139
+2931915:
+  aliases: ['Uranotaenia sp. M16']
+  parents:
+  - 3407139
+498402:
+  aliases: ['Uranotaenia stricklandi']
+  parents:
+  - 325427
+2758659:
+  aliases: ['Uranotaenia trilineata']
+  parents:
+  - 325429
+559294:
+  aliases: ['Uranotaenia unguiculata']
+  parents:
+  - 325427
+1424565:
+  aliases: ['Verrallina butleri']
+  parents:
+  - 317810
+3014973:
+  aliases: ['Verrallina carmenti']
+  parents:
+  - 317810
+3137934:
+  aliases: ['Verrallina dux']
+  parents:
+  - 317810
+1590998:
+  aliases: ['Verrallina funerea']
+  parents:
+  - 317810
+317807:
+  aliases: ['Verrallina indica']
+  parents:
+  - 317806
+569591:
+  aliases: ['Verrallina lineata']
+  parents:
+  - 317810
+376830:
+  aliases: ['Verrallina lugubris']
+  parents:
+  - 317810
+1652499:
+  aliases: ['Verrallina nobukonis']
+  parents:
+  - 317809
+498403:
+  aliases: ['Verrallina pseudomediofasciata']
+  parents:
+  - 317806
+2793856:
+  aliases: ['Verrallina sp. 1 HY-2020']
+  parents:
+  - 3407142
+2793857:
+  aliases: ['Verrallina sp. 2 HY-2020']
+  parents:
+  - 3407142
+2793858:
+  aliases: ['Verrallina sp. 3 HY-2020']
+  parents:
+  - 3407142
+3048047:
+  aliases: ['Verrallina sp. Marks No 52']
+  parents:
+  - 3407142
+2761344:
+  aliases: ['Wyeomyia (Phoniomyia) sp.']
+  parents:
+  - 2631130
+2725263:
+  aliases: ['Wyeomyia (Triamyia) sp. 1 DJS-2020']
+  parents:
+  - 2631130
+2872827:
+  aliases: ['Wyeomyia adelpha/guatemala group sp. I LMHT-2021a']
+  parents:
+  - 2631130
+2872828:
+  aliases: ['Wyeomyia adelpha/guatemala group sp. II LMHT-2021a']
+  parents:
+  - 2631130
+2872829:
+  aliases: ['Wyeomyia adelpha/guatemala group sp. III LMHT-2021a']
+  parents:
+  - 2631130
+2872830:
+  aliases: ['Wyeomyia adelpha/guatemala group sp. IV LMHT-2021a']
+  parents:
+  - 2631130
+3240104:
+  aliases: ['Wyeomyia sp. 1 PSR-2024a']
+  parents:
+  - 2631130
+2496362:
+  aliases: ['Wyeomyia sp. 374 CSS-2018']
+  parents:
+  - 2631130
+869061:
+  aliases: ['Wyeomyia sp. BB-2010']
+  parents:
+  - 2631130
+2872826:
+  aliases: ['Wyeomyia sp. BOLD:ADE5359']
+  parents:
+  - 2631130
+2715096:
+  aliases: ['Wyeomyia sp. Mu340']
+  parents:
+  - 2631130
+2903344:
+  aliases: ['Wyeomyia sp. RCH1']
+  parents:
+  - 2631130
+2232095:
+  aliases: ['Wyeomyia sp. WA1']
+  parents:
+  - 2631130
+2715241:
+  aliases: ['Wyeomyia sp. WY1']
+  parents:
+  - 2631130
+2715243:
+  aliases: ['Wyeomyia sp. WY3']
+  parents:
+  - 2631130
+2715242:
+  aliases: ['Wyeomyia sp. Wy2']
+  parents:
+  - 2631130
+2007247:
+  aliases: ['Wyeomyia sp. stB']
+  parents:
+  - 2631130
+2007248:
+  aliases: ['Wyeomyia sp. stC']
+  parents:
+  - 2631130
+44547:
+  aliases: ['albimanus series']
+  parents:
+  - 44544
+58233:
+  aliases: ['albitarsis series']
+  parents:
+  - 44545
+59118:
+  aliases: ['annulipes species complex']
+  parents:
+  - 44536
+185573:
+  aliases: ['ardensis group']
+  parents:
+  - 44536
+44546:
+  aliases: ['argyritarsis series']
+  parents:
+  - 44545
+262670:
+  aliases: ['cinereus group']
+  parents:
+  - 262669
+63408:
+  aliases: ['culicifacies species complex']
+  parents:
+  - 59140
+59141:
+  aliases: ['demeilloni group']
+  parents:
+  - 59140
+59142:
+  aliases: ['funestus group']
+  parents:
+  - 59140
+44542:
+  aliases: ['gambiae species complex']
+  parents:
+  - 44537
+44538:
+  aliases: ['leucosphyrus group']
+  parents:
+  - 44536
+262671:
+  aliases: ['listeri group']
+  parents:
+  - 262669
+412010:
+  aliases: ['longipalpis species complex']
+  parents:
+  - 59140
+702664:
+  aliases: ['longirostris species complex']
+  parents:
+  - 44536
+59153:
+  aliases: ['lungae species complex']
+  parents:
+  - 44536
+59144:
+  aliases: ['minimus group']
+  parents:
+  - 59140
+2971825:
+  aliases: ['nr. Culex mimeticus']
+  parents:
+  - 3406907
+2971826:
+  aliases: ['nr. Culex tsengi']
+  parents:
+  - 3406907
+44548:
+  aliases: ['oswaldoi series']
+  parents:
+  - 44544
+44541:
+  aliases: ['punctulatus species complex']
+  parents:
+  - 44536
+59159:
+  aliases: ['subpictus species complex']
+  parents:
+  - 44537
+199889:
+  aliases: ['sundaicus species complex']
+  parents:
+  - 44537
+3398453:
+  aliases: ['unclassified Aedes (in: mosquitos, subgenus)']
+  parents:
+  - 149531
+2989694:
+  aliases: ['unclassified Culiciomyia']
+  parents:
+  - 53530
+2793860:
+  aliases: ['unclassified Lophoceraomyia']
+  parents:
+  - 308715
+2730094:
+  aliases: ['unclassified Myzomyia']
+  parents:
+  - 59140
+3398455:
+  aliases: ['unclassified Ochlerotatus (in: mosquitos, subgenus)']
+  parents:
+  - 53545
+3022036:
+  aliases: ['unclassified Stegomyia']
+  parents:
+  - 53541
+3022037:
+  aliases: ['Aedes (Stegomyia) sp.']
+  parents:
+  - 3022036
+2778558:
+  aliases: ['Aedes (Stegomyia) sp. KNP17MP639']
+  parents:
+  - 3022036
+1424507:
+  aliases: ['Aedes aegypti aegypti']
+  parents:
+  - 7159
+1769044:
+  aliases: ['Aedes aegypti formosus']
+  parents:
+  - 7159
+1214272:
+  aliases: ['Aedes aureostriatus okinawanus']
+  parents:
+  - 1214259
+1214273:
+  aliases: ['Aedes aureostriatus taiwanus']
+  parents:
+  - 1214259
+1214274:
+  aliases: ['Aedes flavopictus downsi']
+  parents:
+  - 166586
+1214275:
+  aliases: ['Aedes flavopictus miyarai']
+  parents:
+  - 166586
+2603929:
+  aliases: ['Aedes gardnerii imitator']
+  parents:
+  - 2603928
+706478:
+  aliases: ['Aedes japonicus amamiensis']
+  parents:
+  - 140438
+140439:
+  aliases: ['Aedes japonicus japonicus']
+  parents:
+  - 140438
+706479:
+  aliases: ['Aedes japonicus shintienensis']
+  parents:
+  - 140438
+706480:
+  aliases: ['Aedes japonicus yaeyamensis']
+  parents:
+  - 140438
+3398456:
+  aliases: ['Aedes sp. annulipes/cantans JVDB-2025']
+  parents:
+  - 3398455
+3398454:
+  aliases: ['Aedes sp. cinereus/geminus JVDB-2025']
+  parents:
+  - 3398453
+1214271:
+  aliases: ['Aedes vexans nipponii']
+  parents:
+  - 7163
+569585:
+  aliases: ['Aedes vexans nocturnus']
+  parents:
+  - 7163
+93947:
+  aliases: ['Anopheles aconitus']
+  parents:
+  - 59144
+2730970:
+  aliases: ['Anopheles aff. barbirostris A3']
+  parents:
+  - 58250
+3241327:
+  aliases: ['Anopheles aff. maculatus B MB-2024a']
+  parents:
+  - 74868
+2249359:
+  aliases: ['Anopheles aff. peryassui NECH295']
+  parents:
+  - 58248
+2249360:
+  aliases: ['Anopheles aff. peryassui NECH773']
+  parents:
+  - 58248
+2108331:
+  aliases: ['Anopheles aff. subpictus A SC-2018']
+  parents:
+  - 59159
+667066:
+  aliases: ['Anopheles aff. takasagoensis KTT-2009']
+  parents:
+  - 44538
+7167:
+  aliases: ['Anopheles albimanus']
+  parents:
+  - 44547
+1411912:
+  aliases: ['Anopheles algeriensis']
+  parents:
+  - 44484
+1962413:
+  aliases: ['Anopheles annularis sensu lato 524']
+  parents:
+  - 59162
+376584:
+  aliases: ['Anopheles annulipes']
+  parents:
+  - 59118
+59119:
+  aliases: ['Anopheles annulipes A']
+  parents:
+  - 59118
+59120:
+  aliases: ['Anopheles annulipes B']
+  parents:
+  - 59118
+376585:
+  aliases: ['Anopheles annulipes C']
+  parents:
+  - 59118
+59121:
+  aliases: ['Anopheles annulipes D']
+  parents:
+  - 59118
+376586:
+  aliases: ['Anopheles annulipes E']
+  parents:
+  - 59118
+376587:
+  aliases: ['Anopheles annulipes F']
+  parents:
+  - 59118
+59122:
+  aliases: ['Anopheles annulipes G']
+  parents:
+  - 59118
+376588:
+  aliases: ['Anopheles annulipes H']
+  parents:
+  - 59118
+376589:
+  aliases: ['Anopheles annulipes I']
+  parents:
+  - 59118
+376590:
+  aliases: ['Anopheles annulipes J']
+  parents:
+  - 59118
+376591:
+  aliases: ['Anopheles annulipes K']
+  parents:
+  - 59118
+376592:
+  aliases: ['Anopheles annulipes L']
+  parents:
+  - 59118
+376593:
+  aliases: ['Anopheles annulipes M']
+  parents:
+  - 59118
+376594:
+  aliases: ['Anopheles annulipes N']
+  parents:
+  - 59118
+376595:
+  aliases: ['Anopheles annulipes O']
+  parents:
+  - 59118
+376596:
+  aliases: ['Anopheles annulipes P']
+  parents:
+  - 59118
+376597:
+  aliases: ['Anopheles annulipes Q']
+  parents:
+  - 59118
+410740:
+  aliases: ['Anopheles annulipes s.l. JEB-2006']
+  parents:
+  - 59118
+7173:
+  aliases: ['Anopheles arabiensis']
+  parents:
+  - 44542
+2730971:
+  aliases: ['Anopheles barbirostris sensu lato GE']
+  parents:
+  - 58250
+42896:
+  aliases: ['Anopheles bwambae']
+  parents:
+  - 44542
+2807518:
+  aliases: ['Anopheles cf. coustani']
+  parents:
+  - 58250
+626351:
+  aliases: ['Anopheles cf. funestus BS-2009']
+  parents:
+  - 59142
+1141474:
+  aliases: ['Anopheles cf. funestus LN-2012a']
+  parents:
+  - 59142
+1254527:
+  aliases: ['Anopheles cf. funestus MALAF100']
+  parents:
+  - 59142
+1254528:
+  aliases: ['Anopheles cf. funestus MALAF103']
+  parents:
+  - 59142
+1254529:
+  aliases: ['Anopheles cf. funestus MALAF104']
+  parents:
+  - 59142
+1254530:
+  aliases: ['Anopheles cf. funestus MALAF105']
+  parents:
+  - 59142
+1254531:
+  aliases: ['Anopheles cf. funestus MALAF111']
+  parents:
+  - 59142
+1254532:
+  aliases: ['Anopheles cf. funestus MALAF112']
+  parents:
+  - 59142
+1254533:
+  aliases: ['Anopheles cf. funestus MALAF115']
+  parents:
+  - 59142
+1254534:
+  aliases: ['Anopheles cf. funestus MALAF117']
+  parents:
+  - 59142
+1254535:
+  aliases: ['Anopheles cf. funestus MALAF118']
+  parents:
+  - 59142
+1254536:
+  aliases: ['Anopheles cf. funestus MALAF119']
+  parents:
+  - 59142
+1254537:
+  aliases: ['Anopheles cf. funestus MALAF120']
+  parents:
+  - 59142
+1254538:
+  aliases: ['Anopheles cf. funestus MALAF121']
+  parents:
+  - 59142
+1254539:
+  aliases: ['Anopheles cf. funestus MALAF122']
+  parents:
+  - 59142
+1254540:
+  aliases: ['Anopheles cf. funestus MALAF123']
+  parents:
+  - 59142
+1254541:
+  aliases: ['Anopheles cf. funestus MALAF124']
+  parents:
+  - 59142
+1254542:
+  aliases: ['Anopheles cf. funestus MALAF125']
+  parents:
+  - 59142
+1254543:
+  aliases: ['Anopheles cf. funestus MALAF126']
+  parents:
+  - 59142
+1254544:
+  aliases: ['Anopheles cf. funestus MALAF127']
+  parents:
+  - 59142
+1254545:
+  aliases: ['Anopheles cf. funestus MALAF128']
+  parents:
+  - 59142
+1254546:
+  aliases: ['Anopheles cf. funestus MALAF129']
+  parents:
+  - 59142
+1254547:
+  aliases: ['Anopheles cf. funestus MALAF130']
+  parents:
+  - 59142
+1254548:
+  aliases: ['Anopheles cf. funestus MALAF131']
+  parents:
+  - 59142
+1254549:
+  aliases: ['Anopheles cf. funestus MALAF85']
+  parents:
+  - 59142
+1254550:
+  aliases: ['Anopheles cf. funestus MALAF91']
+  parents:
+  - 59142
+1254551:
+  aliases: ['Anopheles cf. funestus MALAF95']
+  parents:
+  - 59142
+1254552:
+  aliases: ['Anopheles cf. funestus MALAF96']
+  parents:
+  - 59142
+1254553:
+  aliases: ['Anopheles cf. funestus MALAF99']
+  parents:
+  - 59142
+1355220:
+  aliases: ['Anopheles cf. funestus SBV-2013']
+  parents:
+  - 59142
+2730095:
+  aliases: ['Anopheles cf. rivulorum']
+  parents:
+  - 2730094
+303176:
+  aliases: ['Anopheles cf. rivulorum CG-2004']
+  parents:
+  - 59142
+1141477:
+  aliases: ['Anopheles cf. rivulorum LN-2012b']
+  parents:
+  - 59142
+1712671:
+  aliases: ['Anopheles cf. rivulorum NFL-2015']
+  parents:
+  - 59142
+120868:
+  aliases: ['Anopheles claviger']
+  parents:
+  - 44484
+2579878:
+  aliases: ['Anopheles claviger sensu lato MLQSR032017C10']
+  parents:
+  - 44484
+2579879:
+  aliases: ['Anopheles claviger sensu lato MLQSR032017C11']
+  parents:
+  - 44484
+2579880:
+  aliases: ['Anopheles claviger sensu lato MLQSR032017C12']
+  parents:
+  - 44484
+2579881:
+  aliases: ['Anopheles claviger sensu lato MLQSR032017D01']
+  parents:
+  - 44484
+2579882:
+  aliases: ['Anopheles claviger sensu lato MLQSR032017D02']
+  parents:
+  - 44484
+2579883:
+  aliases: ['Anopheles claviger sensu lato MLQSR032017D03']
+  parents:
+  - 44484
+2579884:
+  aliases: ['Anopheles claviger sensu lato MLQSR032017D04']
+  parents:
+  - 44484
+2579885:
+  aliases: ['Anopheles claviger sensu lato MLQSR032017D05']
+  parents:
+  - 44484
+2579886:
+  aliases: ['Anopheles claviger sensu lato MLQSR032017D06']
+  parents:
+  - 44484
+2579887:
+  aliases: ['Anopheles claviger sensu lato MQLR-01-2017D03']
+  parents:
+  - 44484
+2579888:
+  aliases: ['Anopheles claviger sensu lato MQLR-01-2017F03']
+  parents:
+  - 44484
+103858:
+  aliases: ['Anopheles clowi']
+  parents:
+  - 44541
+1518534:
+  aliases: ['Anopheles coluzzii']
+  parents:
+  - 44542
+2081834:
+  aliases: ['Anopheles coluzzii x Anopheles gambiae']
+  parents:
+  - 44542
+139723:
+  aliases: ['Anopheles culicifacies']
+  parents:
+  - 63408
+63366:
+  aliases: ['Anopheles culicifacies A']
+  parents:
+  - 63408
+63367:
+  aliases: ['Anopheles culicifacies B']
+  parents:
+  - 63408
+63368:
+  aliases: ['Anopheles culicifacies C']
+  parents:
+  - 63408
+216372:
+  aliases: ['Anopheles culicifacies D']
+  parents:
+  - 63408
+216373:
+  aliases: ['Anopheles culicifacies E']
+  parents:
+  - 63408
+3121305:
+  aliases: ['Anopheles culicifacies complex sp.']
+  parents:
+  - 63408
+484759:
+  aliases: ['Anopheles culicifacies s.l. NPK-2007']
+  parents:
+  - 63408
+115967:
+  aliases: ['Anopheles dispar']
+  parents:
+  - 74868
+138536:
+  aliases: ['Anopheles dravidicus']
+  parents:
+  - 74868
+199890:
+  aliases: ['Anopheles epiroticus']
+  parents:
+  - 199889
+69004:
+  aliases: ['Anopheles farauti']
+  parents:
+  - 44541
+59191:
+  aliases: ['Anopheles farauti No. 4']
+  parents:
+  - 44541
+59192:
+  aliases: ['Anopheles farauti No. 5']
+  parents:
+  - 44541
+59193:
+  aliases: ['Anopheles farauti No. 6']
+  parents:
+  - 44541
+59146:
+  aliases: ['Anopheles filipinae']
+  parents:
+  - 59144
+59147:
+  aliases: ['Anopheles flavirostris']
+  parents:
+  - 59144
+364273:
+  aliases: ['Anopheles fluminensis']
+  parents:
+  - 58248
+2494418:
+  aliases: ['Anopheles fontenillei']
+  parents:
+  - 44542
+320068:
+  aliases: ['Anopheles freyi']
+  parents:
+  - 58250
+62324:
+  aliases: ['Anopheles funestus']
+  parents:
+  - 59142
+1316263:
+  aliases: ['Anopheles funestus s.l. MBC-2013']
+  parents:
+  - 59142
+2763070:
+  aliases: ['Anopheles funestus-like sensu Spillings et al. (2009)']
+  parents:
+  - 59142
+7165:
+  aliases: ['Anopheles gambiae']
+  parents:
+  - 44542
+1975581:
+  aliases: ['Anopheles gambiae x Anopheles arabiensis']
+  parents:
+  - 44542
+1547548:
+  aliases: ['Anopheles gambiae x Anopheles merus']
+  parents:
+  - 44542
+115968:
+  aliases: ['Anopheles greeni']
+  parents:
+  - 74868
+59189:
+  aliases: ['Anopheles hinesorum']
+  parents:
+  - 44541
+667562:
+  aliases: ['Anopheles implexus']
+  parents:
+  - 58249
+498628:
+  aliases: ['Anopheles interruptus']
+  parents:
+  - 498624
+59194:
+  aliases: ['Anopheles irenicus']
+  parents:
+  - 44541
+1962410:
+  aliases: ['Anopheles jamesii sensu lato 145']
+  parents:
+  - 59162
+107326:
+  aliases: ['Anopheles jeyporiensis']
+  parents:
+  - 59144
+30065:
+  aliases: ['Anopheles koliensis']
+  parents:
+  - 44541
+162636:
+  aliases: ['Anopheles leesoni']
+  parents:
+  - 59144
+691885:
+  aliases: ['Anopheles leucosphyrus group Nusa Tenggara Barat species']
+  parents:
+  - 44538
+273150:
+  aliases: ['Anopheles listeri']
+  parents:
+  - 262671
+412009:
+  aliases: ['Anopheles longipalpis']
+  parents:
+  - 412010
+412011:
+  aliases: ['Anopheles longipalpis A']
+  parents:
+  - 412010
+412012:
+  aliases: ['Anopheles longipalpis C']
+  parents:
+  - 412010
+59152:
+  aliases: ['Anopheles longirostris']
+  parents:
+  - 702664
+702665:
+  aliases: ['Anopheles longirostris A NWB-2009']
+  parents:
+  - 702664
+702666:
+  aliases: ['Anopheles longirostris B NWB-2009']
+  parents:
+  - 702664
+702667:
+  aliases: ['Anopheles longirostris C1 NWB-2009']
+  parents:
+  - 702664
+702668:
+  aliases: ['Anopheles longirostris C2 NWB-2009']
+  parents:
+  - 702664
+702669:
+  aliases: ['Anopheles longirostris D NWB-2009']
+  parents:
+  - 702664
+702670:
+  aliases: ['Anopheles longirostris E NWB-2009']
+  parents:
+  - 702664
+702671:
+  aliases: ['Anopheles longirostris F NWB-2009']
+  parents:
+  - 702664
+702672:
+  aliases: ['Anopheles longirostris G NWB-2009']
+  parents:
+  - 702664
+702673:
+  aliases: ['Anopheles longirostris H NWB-2009']
+  parents:
+  - 702664
+59154:
+  aliases: ['Anopheles lungae']
+  parents:
+  - 59153
+74869:
+  aliases: ['Anopheles maculatus']
+  parents:
+  - 74868
+1962408:
+  aliases: ['Anopheles maculatus sensu lato 4821']
+  parents:
+  - 74868
+1043304:
+  aliases: ['Anopheles malefactor']
+  parents:
+  - 58248
+59156:
+  aliases: ['Anopheles mangyanus']
+  parents:
+  - 59144
+139049:
+  aliases: ['Anopheles mattogrossensis']
+  parents:
+  - 58248
+2803201:
+  aliases: ['Anopheles medialis']
+  parents:
+  - 58248
+184758:
+  aliases: ['Anopheles mediopunctatus']
+  parents:
+  - 58248
+34690:
+  aliases: ['Anopheles melas']
+  parents:
+  - 44542
+30066:
+  aliases: ['Anopheles merus']
+  parents:
+  - 44542
+1579502:
+  aliases: ['Anopheles merus x Anopheles coluzzii']
+  parents:
+  - 44542
+596826:
+  aliases: ['Anopheles minor']
+  parents:
+  - 58248
+373597:
+  aliases: ['Anopheles moucheti bervoetsi']
+  parents:
+  - 186751
+2789022:
+  aliases: ['Anopheles moucheti cf. moucheti']
+  parents:
+  - 186751
+2564025:
+  aliases: ['Anopheles moucheti moucheti']
+  parents:
+  - 186751
+373596:
+  aliases: ['Anopheles moucheti nigeriensis']
+  parents:
+  - 186751
+273151:
+  aliases: ['Anopheles multicolor']
+  parents:
+  - 262671
+301835:
+  aliases: ['Anopheles notanandai']
+  parents:
+  - 74868
+3424146:
+  aliases: ['Anopheles nr. fluminensis']
+  parents:
+  - 58248
+2848159:
+  aliases: ['Anopheles nr. fluminensis AC514-4']
+  parents:
+  - 58248
+1426911:
+  aliases: ['Anopheles nr. fluminensis BOLD:AAI4551']
+  parents:
+  - 58248
+2419673:
+  aliases: ['Anopheles nr. fluminensis G1 MAMS-2018']
+  parents:
+  - 58248
+2419674:
+  aliases: ['Anopheles nr. fluminensis ss MAMS-2018']
+  parents:
+  - 58248
+3424147:
+  aliases: ['Anopheles nr. malefactor']
+  parents:
+  - 58248
+2848160:
+  aliases: ['Anopheles nr. malefactor AC532-3']
+  parents:
+  - 58248
+2848161:
+  aliases: ['Anopheles nr. malefactor AM448-2']
+  parents:
+  - 58248
+2848162:
+  aliases: ['Anopheles nr. malefactor AM449-3']
+  parents:
+  - 58248
+2419675:
+  aliases: ['Anopheles nr. malefactor MAMS-2018']
+  parents:
+  - 58248
+1698798:
+  aliases: ['Anopheles obscurus']
+  parents:
+  - 58250
+308711:
+  aliases: ['Anopheles pallidus']
+  parents:
+  - 59162
+123673:
+  aliases: ['Anopheles pampanai']
+  parents:
+  - 59144
+162637:
+  aliases: ['Anopheles parensis']
+  parents:
+  - 59142
+184770:
+  aliases: ['Anopheles peryassui']
+  parents:
+  - 58248
+205392:
+  aliases: ['Anopheles petragnani']
+  parents:
+  - 44484
+138531:
+  aliases: ['Anopheles pseudowillmori']
+  parents:
+  - 74868
+190378:
+  aliases: ['Anopheles punctimacula']
+  parents:
+  - 58248
+30068:
+  aliases: ['Anopheles punctulatus']
+  parents:
+  - 44541
+34691:
+  aliases: ['Anopheles quadriannulatus']
+  parents:
+  - 44542
+383384:
+  aliases: ['Anopheles rampae']
+  parents:
+  - 74868
+70327:
+  aliases: ['Anopheles rivulorum']
+  parents:
+  - 59142
+142886:
+  aliases: ['Anopheles sawadwongporni']
+  parents:
+  - 74868
+273454:
+  aliases: ['Anopheles sergentii']
+  parents:
+  - 59141
+59155:
+  aliases: ['Anopheles solomonis']
+  parents:
+  - 59153
+468925:
+  aliases: ['Anopheles sp. OPS-2007']
+  parents:
+  - 59144
+38297:
+  aliases: ['Anopheles sp. near punctulatus']
+  parents:
+  - 44541
+410748:
+  aliases: ['Anopheles sp. near punctulatus JEB-2006']
+  parents:
+  - 44541
+59160:
+  aliases: ['Anopheles subpictus']
+  parents:
+  - 59159
+1064590:
+  aliases: ['Anopheles subpictus A MZ-2011']
+  parents:
+  - 59159
+484761:
+  aliases: ['Anopheles subpictus s.l. NPK-2007']
+  parents:
+  - 59159
+34692:
+  aliases: ['Anopheles sundaicus']
+  parents:
+  - 199889
+2778658:
+  aliases: ['Anopheles sundaicus sensu lato D OPS-2020']
+  parents:
+  - 199889
+2995625:
+  aliases: ['Anopheles sundaicus sensu lato sp.']
+  parents:
+  - 199889
+382961:
+  aliases: ['Anopheles superpictus B']
+  parents:
+  - 262673
+59190:
+  aliases: ['Anopheles torresiensis']
+  parents:
+  - 44541
+262672:
+  aliases: ['Anopheles turkhudi']
+  parents:
+  - 262670
+2793312:
+  aliases: ['Anopheles vagus vagus']
+  parents:
+  - 142887
+62325:
+  aliases: ['Anopheles vaneedeni']
+  parents:
+  - 59142
+93948:
+  aliases: ['Anopheles varuna']
+  parents:
+  - 59144
+1300248:
+  aliases: ['Anopheles vinckei']
+  parents:
+  - 185573
+142888:
+  aliases: ['Anopheles willmori']
+  parents:
+  - 74868
+2989695:
+  aliases: ['Culex (Culiciomyia) sp.']
+  parents:
+  - 2989694
+3038203:
+  aliases: ['Culex (Lophoceraomyia) sp.']
+  parents:
+  - 2793860
+2793839:
+  aliases: ['Culex (Lophoceraomyia) sp. 1 HY-2020']
+  parents:
+  - 2793860
+2793840:
+  aliases: ['Culex (Lophoceraomyia) sp. 10 HY-2020']
+  parents:
+  - 2793860
+2793841:
+  aliases: ['Culex (Lophoceraomyia) sp. 11 HY-2020']
+  parents:
+  - 2793860
+2793842:
+  aliases: ['Culex (Lophoceraomyia) sp. 2 HY-2020']
+  parents:
+  - 2793860
+2793843:
+  aliases: ['Culex (Lophoceraomyia) sp. 3 HY-2020']
+  parents:
+  - 2793860
+2793844:
+  aliases: ['Culex (Lophoceraomyia) sp. 4 HY-2020']
+  parents:
+  - 2793860
+2793845:
+  aliases: ['Culex (Lophoceraomyia) sp. 5 HY-2020']
+  parents:
+  - 2793860
+2793846:
+  aliases: ['Culex (Lophoceraomyia) sp. 6 HY-2020']
+  parents:
+  - 2793860
+2793847:
+  aliases: ['Culex (Lophoceraomyia) sp. 7 HY-2020']
+  parents:
+  - 2793860
+2793848:
+  aliases: ['Culex (Lophoceraomyia) sp. 8 HY-2020']
+  parents:
+  - 2793860
+2793849:
+  aliases: ['Culex (Lophoceraomyia) sp. 9 HY-2020']
+  parents:
+  - 2793860
+260110:
+  aliases: ['Culex australicus']
+  parents:
+  - 518105
+1771965:
+  aliases: ['Culex hayashii hayashii']
+  parents:
+  - 1214266
+1214270:
+  aliases: ['Culex hayashii ryukyuanus']
+  parents:
+  - 1214266
+2686152:
+  aliases: ['Culex nr. pipiens APHA-1-2015A11']
+  parents:
+  - 518105
+2686127:
+  aliases: ['Culex nr. pipiens APHA-1-2015B01']
+  parents:
+  - 518105
+2686134:
+  aliases: ['Culex nr. pipiens APHA-1-2015B04']
+  parents:
+  - 518105
+2686155:
+  aliases: ['Culex nr. pipiens APHA-1-2015B05']
+  parents:
+  - 518105
+2686143:
+  aliases: ['Culex nr. pipiens APHA-1-2015B06']
+  parents:
+  - 518105
+2686122:
+  aliases: ['Culex nr. pipiens APHA-1-2015B07']
+  parents:
+  - 518105
+2686150:
+  aliases: ['Culex nr. pipiens APHA-1-2015B10']
+  parents:
+  - 518105
+2686149:
+  aliases: ['Culex nr. pipiens APHA-1-2015B11']
+  parents:
+  - 518105
+2686138:
+  aliases: ['Culex nr. pipiens APHA-1-2015C01']
+  parents:
+  - 518105
+2686146:
+  aliases: ['Culex nr. pipiens APHA-1-2015C02']
+  parents:
+  - 518105
+2686126:
+  aliases: ['Culex nr. pipiens APHA-1-2015C05']
+  parents:
+  - 518105
+2686124:
+  aliases: ['Culex nr. pipiens APHA-1-2015C06']
+  parents:
+  - 518105
+2686157:
+  aliases: ['Culex nr. pipiens APHA-1-2015C07']
+  parents:
+  - 518105
+2686136:
+  aliases: ['Culex nr. pipiens APHA-1-2015C08']
+  parents:
+  - 518105
+2686142:
+  aliases: ['Culex nr. pipiens APHA-1-2015C09']
+  parents:
+  - 518105
+2686125:
+  aliases: ['Culex nr. pipiens APHA-1-2015C10']
+  parents:
+  - 518105
+2686156:
+  aliases: ['Culex nr. pipiens APHA-1-2015C12']
+  parents:
+  - 518105
+2686121:
+  aliases: ['Culex nr. pipiens APHA-1-2015D02']
+  parents:
+  - 518105
+2686148:
+  aliases: ['Culex nr. pipiens APHA-1-2015D03']
+  parents:
+  - 518105
+2686158:
+  aliases: ['Culex nr. pipiens APHA-1-2015D04']
+  parents:
+  - 518105
+2686145:
+  aliases: ['Culex nr. pipiens APHA-1-2015D05']
+  parents:
+  - 518105
+2686147:
+  aliases: ['Culex nr. pipiens APHA-1-2015D07']
+  parents:
+  - 518105
+2686132:
+  aliases: ['Culex nr. pipiens APHA-1-2015G03']
+  parents:
+  - 518105
+2686151:
+  aliases: ['Culex nr. pipiens APHA-10-2015E10']
+  parents:
+  - 518105
+2686153:
+  aliases: ['Culex nr. pipiens APHA-10-2015G02']
+  parents:
+  - 518105
+2686130:
+  aliases: ['Culex nr. pipiens APHA-3-2015G03']
+  parents:
+  - 518105
+2686131:
+  aliases: ['Culex nr. pipiens APHA-3-2015G05']
+  parents:
+  - 518105
+2686137:
+  aliases: ['Culex nr. pipiens APHA-3-2015G06']
+  parents:
+  - 518105
+2686129:
+  aliases: ['Culex nr. pipiens APHA-3-2015G07']
+  parents:
+  - 518105
+2686135:
+  aliases: ['Culex nr. pipiens APHA-3-2015G08']
+  parents:
+  - 518105
+2686123:
+  aliases: ['Culex nr. pipiens APHA-3-2015G09']
+  parents:
+  - 518105
+2686139:
+  aliases: ['Culex nr. pipiens APHA-3-2015G10']
+  parents:
+  - 518105
+2686141:
+  aliases: ['Culex nr. pipiens APHA-3-2015G11']
+  parents:
+  - 518105
+2686133:
+  aliases: ['Culex nr. pipiens APHA-3-2015H01']
+  parents:
+  - 518105
+2686128:
+  aliases: ['Culex nr. pipiens APHA-3-2015H02']
+  parents:
+  - 518105
+2686154:
+  aliases: ['Culex nr. pipiens APHA-3-2015H04']
+  parents:
+  - 518105
+2686140:
+  aliases: ['Culex nr. pipiens APHA-3-2015H07']
+  parents:
+  - 518105
+2686144:
+  aliases: ['Culex nr. pipiens APHA-3-2015H08']
+  parents:
+  - 518105
+7175:
+  aliases: ['Culex pipiens']
+  parents:
+  - 518105
+3018961:
+  aliases: ['Culex pipiens complex sp.']
+  parents:
+  - 518105
+2924060:
+  aliases: ['Culex pipiens complex sp. CROBB162']
+  parents:
+  - 518105
+2924055:
+  aliases: ['Culex pipiens complex sp. CROBB167']
+  parents:
+  - 518105
+2924063:
+  aliases: ['Culex pipiens complex sp. CROBB168']
+  parents:
+  - 518105
+2924053:
+  aliases: ['Culex pipiens complex sp. CROBB169']
+  parents:
+  - 518105
+2924057:
+  aliases: ['Culex pipiens complex sp. CROBB636']
+  parents:
+  - 518105
+2924056:
+  aliases: ['Culex pipiens complex sp. CROBB647']
+  parents:
+  - 518105
+2924062:
+  aliases: ['Culex pipiens complex sp. CROBB649']
+  parents:
+  - 518105
+2924054:
+  aliases: ['Culex pipiens complex sp. CROBB650']
+  parents:
+  - 518105
+2924064:
+  aliases: ['Culex pipiens complex sp. CROBB651']
+  parents:
+  - 518105
+2924059:
+  aliases: ['Culex pipiens complex sp. CROBB652']
+  parents:
+  - 518105
+2924061:
+  aliases: ['Culex pipiens complex sp. CROBB653']
+  parents:
+  - 518105
+2924058:
+  aliases: ['Culex pipiens complex sp. CROBB654']
+  parents:
+  - 518105
+1177198:
+  aliases: ['Culex pipiens complex sp. HZ-2012']
+  parents:
+  - 518105
+1179746:
+  aliases: ['Culex pipiens complex sp. MW-2012']
+  parents:
+  - 518105
+946124:
+  aliases: ['Culex pipiens complex sp. YL-2011']
+  parents:
+  - 518105
+2874183:
+  aliases: ['Culex pipiens sensu lato']
+  parents:
+  - 518105
+2579914:
+  aliases: ['Culex pipiens sensu lato LRMQ-2-2017E07']
+  parents:
+  - 518105
+2579915:
+  aliases: ['Culex pipiens sensu lato LRMQ-2-2017E09']
+  parents:
+  - 518105
+2579889:
+  aliases: ['Culex pipiens sensu lato LRMQ-2-2017F07']
+  parents:
+  - 518105
+2579890:
+  aliases: ['Culex pipiens sensu lato LRMQ-2-2017G02']
+  parents:
+  - 518105
+2579916:
+  aliases: ['Culex pipiens sensu lato LRMQ-2-2017G04']
+  parents:
+  - 518105
+2579891:
+  aliases: ['Culex pipiens sensu lato MLQSR032017A05']
+  parents:
+  - 518105
+2579892:
+  aliases: ['Culex pipiens sensu lato MLQSR032017A06']
+  parents:
+  - 518105
+2579893:
+  aliases: ['Culex pipiens sensu lato MLQSR032017A07']
+  parents:
+  - 518105
+2579894:
+  aliases: ['Culex pipiens sensu lato MLQSR032017B04']
+  parents:
+  - 518105
+2579895:
+  aliases: ['Culex pipiens sensu lato MLQSR032017F04']
+  parents:
+  - 518105
+2579896:
+  aliases: ['Culex pipiens sensu lato MLQSR032017G04']
+  parents:
+  - 518105
+2579897:
+  aliases: ['Culex pipiens sensu lato MLQSR032017G05']
+  parents:
+  - 518105
+2579898:
+  aliases: ['Culex pipiens sensu lato MQLR-01-2017B08']
+  parents:
+  - 518105
+2579899:
+  aliases: ['Culex pipiens sensu lato MQLR-01-2017B09']
+  parents:
+  - 518105
+2579900:
+  aliases: ['Culex pipiens sensu lato MQLR-01-2017C03']
+  parents:
+  - 518105
+2579901:
+  aliases: ['Culex pipiens sensu lato MQLR-01-2017C04']
+  parents:
+  - 518105
+2579902:
+  aliases: ['Culex pipiens sensu lato MQLR-01-2017C05']
+  parents:
+  - 518105
+2579903:
+  aliases: ['Culex pipiens sensu lato MQLR-01-2017C06']
+  parents:
+  - 518105
+2579904:
+  aliases: ['Culex pipiens sensu lato MQLR-01-2017C07']
+  parents:
+  - 518105
+2579905:
+  aliases: ['Culex pipiens sensu lato MQLR-01-2017F11']
+  parents:
+  - 518105
+2579906:
+  aliases: ['Culex pipiens sensu lato MQLR-01-2017F12']
+  parents:
+  - 518105
+2579907:
+  aliases: ['Culex pipiens sensu lato MQLR-01-2017G01']
+  parents:
+  - 518105
+2579908:
+  aliases: ['Culex pipiens sensu lato MQLR-01-2017G07']
+  parents:
+  - 518105
+2579909:
+  aliases: ['Culex pipiens sensu lato MQLR-01-2017G08']
+  parents:
+  - 518105
+2579910:
+  aliases: ['Culex pipiens sensu lato MQLR-01-2017H04']
+  parents:
+  - 518105
+2579911:
+  aliases: ['Culex pipiens sensu lato MQLR-01-2017H06']
+  parents:
+  - 518105
+2579912:
+  aliases: ['Culex pipiens sensu lato MQLR-01-2017H10']
+  parents:
+  - 518105
+2579913:
+  aliases: ['Culex pipiens sensu lato MQLR-01-2017H11']
+  parents:
+  - 518105
+42435:
+  aliases: ['Culex pipiens x Culex quinquefasciatus']
+  parents:
+  - 518105
+7176:
+  aliases: ['Culex quinquefasciatus']
+  parents:
+  - 518105
+329104:
+  aliases: ['Ochlerotatus canadensis canadensis']
+  parents:
+  - 228917
+1712864:
+  aliases: ['Ochlerotatus eatoni hewitti (nomen nudum)']
+  parents:
+  - 1712862
+1712863:
+  aliases: ['Ochlerotatus eatoni krimbasi (nomen nudum)']
+  parents:
+  - 1712862
+2067437:
+  aliases: ['Ochlerotatus fulvus pallens']
+  parents:
+  - 1285602
+2938205:
+  aliases: ['Ochlerotatus pulcritarsis asiaticus']
+  parents:
+  - 1529939
+2498887:
+  aliases: ['Tripteroides bambusa bambusa']
+  parents:
+  - 53568
+2498888:
+  aliases: ['Tripteroides bambusa yaeyamensis']
+  parents:
+  - 53568
+1771966:
+  aliases: ['Uranotaenia novobscura novobscura']
+  parents:
+  - 1245379
+44508:
+  aliases: ['aitkenii group']
+  parents:
+  - 44484
+58234:
+  aliases: ['albitarsis group']
+  parents:
+  - 58233
+59125:
+  aliases: ['albotaeniatus group']
+  parents:
+  - 58250
+348691:
+  aliases: ['annularis species complex']
+  parents:
+  - 59162
+58238:
+  aliases: ['argyritarsis group']
+  parents:
+  - 44546
+59126:
+  aliases: ['bancroftii group']
+  parents:
+  - 58250
+59127:
+  aliases: ['barbirostris group']
+  parents:
+  - 58250
+58235:
+  aliases: ['braziliensis group']
+  parents:
+  - 58233
+59130:
+  aliases: ['coustani group']
+  parents:
+  - 58250
+44512:
+  aliases: ['culiciformis group']
+  parents:
+  - 44484
+44552:
+  aliases: ['darlingi group']
+  parents:
+  - 44546
+409341:
+  aliases: ['elegans subgroup (in: mosquitos)']
+  parents:
+  - 44538
+112264:
+  aliases: ['fluviatilis species complex']
+  parents:
+  - 59144
+409348:
+  aliases: ['hackeri subgroup']
+  parents:
+  - 44538
+59131:
+  aliases: ['hyrcanus group']
+  parents:
+  - 58250
+44539:
+  aliases: ['leucosphyrus subgroup']
+  parents:
+  - 44538
+44513:
+  aliases: ['lindesayi group']
+  parents:
+  - 44484
+44485:
+  aliases: ['maculipennis group']
+  parents:
+  - 44484
+93949:
+  aliases: ['minimus species complex']
+  parents:
+  - 59144
+185574:
+  aliases: ['nili species complex']
+  parents:
+  - 185573
+74870:
+  aliases: ['nivipes species complex']
+  parents:
+  - 59162
+44549:
+  aliases: ['oswaldoi group']
+  parents:
+  - 44548
+58240:
+  aliases: ['pictipennis group']
+  parents:
+  - 44546
+44514:
+  aliases: ['plumbeus group']
+  parents:
+  - 44484
+44516:
+  aliases: ['pseudopunctipennis group']
+  parents:
+  - 44484
+44517:
+  aliases: ['punctipennis group']
+  parents:
+  - 44484
+409342:
+  aliases: ['riparis subgroup']
+  parents:
+  - 44538
+54113:
+  aliases: ['triannulatus group']
+  parents:
+  - 44548
+59134:
+  aliases: ['umbrosus group']
+  parents:
+  - 58250
+1354096:
+  aliases: ['(Anopheles kleini x Anopheles sinensis) x Anopheles kleini']
+  parents:
+  - 59131
+1354097:
+  aliases: ['(Anopheles sinensis x Anopheles kleini) x Anopheles sinensis']
+  parents:
+  - 59131
+2848153:
+  aliases: ['Anopheles aff. albitarsis G TMPO-2021']
+  parents:
+  - 58234
+2419677:
+  aliases: ['Anopheles aff. albitarsis H MAMS-2018']
+  parents:
+  - 58234
+2171924:
+  aliases: ['Anopheles aff. albitarsis H PGF-2018']
+  parents:
+  - 58234
+325439:
+  aliases: ['Anopheles aitkenii']
+  parents:
+  - 44508
+58236:
+  aliases: ['Anopheles albitarsis']
+  parents:
+  - 58234
+352057:
+  aliases: ['Anopheles albitarsis F Brochero et al., 2007']
+  parents:
+  - 58234
+908352:
+  aliases: ['Anopheles albitarsis G Krzywinski et al., 2011']
+  parents:
+  - 58234
+1155478:
+  aliases: ['Anopheles albitarsis H Ruiz-Lopez et al. 2012']
+  parents:
+  - 58234
+1155479:
+  aliases: ['Anopheles albitarsis I Ruiz-Lopez et al. 2012']
+  parents:
+  - 58234
+2719617:
+  aliases: ['Anopheles albitarsis J MTM-2020']
+  parents:
+  - 58234
+1221518:
+  aliases: ['Anopheles albitarsis s.l. MLQ-2012']
+  parents:
+  - 58234
+59163:
+  aliases: ['Anopheles annularis']
+  parents:
+  - 348691
+3121304:
+  aliases: ['Anopheles annularis complex sp.']
+  parents:
+  - 348691
+58241:
+  aliases: ['Anopheles argyritarsis']
+  parents:
+  - 58238
+2848165:
+  aliases: ['Anopheles argyritarsis sensu lato MG180-103']
+  parents:
+  - 58238
+722774:
+  aliases: ['Anopheles atacamensis']
+  parents:
+  - 58240
+190376:
+  aliases: ['Anopheles atropos']
+  parents:
+  - 44485
+48725:
+  aliases: ['Anopheles baimaii']
+  parents:
+  - 44539
+59136:
+  aliases: ['Anopheles bancroftii']
+  parents:
+  - 59126
+2793837:
+  aliases: ['Anopheles barbirostris complex sp. 1 HY-2020']
+  parents:
+  - 59127
+2793838:
+  aliases: ['Anopheles barbirostris complex sp. 2 HY-2020']
+  parents:
+  - 59127
+3230858:
+  aliases: ['Anopheles barbirostris group sp.']
+  parents:
+  - 59127
+1962411:
+  aliases: ['Anopheles barbirostris sensu lato 245']
+  parents:
+  - 59127
+254294:
+  aliases: ['Anopheles belenrae']
+  parents:
+  - 59131
+758765:
+  aliases: ['Anopheles bengalensis']
+  parents:
+  - 44508
+58242:
+  aliases: ['Anopheles braziliensis']
+  parents:
+  - 58235
+1712673:
+  aliases: ['Anopheles cf. coustani 1 NFL-2015']
+  parents:
+  - 59130
+1712674:
+  aliases: ['Anopheles cf. coustani 2 NFL-2015']
+  parents:
+  - 59130
+464762:
+  aliases: ['Anopheles cf. hyrcanus DDN-2007']
+  parents:
+  - 59131
+940851:
+  aliases: ['Anopheles cf. janconnae Gutierrez et al., 2010']
+  parents:
+  - 58234
+2024867:
+  aliases: ['Anopheles cf. janconnae MCAP-2017']
+  parents:
+  - 58234
+908353:
+  aliases: ['Anopheles cf. marajoara/albitarsis G SNM-2010']
+  parents:
+  - 58234
+93952:
+  aliases: ['Anopheles cf. minimus #157']
+  parents:
+  - 93949
+139045:
+  aliases: ['Anopheles coustani']
+  parents:
+  - 59130
+2569797:
+  aliases: ['Anopheles coustani group sp. BNG1032']
+  parents:
+  - 59130
+2569799:
+  aliases: ['Anopheles coustani group sp. BNG147']
+  parents:
+  - 59130
+2569798:
+  aliases: ['Anopheles coustani group sp. BNG4574']
+  parents:
+  - 59130
+2569796:
+  aliases: ['Anopheles coustani group sp. BNG492']
+  parents:
+  - 59130
+2569795:
+  aliases: ['Anopheles coustani group sp. BNG69']
+  parents:
+  - 59130
+3125891:
+  aliases: ['Anopheles coustani sensu lato sp.']
+  parents:
+  - 59130
+123217:
+  aliases: ['Anopheles cracens']
+  parents:
+  - 44539
+3142371:
+  aliases: ['Anopheles culiciformis group sp.']
+  parents:
+  - 44512
+43151:
+  aliases: ['Anopheles darlingi']
+  parents:
+  - 44552
+58243:
+  aliases: ['Anopheles deaneorum']
+  parents:
+  - 58234
+1513311:
+  aliases: ['Anopheles dissidens']
+  parents:
+  - 59127
+184757:
+  aliases: ['Anopheles eiseni']
+  parents:
+  - 44516
+409343:
+  aliases: ['Anopheles elegans']
+  parents:
+  - 409341
+261461:
+  aliases: ['Anopheles engarensis']
+  parents:
+  - 59131
+111615:
+  aliases: ['Anopheles fluviatilis']
+  parents:
+  - 112264
+112265:
+  aliases: ['Anopheles fluviatilis S']
+  parents:
+  - 112264
+112266:
+  aliases: ['Anopheles fluviatilis T']
+  parents:
+  - 112264
+175248:
+  aliases: ['Anopheles fluviatilis U']
+  parents:
+  - 112264
+1073928:
+  aliases: ['Anopheles fluviatilis V']
+  parents:
+  - 112264
+345575:
+  aliases: ['Anopheles fuscicolor']
+  parents:
+  - 59130
+180454:
+  aliases: ['Anopheles gambiae str. PEST']
+  parents:
+  - 7165
+138534:
+  aliases: ['Anopheles hyrcanus']
+  parents:
+  - 59131
+931282:
+  aliases: ['Anopheles hyrcanus group sp. 1 CPE-2010']
+  parents:
+  - 59131
+931283:
+  aliases: ['Anopheles hyrcanus group sp. 2 CPE-2010']
+  parents:
+  - 59131
+931284:
+  aliases: ['Anopheles hyrcanus group sp. 3 CPE-2010']
+  parents:
+  - 59131
+1254524:
+  aliases: ['Anopheles hyrcanus group sp. LL1']
+  parents:
+  - 59131
+1254525:
+  aliases: ['Anopheles hyrcanus group sp. LL2']
+  parents:
+  - 59131
+1254526:
+  aliases: ['Anopheles hyrcanus group sp. LL3']
+  parents:
+  - 59131
+1193693:
+  aliases: ['Anopheles hyrcanus group sp. RZ-2012']
+  parents:
+  - 59131
+1962412:
+  aliases: ['Anopheles hyrcanus sensu lato 2836']
+  parents:
+  - 59131
+337448:
+  aliases: ['Anopheles janconnae']
+  parents:
+  - 58234
+190377:
+  aliases: ['Anopheles judithae']
+  parents:
+  - 44514
+232293:
+  aliases: ['Anopheles junlianensis']
+  parents:
+  - 59131
+296717:
+  aliases: ['Anopheles kleini']
+  parents:
+  - 59131
+232291:
+  aliases: ['Anopheles kunmingensis']
+  parents:
+  - 59131
+138535:
+  aliases: ['Anopheles kweiyangensis']
+  parents:
+  - 59131
+113049:
+  aliases: ['Anopheles liangshanensis']
+  parents:
+  - 59131
+409346:
+  aliases: ['Anopheles macarthuri']
+  parents:
+  - 409342
+58244:
+  aliases: ['Anopheles marajoara']
+  parents:
+  - 58234
+112268:
+  aliases: ['Anopheles minimus']
+  parents:
+  - 93949
+93950:
+  aliases: ['Anopheles minimus A']
+  parents:
+  - 93949
+139059:
+  aliases: ['Anopheles minimus A x Anopheles minimus C']
+  parents:
+  - 93949
+344935:
+  aliases: ['Anopheles minimus A1']
+  parents:
+  - 93949
+344936:
+  aliases: ['Anopheles minimus A2']
+  parents:
+  - 93949
+93951:
+  aliases: ['Anopheles minimus C']
+  parents:
+  - 93949
+344937:
+  aliases: ['Anopheles minimus C1']
+  parents:
+  - 93949
+344938:
+  aliases: ['Anopheles minimus C2']
+  parents:
+  - 93949
+313724:
+  aliases: ['Anopheles minimus D3']
+  parents:
+  - 93949
+131314:
+  aliases: ['Anopheles minimus E']
+  parents:
+  - 93949
+487308:
+  aliases: ['Anopheles minimus s.l. NPK-2007']
+  parents:
+  - 93949
+1962409:
+  aliases: ['Anopheles minimus sensu lato 1775']
+  parents:
+  - 93949
+409349:
+  aliases: ['Anopheles mirans']
+  parents:
+  - 409348
+345576:
+  aliases: ['Anopheles namibiensis']
+  parents:
+  - 59130
+185578:
+  aliases: ['Anopheles nili']
+  parents:
+  - 185574
+185576:
+  aliases: ["Anopheles nili 'oveng form'"]
+  parents:
+  - 185574
+185575:
+  aliases: ['Anopheles nili T']
+  parents:
+  - 185574
+113074:
+  aliases: ['Anopheles nimpe']
+  parents:
+  - 59131
+1284620:
+  aliases: ['Anopheles nitidus']
+  parents:
+  - 59131
+74871:
+  aliases: ['Anopheles nivipes']
+  parents:
+  - 74870
+2171938:
+  aliases: ['Anopheles nr. braziliensis BA50_1_104']
+  parents:
+  - 58235
+58237:
+  aliases: ['Anopheles oryzalimnetes']
+  parents:
+  - 58234
+345577:
+  aliases: ['Anopheles paludis']
+  parents:
+  - 59130
+503459:
+  aliases: ['Anopheles pictipennis']
+  parents:
+  - 58240
+227531:
+  aliases: ['Anopheles plumbeus']
+  parents:
+  - 44514
+456297:
+  aliases: ['Anopheles pseudopictus']
+  parents:
+  - 59131
+46955:
+  aliases: ['Anopheles pseudopunctipennis']
+  parents:
+  - 44516
+3350976:
+  aliases: ['Anopheles pujutensis']
+  parents:
+  - 409348
+251639:
+  aliases: ['Anopheles pullus']
+  parents:
+  - 59131
+377122:
+  aliases: ['Anopheles quadriannulatus A']
+  parents:
+  - 34691
+193510:
+  aliases: ['Anopheles quadriannulatus B']
+  parents:
+  - 34691
+1513312:
+  aliases: ['Anopheles saeungae']
+  parents:
+  - 59127
+252133:
+  aliases: ['Anopheles saperoi']
+  parents:
+  - 59125
+1552952:
+  aliases: ['Anopheles sawyeri']
+  parents:
+  - 58238
+114091:
+  aliases: ['Anopheles scanloni']
+  parents:
+  - 44539
+74873:
+  aliases: ['Anopheles sinensis']
+  parents:
+  - 59131
+1354098:
+  aliases: ['Anopheles sinensis x Anopheles kleini']
+  parents:
+  - 59131
+261159:
+  aliases: ['Anopheles sineroides']
+  parents:
+  - 59131
+190123:
+  aliases: ['Anopheles somalicus']
+  parents:
+  - 185574
+286421:
+  aliases: ['Anopheles sp. YM-2004']
+  parents:
+  - 59131
+409344:
+  aliases: ['Anopheles sulawesi']
+  parents:
+  - 409341
+345579:
+  aliases: ['Anopheles tenebrosus']
+  parents:
+  - 59130
+58253:
+  aliases: ['Anopheles triannulatus']
+  parents:
+  - 54113
+1071030:
+  aliases: ["Anopheles triannulatus 'C' TFSN-2007"]
+  parents:
+  - 54113
+49923:
+  aliases: ['Anopheles walkeri']
+  parents:
+  - 44485
+1214263:
+  aliases: ['Anopheles yaeyamaensis']
+  parents:
+  - 93949
+113050:
+  aliases: ['Anopheles yatsushiroensis']
+  parents:
+  - 59131
+345580:
+  aliases: ['Anopheles ziemanni']
+  parents:
+  - 59130
+233155:
+  aliases: ['Culex pipiens molestus']
+  parents:
+  - 7175
+42434:
+  aliases: ['Culex pipiens pallens']
+  parents:
+  - 7175
+38569:
+  aliases: ['Culex pipiens pipiens']
+  parents:
+  - 7175
+1833972:
+  aliases: ['Culex pipiens pipiens x Culex pipiens molestus']
+  parents:
+  - 7175
+710234:
+  aliases: ['Culex quinquefasciatus quinquefasciatus']
+  parents:
+  - 7176
+59128:
+  aliases: ['barbirostris subgroup']
+  parents:
+  - 59127
+49916:
+  aliases: ['crucians subgroup']
+  parents:
+  - 44517
+409350:
+  aliases: ['dirus species complex']
+  parents:
+  - 44539
+2993839:
+  aliases: ['gigas subgroup']
+  parents:
+  - 44513
+59132:
+  aliases: ['lesteri subgroup']
+  parents:
+  - 59131
+59135:
+  aliases: ['letifer subgroup']
+  parents:
+  - 59134
+59123:
+  aliases: ['leucosphyrus species complex']
+  parents:
+  - 44539
+2993838:
+  aliases: ['lindesayi subgroup']
+  parents:
+  - 44513
+44533:
+  aliases: ['maculipennis species complex']
+  parents:
+  - 44485
+44486:
+  aliases: ['maculipennis subgroup']
+  parents:
+  - 44485
+59133:
+  aliases: ['nigerrimus subgroup']
+  parents:
+  - 59131
+44550:
+  aliases: ['oswaldoi subgroup']
+  parents:
+  - 44549
+49919:
+  aliases: ['punctipennis species complex']
+  parents:
+  - 44517
+44551:
+  aliases: ['strodei subgroup']
+  parents:
+  - 44549
+59129:
+  aliases: ['vanus subgroup']
+  parents:
+  - 59127
+2171925:
+  aliases: ['Anopheles aff. arthuri B PGF-2018']
+  parents:
+  - 44551
+2171926:
+  aliases: ['Anopheles aff. arthuri C PGF-2018']
+  parents:
+  - 44551
+2171927:
+  aliases: ['Anopheles aff. arthuri D PGF-2018']
+  parents:
+  - 44551
+2419678:
+  aliases: ['Anopheles aff. benarrochi B MAMS-2018']
+  parents:
+  - 44551
+2419679:
+  aliases: ['Anopheles aff. benarrochi G1 MAMS-2018']
+  parents:
+  - 44551
+2419680:
+  aliases: ['Anopheles aff. benarrochi G2 MAMS-2018']
+  parents:
+  - 44551
+2171933:
+  aliases: ['Anopheles aff. nuneztovari A PGF-2018']
+  parents:
+  - 44550
+2049327:
+  aliases: ['Anopheles aff. oswaldoi A JFS-2017']
+  parents:
+  - 44550
+2419681:
+  aliases: ['Anopheles aff. oswaldoi A MAMS-2018']
+  parents:
+  - 44550
+2171934:
+  aliases: ['Anopheles aff. oswaldoi A PGF-2018']
+  parents:
+  - 44550
+2049328:
+  aliases: ['Anopheles aff. oswaldoi B JFS-2017']
+  parents:
+  - 44550
+2024868:
+  aliases: ['Anopheles aff. oswaldoi B MCAP-2017']
+  parents:
+  - 44550
+2830292:
+  aliases: ['Anopheles aff. oswaldoi B TMPO-2021a']
+  parents:
+  - 44550
+2171935:
+  aliases: ['Anopheles aff. oswaldoi SPForm PGF-2018']
+  parents:
+  - 44550
+862807:
+  aliases: ['Anopheles albertoi']
+  parents:
+  - 44551
+382438:
+  aliases: ['Anopheles annularis A']
+  parents:
+  - 59163
+74872:
+  aliases: ['Anopheles anthropophagus']
+  parents:
+  - 59132
+42839:
+  aliases: ['Anopheles aquasalis']
+  parents:
+  - 44550
+297585:
+  aliases: ['Anopheles artemievi']
+  parents:
+  - 44533
+862808:
+  aliases: ['Anopheles arthuri']
+  parents:
+  - 44551
+2304035:
+  aliases: ['Anopheles arthuri complex sp. A BDS-2018']
+  parents:
+  - 44551
+2304036:
+  aliases: ['Anopheles arthuri complex sp. B BDS-2018']
+  parents:
+  - 44551
+2304037:
+  aliases: ['Anopheles arthuri complex sp. C BDS-2018']
+  parents:
+  - 44551
+2304038:
+  aliases: ['Anopheles arthuri complex sp. D BDS-2018']
+  parents:
+  - 44551
+1324767:
+  aliases: ['Anopheles arthuri s.l. A MAS-2013']
+  parents:
+  - 44551
+1324768:
+  aliases: ['Anopheles arthuri s.l. B MAS-2013']
+  parents:
+  - 44551
+1324769:
+  aliases: ['Anopheles arthuri s.l. C MAS-2013']
+  parents:
+  - 44551
+1324770:
+  aliases: ['Anopheles arthuri s.l. D MAS-2013']
+  parents:
+  - 44551
+41427:
+  aliases: ['Anopheles atroparvus']
+  parents:
+  - 44533
+49915:
+  aliases: ['Anopheles aztecus']
+  parents:
+  - 44486
+59124:
+  aliases: ['Anopheles balabacensis']
+  parents:
+  - 59123
+112267:
+  aliases: ['Anopheles barbirostris']
+  parents:
+  - 59128
+576155:
+  aliases: ['Anopheles barbirostris subgroup clade I']
+  parents:
+  - 59128
+576156:
+  aliases: ['Anopheles barbirostris subgroup clade II']
+  parents:
+  - 59128
+576157:
+  aliases: ['Anopheles barbirostris subgroup clade III']
+  parents:
+  - 59128
+576158:
+  aliases: ['Anopheles barbirostris subgroup clade IV']
+  parents:
+  - 59128
+3122452:
+  aliases: ['Anopheles barbirostris subgroup sp.']
+  parents:
+  - 59128
+1137571:
+  aliases: ['Anopheles barbumbrosus']
+  parents:
+  - 59129
+210816:
+  aliases: ['Anopheles beklemishevi']
+  parents:
+  - 44533
+43061:
+  aliases: ['Anopheles benarrochi']
+  parents:
+  - 44551
+360405:
+  aliases: ['Anopheles benarrochi B']
+  parents:
+  - 44551
+49917:
+  aliases: ['Anopheles bradleyi']
+  parents:
+  - 49916
+453036:
+  aliases: ['Anopheles campestris']
+  parents:
+  - 59128
+138537:
+  aliases: ['Anopheles crawfordi']
+  parents:
+  - 59132
+281737:
+  aliases: ['Anopheles daciae']
+  parents:
+  - 44533
+7168:
+  aliases: ['Anopheles dirus']
+  parents:
+  - 409350
+3122451:
+  aliases: ['Anopheles dirus complex sp.']
+  parents:
+  - 409350
+881808:
+  aliases: ['Anopheles dirus complex sp. X AP-2010']
+  parents:
+  - 409350
+1962414:
+  aliases: ['Anopheles dirus sensu lato 3856']
+  parents:
+  - 409350
+58245:
+  aliases: ['Anopheles dunhami']
+  parents:
+  - 44550
+49918:
+  aliases: ['Anopheles earlei']
+  parents:
+  - 44486
+2171668:
+  aliases: ['Anopheles eiseni geometricus']
+  parents:
+  - 184757
+53710:
+  aliases: ['Anopheles evansae']
+  parents:
+  - 44550
+58246:
+  aliases: ['Anopheles galvaoi']
+  parents:
+  - 44550
+585440:
+  aliases: ['Anopheles goeldii']
+  parents:
+  - 44550
+2126075:
+  aliases: ['Anopheles hyrcanus ssp. AKJ-2018']
+  parents:
+  - 138534
+658928:
+  aliases: ['Anopheles kleini x Anopheles sinensis']
+  parents:
+  - 296717
+262075:
+  aliases: ['Anopheles koreicus']
+  parents:
+  - 59128
+41428:
+  aliases: ['Anopheles labranchiae']
+  parents:
+  - 44533
+409347:
+  aliases: ['Anopheles latens']
+  parents:
+  - 59123
+109668:
+  aliases: ['Anopheles lesteri']
+  parents:
+  - 59132
+1137572:
+  aliases: ['Anopheles letifer']
+  parents:
+  - 59135
+2751809:
+  aliases: ['Anopheles letifer sensu lato']
+  parents:
+  - 59135
+409345:
+  aliases: ['Anopheles leucosphyrus']
+  parents:
+  - 59123
+2751810:
+  aliases: ['Anopheles leucosphyrus sensu lato']
+  parents:
+  - 59123
+41429:
+  aliases: ['Anopheles maculipennis']
+  parents:
+  - 44533
+2768836:
+  aliases: ['Anopheles maculipennis complex sp. 1 NMR-2020']
+  parents:
+  - 44533
+2768837:
+  aliases: ['Anopheles maculipennis complex sp. 2 NMR-2020']
+  parents:
+  - 44533
+1382457:
+  aliases: ['Anopheles maculipennis complex sp. GB-2013']
+  parents:
+  - 44533
+1578836:
+  aliases: ['Anopheles maculipennis sensu lato BTLHVDV-2014']
+  parents:
+  - 44533
+73142:
+  aliases: ['Anopheles martinius']
+  parents:
+  - 44533
+73143:
+  aliases: ['Anopheles melanoon']
+  parents:
+  - 44533
+41430:
+  aliases: ['Anopheles messeae']
+  parents:
+  - 44533
+2066577:
+  aliases: ['Anopheles messeae x Anopheles daciae']
+  parents:
+  - 44533
+409351:
+  aliases: ['Anopheles nemophilous']
+  parents:
+  - 409350
+209202:
+  aliases: ['Anopheles nigerrimus']
+  parents:
+  - 59133
+30067:
+  aliases: ['Anopheles nuneztovari']
+  parents:
+  - 44550
+2830335:
+  aliases: ['Anopheles nuneztovari sensu lato 1044']
+  parents:
+  - 44550
+2830334:
+  aliases: ['Anopheles nuneztovari sensu lato M5']
+  parents:
+  - 44550
+7172:
+  aliases: ['Anopheles occidentalis']
+  parents:
+  - 44486
+43181:
+  aliases: ['Anopheles oswaldoi']
+  parents:
+  - 44550
+1326106:
+  aliases: ['Anopheles oswaldoi A sensu Ruiz-Lopez et al. (2013)']
+  parents:
+  - 44550
+1326107:
+  aliases: ['Anopheles oswaldoi B sensu Ruiz-Lopez et al. (2013)']
+  parents:
+  - 44550
+1184685:
+  aliases: ['Anopheles oswaldoi s.l. AC18']
+  parents:
+  - 44550
+1221519:
+  aliases: ['Anopheles oswaldoi s.l. MLQ-2012']
+  parents:
+  - 44550
+1290811:
+  aliases: ['Anopheles oswaldoi s.l. PA_15']
+  parents:
+  - 44550
+741735:
+  aliases: ['Anopheles paraliae']
+  parents:
+  - 59132
+206113:
+  aliases: ['Anopheles peditaeniatus']
+  parents:
+  - 59132
+208662:
+  aliases: ['Anopheles persiensis']
+  parents:
+  - 44533
+102899:
+  aliases: ['Anopheles punctipennis']
+  parents:
+  - 49919
+49920:
+  aliases: ['Anopheles punctipennis E']
+  parents:
+  - 49919
+49921:
+  aliases: ['Anopheles punctipennis W']
+  parents:
+  - 49919
+42840:
+  aliases: ['Anopheles rangeli']
+  parents:
+  - 44550
+58252:
+  aliases: ['Anopheles rondoni']
+  parents:
+  - 44551
+72408:
+  aliases: ['Anopheles sacharovi']
+  parents:
+  - 44533
+3076058:
+  aliases: ['Anopheles sarpangensis']
+  parents:
+  - 59128
+284817:
+  aliases: ['Anopheles sp. AkKh10i']
+  parents:
+  - 44533
+284818:
+  aliases: ['Anopheles sp. KoKk10i']
+  parents:
+  - 44533
+284819:
+  aliases: ['Anopheles sp. NuKk1i']
+  parents:
+  - 44533
+470212:
+  aliases: ['Anopheles sp. RiFe30i']
+  parents:
+  - 44533
+474926:
+  aliases: ['Anopheles sp. RiFe51i']
+  parents:
+  - 44533
+2171671:
+  aliases: ['Anopheles striatus']
+  parents:
+  - 44551
+53711:
+  aliases: ['Anopheles strodei']
+  parents:
+  - 44551
+862092:
+  aliases: ['Anopheles strodei s.l. CP form']
+  parents:
+  - 44551
+409352:
+  aliases: ['Anopheles takasagoensis']
+  parents:
+  - 409350
+1285095:
+  aliases: ['Anopheles vanderwulpi']
+  parents:
+  - 59128
+1513313:
+  aliases: ['Anopheles wejchoochotei']
+  parents:
+  - 59128
+2993840:
+  aliases: ['baileyi species complex']
+  parents:
+  - 2993839
+232555:
+  aliases: ['crucians species complex']
+  parents:
+  - 49916
+44531:
+  aliases: ['freeborni species complex']
+  parents:
+  - 44486
+261162:
+  aliases: ['gigas species complex']
+  parents:
+  - 2993839
+261160:
+  aliases: ['lindesayi species complex']
+  parents:
+  - 2993838
+44532:
+  aliases: ['quadrimaculatus species complex']
+  parents:
+  - 44486
+1245357:
+  aliases: ['Anopheles baileyi']
+  parents:
+  - 2993840
+2993841:
+  aliases: ['Anopheles bhutanensis']
+  parents:
+  - 2993840
+232558:
+  aliases: ['Anopheles crucians A']
+  parents:
+  - 232555
+232559:
+  aliases: ['Anopheles crucians B']
+  parents:
+  - 232555
+247656:
+  aliases: ['Anopheles crucians C']
+  parents:
+  - 232555
+247657:
+  aliases: ['Anopheles crucians D']
+  parents:
+  - 232555
+247658:
+  aliases: ['Anopheles crucians E']
+  parents:
+  - 232555
+48724:
+  aliases: ['Anopheles dirus A']
+  parents:
+  - 7168
+7170:
+  aliases: ['Anopheles freeborni']
+  parents:
+  - 44531
+498620:
+  aliases: ['Anopheles gigas']
+  parents:
+  - 261162
+7171:
+  aliases: ['Anopheles hermsi']
+  parents:
+  - 44531
+2993853:
+  aliases: ['Anopheles inthanonensis']
+  parents:
+  - 2993840
+261161:
+  aliases: ['Anopheles lindesayi']
+  parents:
+  - 261160
+2993842:
+  aliases: ['Anopheles monticola']
+  parents:
+  - 2993840
+1708518:
+  aliases: ['Anopheles nilgiricus']
+  parents:
+  - 261160
+7166:
+  aliases: ['Anopheles quadrimaculatus']
+  parents:
+  - 44532
+42377:
+  aliases: ['Anopheles quadrimaculatus A']
+  parents:
+  - 44532
+42378:
+  aliases: ['Anopheles quadrimaculatus B']
+  parents:
+  - 44532
+49922:
+  aliases: ['Anopheles quadrimaculatus C']
+  parents:
+  - 44532
+42379:
+  aliases: ['Anopheles quadrimaculatus C1']
+  parents:
+  - 44532
+42380:
+  aliases: ['Anopheles quadrimaculatus C2']
+  parents:
+  - 44532
+42381:
+  aliases: ['Anopheles quadrimaculatus D']
+  parents:
+  - 44532
+3057578:
+  aliases: ['Anopheles gigas simlensis']
+  parents:
+  - 498620
+373689:
+  aliases: ['Anopheles lindesayi japonicus']
+  parents:
+  - 261161
+9397:
+  aliases: ['Bats']
+  parents: []
+30560:
+  aliases: ['Yangochiroptera']
+  parents:
+  - 9397
+30559:
+  aliases: ['Yinpterochiroptera']
+  parents:
+  - 9397
+1617257:
+  aliases: ['environmental samples']
+  parents:
+  - 9397
+727696:
+  aliases: ['unclassified Chiroptera']
+  parents:
+  - 9397
+2792177:
+  aliases: ['Chiroptera sp. B1002']
+  parents:
+  - 727696
+2792194:
+  aliases: ['Chiroptera sp. B1052']
+  parents:
+  - 727696
+2792202:
+  aliases: ['Chiroptera sp. B1342']
+  parents:
+  - 727696
+2792219:
+  aliases: ['Chiroptera sp. B1345']
+  parents:
+  - 727696
+2792220:
+  aliases: ['Chiroptera sp. B1349']
+  parents:
+  - 727696
+2792184:
+  aliases: ['Chiroptera sp. B1379']
+  parents:
+  - 727696
+2792178:
+  aliases: ['Chiroptera sp. B1398']
+  parents:
+  - 727696
+2792192:
+  aliases: ['Chiroptera sp. B1466']
+  parents:
+  - 727696
+2792198:
+  aliases: ['Chiroptera sp. B159']
+  parents:
+  - 727696
+2792179:
+  aliases: ['Chiroptera sp. B1682']
+  parents:
+  - 727696
+2792180:
+  aliases: ['Chiroptera sp. B1700']
+  parents:
+  - 727696
+2792181:
+  aliases: ['Chiroptera sp. B1707']
+  parents:
+  - 727696
+2792182:
+  aliases: ['Chiroptera sp. B1740']
+  parents:
+  - 727696
+2792173:
+  aliases: ['Chiroptera sp. B265']
+  parents:
+  - 727696
+2792186:
+  aliases: ['Chiroptera sp. B332']
+  parents:
+  - 727696
+2792218:
+  aliases: ['Chiroptera sp. B44']
+  parents:
+  - 727696
+2792174:
+  aliases: ['Chiroptera sp. B469']
+  parents:
+  - 727696
+2792215:
+  aliases: ['Chiroptera sp. B481']
+  parents:
+  - 727696
+2792216:
+  aliases: ['Chiroptera sp. B482']
+  parents:
+  - 727696
+2792191:
+  aliases: ['Chiroptera sp. B651']
+  parents:
+  - 727696
+2792204:
+  aliases: ['Chiroptera sp. B657']
+  parents:
+  - 727696
+2792175:
+  aliases: ['Chiroptera sp. B688']
+  parents:
+  - 727696
+2792207:
+  aliases: ['Chiroptera sp. B774']
+  parents:
+  - 727696
+2792188:
+  aliases: ['Chiroptera sp. B789']
+  parents:
+  - 727696
+2792205:
+  aliases: ['Chiroptera sp. B829']
+  parents:
+  - 727696
+2792171:
+  aliases: ['Chiroptera sp. B935']
+  parents:
+  - 727696
+2792176:
+  aliases: ['Chiroptera sp. B955']
+  parents:
+  - 727696
+2792206:
+  aliases: ['Chiroptera sp. B999']
+  parents:
+  - 727696
+816723:
+  aliases: ['Chiroptera sp. BOLD:AAA0002']
+  parents:
+  - 727696
+974259:
+  aliases: ['Chiroptera sp. BOLD:AAA0003']
+  parents:
+  - 727696
+816724:
+  aliases: ['Chiroptera sp. BOLD:AAA0874']
+  parents:
+  - 727696
+816725:
+  aliases: ['Chiroptera sp. BOLD:AAA1218']
+  parents:
+  - 727696
+816726:
+  aliases: ['Chiroptera sp. BOLD:AAA1219']
+  parents:
+  - 727696
+915892:
+  aliases: ['Chiroptera sp. BOLD:AAA1225']
+  parents:
+  - 727696
+816727:
+  aliases: ['Chiroptera sp. BOLD:AAA1245']
+  parents:
+  - 727696
+974260:
+  aliases: ['Chiroptera sp. BOLD:AAA1246']
+  parents:
+  - 727696
+915893:
+  aliases: ['Chiroptera sp. BOLD:AAA1247']
+  parents:
+  - 727696
+974261:
+  aliases: ['Chiroptera sp. BOLD:AAA1248']
+  parents:
+  - 727696
+915894:
+  aliases: ['Chiroptera sp. BOLD:AAA1268']
+  parents:
+  - 727696
+816728:
+  aliases: ['Chiroptera sp. BOLD:AAA1464']
+  parents:
+  - 727696
+915895:
+  aliases: ['Chiroptera sp. BOLD:AAA1465']
+  parents:
+  - 727696
+974262:
+  aliases: ['Chiroptera sp. BOLD:AAA1564']
+  parents:
+  - 727696
+816729:
+  aliases: ['Chiroptera sp. BOLD:AAA1667']
+  parents:
+  - 727696
+915896:
+  aliases: ['Chiroptera sp. BOLD:AAA2133']
+  parents:
+  - 727696
+915897:
+  aliases: ['Chiroptera sp. BOLD:AAA2159']
+  parents:
+  - 727696
+915898:
+  aliases: ['Chiroptera sp. BOLD:AAA2160']
+  parents:
+  - 727696
+816730:
+  aliases: ['Chiroptera sp. BOLD:AAA2242']
+  parents:
+  - 727696
+915899:
+  aliases: ['Chiroptera sp. BOLD:AAA2243']
+  parents:
+  - 727696
+915900:
+  aliases: ['Chiroptera sp. BOLD:AAA2244']
+  parents:
+  - 727696
+974263:
+  aliases: ['Chiroptera sp. BOLD:AAA2245']
+  parents:
+  - 727696
+915901:
+  aliases: ['Chiroptera sp. BOLD:AAA2293']
+  parents:
+  - 727696
+915902:
+  aliases: ['Chiroptera sp. BOLD:AAA2300']
+  parents:
+  - 727696
+915903:
+  aliases: ['Chiroptera sp. BOLD:AAA2332']
+  parents:
+  - 727696
+915904:
+  aliases: ['Chiroptera sp. BOLD:AAA2396']
+  parents:
+  - 727696
+974264:
+  aliases: ['Chiroptera sp. BOLD:AAA2454']
+  parents:
+  - 727696
+915905:
+  aliases: ['Chiroptera sp. BOLD:AAA2524']
+  parents:
+  - 727696
+816731:
+  aliases: ['Chiroptera sp. BOLD:AAA2574']
+  parents:
+  - 727696
+915906:
+  aliases: ['Chiroptera sp. BOLD:AAA2579']
+  parents:
+  - 727696
+915907:
+  aliases: ['Chiroptera sp. BOLD:AAA2648']
+  parents:
+  - 727696
+816732:
+  aliases: ['Chiroptera sp. BOLD:AAA2651']
+  parents:
+  - 727696
+915908:
+  aliases: ['Chiroptera sp. BOLD:AAA2653']
+  parents:
+  - 727696
+915909:
+  aliases: ['Chiroptera sp. BOLD:AAA2705']
+  parents:
+  - 727696
+816733:
+  aliases: ['Chiroptera sp. BOLD:AAA2799']
+  parents:
+  - 727696
+974265:
+  aliases: ['Chiroptera sp. BOLD:AAA2961']
+  parents:
+  - 727696
+974266:
+  aliases: ['Chiroptera sp. BOLD:AAA3113']
+  parents:
+  - 727696
+816734:
+  aliases: ['Chiroptera sp. BOLD:AAA3386']
+  parents:
+  - 727696
+816735:
+  aliases: ['Chiroptera sp. BOLD:AAA3811']
+  parents:
+  - 727696
+891568:
+  aliases: ['Chiroptera sp. BOLD:AAA4089']
+  parents:
+  - 727696
+1296574:
+  aliases: ['Chiroptera sp. BOLD:AAA4092']
+  parents:
+  - 727696
+915910:
+  aliases: ['Chiroptera sp. BOLD:AAA4162']
+  parents:
+  - 727696
+816736:
+  aliases: ['Chiroptera sp. BOLD:AAA4283']
+  parents:
+  - 727696
+974267:
+  aliases: ['Chiroptera sp. BOLD:AAA4430']
+  parents:
+  - 727696
+915911:
+  aliases: ['Chiroptera sp. BOLD:AAA4431']
+  parents:
+  - 727696
+915912:
+  aliases: ['Chiroptera sp. BOLD:AAA4504']
+  parents:
+  - 727696
+974268:
+  aliases: ['Chiroptera sp. BOLD:AAA4512']
+  parents:
+  - 727696
+974269:
+  aliases: ['Chiroptera sp. BOLD:AAA5412']
+  parents:
+  - 727696
+915913:
+  aliases: ['Chiroptera sp. BOLD:AAA5413']
+  parents:
+  - 727696
+915914:
+  aliases: ['Chiroptera sp. BOLD:AAA5616']
+  parents:
+  - 727696
+816737:
+  aliases: ['Chiroptera sp. BOLD:AAA5873']
+  parents:
+  - 727696
+974270:
+  aliases: ['Chiroptera sp. BOLD:AAA5902']
+  parents:
+  - 727696
+816738:
+  aliases: ['Chiroptera sp. BOLD:AAA5920']
+  parents:
+  - 727696
+974271:
+  aliases: ['Chiroptera sp. BOLD:AAA6041']
+  parents:
+  - 727696
+974272:
+  aliases: ['Chiroptera sp. BOLD:AAA6103']
+  parents:
+  - 727696
+816739:
+  aliases: ['Chiroptera sp. BOLD:AAA6105']
+  parents:
+  - 727696
+915915:
+  aliases: ['Chiroptera sp. BOLD:AAA6335']
+  parents:
+  - 727696
+1067767:
+  aliases: ['Chiroptera sp. BOLD:AAA6350']
+  parents:
+  - 727696
+915916:
+  aliases: ['Chiroptera sp. BOLD:AAA6450']
+  parents:
+  - 727696
+1158966:
+  aliases: ['Chiroptera sp. BOLD:AAA6452']
+  parents:
+  - 727696
+915917:
+  aliases: ['Chiroptera sp. BOLD:AAA6499']
+  parents:
+  - 727696
+915918:
+  aliases: ['Chiroptera sp. BOLD:AAA7459']
+  parents:
+  - 727696
+915919:
+  aliases: ['Chiroptera sp. BOLD:AAA7734']
+  parents:
+  - 727696
+974273:
+  aliases: ['Chiroptera sp. BOLD:AAA7750']
+  parents:
+  - 727696
+816740:
+  aliases: ['Chiroptera sp. BOLD:AAA7783']
+  parents:
+  - 727696
+974274:
+  aliases: ['Chiroptera sp. BOLD:AAA8314']
+  parents:
+  - 727696
+915920:
+  aliases: ['Chiroptera sp. BOLD:AAA8683']
+  parents:
+  - 727696
+816741:
+  aliases: ['Chiroptera sp. BOLD:AAA8747']
+  parents:
+  - 727696
+891570:
+  aliases: ['Chiroptera sp. BOLD:AAA8748']
+  parents:
+  - 727696
+1067768:
+  aliases: ['Chiroptera sp. BOLD:AAA8809']
+  parents:
+  - 727696
+915921:
+  aliases: ['Chiroptera sp. BOLD:AAA9061']
+  parents:
+  - 727696
+816742:
+  aliases: ['Chiroptera sp. BOLD:AAA9064']
+  parents:
+  - 727696
+974275:
+  aliases: ['Chiroptera sp. BOLD:AAA9090']
+  parents:
+  - 727696
+974276:
+  aliases: ['Chiroptera sp. BOLD:AAA9168']
+  parents:
+  - 727696
+816743:
+  aliases: ['Chiroptera sp. BOLD:AAA9336']
+  parents:
+  - 727696
+915922:
+  aliases: ['Chiroptera sp. BOLD:AAA9642']
+  parents:
+  - 727696
+1067769:
+  aliases: ['Chiroptera sp. BOLD:AAA9800']
+  parents:
+  - 727696
+816744:
+  aliases: ['Chiroptera sp. BOLD:AAA9952']
+  parents:
+  - 727696
+816745:
+  aliases: ['Chiroptera sp. BOLD:AAB1237']
+  parents:
+  - 727696
+974277:
+  aliases: ['Chiroptera sp. BOLD:AAB1868']
+  parents:
+  - 727696
+974278:
+  aliases: ['Chiroptera sp. BOLD:AAB1869']
+  parents:
+  - 727696
+816746:
+  aliases: ['Chiroptera sp. BOLD:AAB2554']
+  parents:
+  - 727696
+974279:
+  aliases: ['Chiroptera sp. BOLD:AAB2719']
+  parents:
+  - 727696
+915923:
+  aliases: ['Chiroptera sp. BOLD:AAB2781']
+  parents:
+  - 727696
+1067770:
+  aliases: ['Chiroptera sp. BOLD:AAB3099']
+  parents:
+  - 727696
+816747:
+  aliases: ['Chiroptera sp. BOLD:AAB3205']
+  parents:
+  - 727696
+974280:
+  aliases: ['Chiroptera sp. BOLD:AAB4238']
+  parents:
+  - 727696
+816748:
+  aliases: ['Chiroptera sp. BOLD:AAB4312']
+  parents:
+  - 727696
+816749:
+  aliases: ['Chiroptera sp. BOLD:AAB4668']
+  parents:
+  - 727696
+816750:
+  aliases: ['Chiroptera sp. BOLD:AAB4801']
+  parents:
+  - 727696
+816751:
+  aliases: ['Chiroptera sp. BOLD:AAB4878']
+  parents:
+  - 727696
+915924:
+  aliases: ['Chiroptera sp. BOLD:AAB5104']
+  parents:
+  - 727696
+915925:
+  aliases: ['Chiroptera sp. BOLD:AAB5595']
+  parents:
+  - 727696
+816752:
+  aliases: ['Chiroptera sp. BOLD:AAB5742']
+  parents:
+  - 727696
+974281:
+  aliases: ['Chiroptera sp. BOLD:AAB5743']
+  parents:
+  - 727696
+974282:
+  aliases: ['Chiroptera sp. BOLD:AAB5807']
+  parents:
+  - 727696
+816753:
+  aliases: ['Chiroptera sp. BOLD:AAB5809']
+  parents:
+  - 727696
+974283:
+  aliases: ['Chiroptera sp. BOLD:AAB5823']
+  parents:
+  - 727696
+915926:
+  aliases: ['Chiroptera sp. BOLD:AAB6222']
+  parents:
+  - 727696
+1067771:
+  aliases: ['Chiroptera sp. BOLD:AAB6224']
+  parents:
+  - 727696
+974284:
+  aliases: ['Chiroptera sp. BOLD:AAB6385']
+  parents:
+  - 727696
+974285:
+  aliases: ['Chiroptera sp. BOLD:AAB6408']
+  parents:
+  - 727696
+915927:
+  aliases: ['Chiroptera sp. BOLD:AAB6783']
+  parents:
+  - 727696
+816754:
+  aliases: ['Chiroptera sp. BOLD:AAB7229']
+  parents:
+  - 727696
+816755:
+  aliases: ['Chiroptera sp. BOLD:AAB7230']
+  parents:
+  - 727696
+816756:
+  aliases: ['Chiroptera sp. BOLD:AAB8126']
+  parents:
+  - 727696
+891572:
+  aliases: ['Chiroptera sp. BOLD:AAB8309']
+  parents:
+  - 727696
+974286:
+  aliases: ['Chiroptera sp. BOLD:AAB8311']
+  parents:
+  - 727696
+974287:
+  aliases: ['Chiroptera sp. BOLD:AAB9060']
+  parents:
+  - 727696
+816757:
+  aliases: ['Chiroptera sp. BOLD:AAB9061']
+  parents:
+  - 727696
+891573:
+  aliases: ['Chiroptera sp. BOLD:AAB9127']
+  parents:
+  - 727696
+891574:
+  aliases: ['Chiroptera sp. BOLD:AAB9238']
+  parents:
+  - 727696
+974288:
+  aliases: ['Chiroptera sp. BOLD:AAB9572']
+  parents:
+  - 727696
+974289:
+  aliases: ['Chiroptera sp. BOLD:AAB9950']
+  parents:
+  - 727696
+816758:
+  aliases: ['Chiroptera sp. BOLD:AAB9974']
+  parents:
+  - 727696
+816759:
+  aliases: ['Chiroptera sp. BOLD:AAC0085']
+  parents:
+  - 727696
+974290:
+  aliases: ['Chiroptera sp. BOLD:AAC0447']
+  parents:
+  - 727696
+974291:
+  aliases: ['Chiroptera sp. BOLD:AAC0448']
+  parents:
+  - 727696
+816760:
+  aliases: ['Chiroptera sp. BOLD:AAC1209']
+  parents:
+  - 727696
+816761:
+  aliases: ['Chiroptera sp. BOLD:AAC1210']
+  parents:
+  - 727696
+1067772:
+  aliases: ['Chiroptera sp. BOLD:AAC1299']
+  parents:
+  - 727696
+816762:
+  aliases: ['Chiroptera sp. BOLD:AAC1494']
+  parents:
+  - 727696
+816763:
+  aliases: ['Chiroptera sp. BOLD:AAC1895']
+  parents:
+  - 727696
+816764:
+  aliases: ['Chiroptera sp. BOLD:AAC1909']
+  parents:
+  - 727696
+816765:
+  aliases: ['Chiroptera sp. BOLD:AAC2754']
+  parents:
+  - 727696
+915928:
+  aliases: ['Chiroptera sp. BOLD:AAC2864']
+  parents:
+  - 727696
+974292:
+  aliases: ['Chiroptera sp. BOLD:AAC2867']
+  parents:
+  - 727696
+816766:
+  aliases: ['Chiroptera sp. BOLD:AAC2946']
+  parents:
+  - 727696
+816767:
+  aliases: ['Chiroptera sp. BOLD:AAC2947']
+  parents:
+  - 727696
+891575:
+  aliases: ['Chiroptera sp. BOLD:AAC3088']
+  parents:
+  - 727696
+974293:
+  aliases: ['Chiroptera sp. BOLD:AAC3741']
+  parents:
+  - 727696
+974294:
+  aliases: ['Chiroptera sp. BOLD:AAC3742']
+  parents:
+  - 727696
+915929:
+  aliases: ['Chiroptera sp. BOLD:AAC4061']
+  parents:
+  - 727696
+816768:
+  aliases: ['Chiroptera sp. BOLD:AAC4219']
+  parents:
+  - 727696
+816769:
+  aliases: ['Chiroptera sp. BOLD:AAC4846']
+  parents:
+  - 727696
+974295:
+  aliases: ['Chiroptera sp. BOLD:AAC5354']
+  parents:
+  - 727696
+974296:
+  aliases: ['Chiroptera sp. BOLD:AAC5425']
+  parents:
+  - 727696
+816770:
+  aliases: ['Chiroptera sp. BOLD:AAC5514']
+  parents:
+  - 727696
+816771:
+  aliases: ['Chiroptera sp. BOLD:AAC5524']
+  parents:
+  - 727696
+1067773:
+  aliases: ['Chiroptera sp. BOLD:AAC7539']
+  parents:
+  - 727696
+891576:
+  aliases: ['Chiroptera sp. BOLD:AAC8422']
+  parents:
+  - 727696
+974297:
+  aliases: ['Chiroptera sp. BOLD:AAC8894']
+  parents:
+  - 727696
+816772:
+  aliases: ['Chiroptera sp. BOLD:AAC9465']
+  parents:
+  - 727696
+891577:
+  aliases: ['Chiroptera sp. BOLD:AAC9527']
+  parents:
+  - 727696
+974298:
+  aliases: ['Chiroptera sp. BOLD:AAC9705']
+  parents:
+  - 727696
+1067774:
+  aliases: ['Chiroptera sp. BOLD:AAC9992']
+  parents:
+  - 727696
+1067775:
+  aliases: ['Chiroptera sp. BOLD:AAD1297']
+  parents:
+  - 727696
+1067776:
+  aliases: ['Chiroptera sp. BOLD:AAD1601']
+  parents:
+  - 727696
+816773:
+  aliases: ['Chiroptera sp. BOLD:AAD2238']
+  parents:
+  - 727696
+974299:
+  aliases: ['Chiroptera sp. BOLD:AAD3719']
+  parents:
+  - 727696
+915930:
+  aliases: ['Chiroptera sp. BOLD:AAD3874']
+  parents:
+  - 727696
+1067777:
+  aliases: ['Chiroptera sp. BOLD:AAD4873']
+  parents:
+  - 727696
+974300:
+  aliases: ['Chiroptera sp. BOLD:AAD6578']
+  parents:
+  - 727696
+974301:
+  aliases: ['Chiroptera sp. BOLD:AAD6796']
+  parents:
+  - 727696
+816774:
+  aliases: ['Chiroptera sp. BOLD:AAD6797']
+  parents:
+  - 727696
+816775:
+  aliases: ['Chiroptera sp. BOLD:AAD6799']
+  parents:
+  - 727696
+816776:
+  aliases: ['Chiroptera sp. BOLD:AAD7561']
+  parents:
+  - 727696
+816777:
+  aliases: ['Chiroptera sp. BOLD:AAD7720']
+  parents:
+  - 727696
+1067778:
+  aliases: ['Chiroptera sp. BOLD:AAD8132']
+  parents:
+  - 727696
+816778:
+  aliases: ['Chiroptera sp. BOLD:AAD8838']
+  parents:
+  - 727696
+915931:
+  aliases: ['Chiroptera sp. BOLD:AAD9402']
+  parents:
+  - 727696
+915932:
+  aliases: ['Chiroptera sp. BOLD:AAE0577']
+  parents:
+  - 727696
+915933:
+  aliases: ['Chiroptera sp. BOLD:AAE1185']
+  parents:
+  - 727696
+816779:
+  aliases: ['Chiroptera sp. BOLD:AAE3205']
+  parents:
+  - 727696
+974302:
+  aliases: ['Chiroptera sp. BOLD:AAE5107']
+  parents:
+  - 727696
+974303:
+  aliases: ['Chiroptera sp. BOLD:AAE6507']
+  parents:
+  - 727696
+1067779:
+  aliases: ['Chiroptera sp. BOLD:AAE6670']
+  parents:
+  - 727696
+915934:
+  aliases: ['Chiroptera sp. BOLD:AAE7621']
+  parents:
+  - 727696
+974304:
+  aliases: ['Chiroptera sp. BOLD:AAE8331']
+  parents:
+  - 727696
+974305:
+  aliases: ['Chiroptera sp. BOLD:AAF1080']
+  parents:
+  - 727696
+974306:
+  aliases: ['Chiroptera sp. BOLD:AAF3921']
+  parents:
+  - 727696
+816780:
+  aliases: ['Chiroptera sp. BOLD:AAF5010']
+  parents:
+  - 727696
+816781:
+  aliases: ['Chiroptera sp. BOLD:AAF5109']
+  parents:
+  - 727696
+891585:
+  aliases: ['Chiroptera sp. BOLD:AAF5805']
+  parents:
+  - 727696
+1067780:
+  aliases: ['Chiroptera sp. BOLD:AAH8358']
+  parents:
+  - 727696
+816782:
+  aliases: ['Chiroptera sp. BOLD:AAI3440']
+  parents:
+  - 727696
+816783:
+  aliases: ['Chiroptera sp. BOLD:AAI6650']
+  parents:
+  - 727696
+816784:
+  aliases: ['Chiroptera sp. BOLD:AAI8257']
+  parents:
+  - 727696
+974307:
+  aliases: ['Chiroptera sp. BOLD:AAJ0261']
+  parents:
+  - 727696
+816785:
+  aliases: ['Chiroptera sp. BOLD:AAJ2519']
+  parents:
+  - 727696
+974308:
+  aliases: ['Chiroptera sp. BOLD:AAJ2726']
+  parents:
+  - 727696
+974309:
+  aliases: ['Chiroptera sp. BOLD:AAJ3874']
+  parents:
+  - 727696
+816786:
+  aliases: ['Chiroptera sp. BOLD:AAJ4556']
+  parents:
+  - 727696
+974310:
+  aliases: ['Chiroptera sp. BOLD:AAK0536']
+  parents:
+  - 727696
+974311:
+  aliases: ['Chiroptera sp. BOLD:AAK5959']
+  parents:
+  - 727696
+974312:
+  aliases: ['Chiroptera sp. BOLD:AAK6473']
+  parents:
+  - 727696
+816787:
+  aliases: ['Chiroptera sp. BOLD:AAK7760']
+  parents:
+  - 727696
+816788:
+  aliases: ['Chiroptera sp. BOLD:AAK8598']
+  parents:
+  - 727696
+1067781:
+  aliases: ['Chiroptera sp. BOLD:AAK8797']
+  parents:
+  - 727696
+974313:
+  aliases: ['Chiroptera sp. BOLD:AAK9006']
+  parents:
+  - 727696
+816789:
+  aliases: ['Chiroptera sp. BOLD:AAL4116']
+  parents:
+  - 727696
+891589:
+  aliases: ['Chiroptera sp. BOLD:AAL5772']
+  parents:
+  - 727696
+891590:
+  aliases: ['Chiroptera sp. BOLD:AAL5777']
+  parents:
+  - 727696
+891591:
+  aliases: ['Chiroptera sp. BOLD:AAM0883']
+  parents:
+  - 727696
+915935:
+  aliases: ['Chiroptera sp. BOLD:AAM2888']
+  parents:
+  - 727696
+915936:
+  aliases: ['Chiroptera sp. BOLD:AAM4700']
+  parents:
+  - 727696
+915937:
+  aliases: ['Chiroptera sp. BOLD:AAM7559']
+  parents:
+  - 727696
+974314:
+  aliases: ['Chiroptera sp. BOLD:AAN2509']
+  parents:
+  - 727696
+974315:
+  aliases: ['Chiroptera sp. BOLD:AAN2514']
+  parents:
+  - 727696
+974316:
+  aliases: ['Chiroptera sp. BOLD:AAN2561']
+  parents:
+  - 727696
+974317:
+  aliases: ['Chiroptera sp. BOLD:AAN2666']
+  parents:
+  - 727696
+974318:
+  aliases: ['Chiroptera sp. BOLD:AAN2669']
+  parents:
+  - 727696
+974319:
+  aliases: ['Chiroptera sp. BOLD:AAN2670']
+  parents:
+  - 727696
+974320:
+  aliases: ['Chiroptera sp. BOLD:AAN2671']
+  parents:
+  - 727696
+974321:
+  aliases: ['Chiroptera sp. BOLD:AAN2688']
+  parents:
+  - 727696
+974322:
+  aliases: ['Chiroptera sp. BOLD:AAN2818']
+  parents:
+  - 727696
+974323:
+  aliases: ['Chiroptera sp. BOLD:AAN2861']
+  parents:
+  - 727696
+974324:
+  aliases: ['Chiroptera sp. BOLD:AAN3075']
+  parents:
+  - 727696
+974325:
+  aliases: ['Chiroptera sp. BOLD:AAN3259']
+  parents:
+  - 727696
+974326:
+  aliases: ['Chiroptera sp. BOLD:AAN3348']
+  parents:
+  - 727696
+974327:
+  aliases: ['Chiroptera sp. BOLD:AAN3459']
+  parents:
+  - 727696
+974328:
+  aliases: ['Chiroptera sp. BOLD:AAN3808']
+  parents:
+  - 727696
+974329:
+  aliases: ['Chiroptera sp. BOLD:AAN4101']
+  parents:
+  - 727696
+974330:
+  aliases: ['Chiroptera sp. BOLD:AAN9716']
+  parents:
+  - 727696
+974331:
+  aliases: ['Chiroptera sp. BOLD:AAN9771']
+  parents:
+  - 727696
+974332:
+  aliases: ['Chiroptera sp. BOLD:AAN9773']
+  parents:
+  - 727696
+974333:
+  aliases: ['Chiroptera sp. BOLD:AAN9981']
+  parents:
+  - 727696
+974334:
+  aliases: ['Chiroptera sp. BOLD:AAO0822']
+  parents:
+  - 727696
+974335:
+  aliases: ['Chiroptera sp. BOLD:AAO1393']
+  parents:
+  - 727696
+974336:
+  aliases: ['Chiroptera sp. BOLD:AAO1562']
+  parents:
+  - 727696
+974337:
+  aliases: ['Chiroptera sp. BOLD:AAO1567']
+  parents:
+  - 727696
+974338:
+  aliases: ['Chiroptera sp. BOLD:AAO1629']
+  parents:
+  - 727696
+1067782:
+  aliases: ['Chiroptera sp. BOLD:AAO1765']
+  parents:
+  - 727696
+974339:
+  aliases: ['Chiroptera sp. BOLD:AAO1832']
+  parents:
+  - 727696
+974340:
+  aliases: ['Chiroptera sp. BOLD:AAO2468']
+  parents:
+  - 727696
+974341:
+  aliases: ['Chiroptera sp. BOLD:AAO2496']
+  parents:
+  - 727696
+1067783:
+  aliases: ['Chiroptera sp. BOLD:AAU3776']
+  parents:
+  - 727696
+1067784:
+  aliases: ['Chiroptera sp. BOLD:AAU3777']
+  parents:
+  - 727696
+2792214:
+  aliases: ['Chiroptera sp. M1109']
+  parents:
+  - 727696
+2792203:
+  aliases: ['Chiroptera sp. M1121']
+  parents:
+  - 727696
+2792217:
+  aliases: ['Chiroptera sp. M1130']
+  parents:
+  - 727696
+2792187:
+  aliases: ['Chiroptera sp. M1148']
+  parents:
+  - 727696
+2792196:
+  aliases: ['Chiroptera sp. M222']
+  parents:
+  - 727696
+2792189:
+  aliases: ['Chiroptera sp. M308']
+  parents:
+  - 727696
+2792195:
+  aliases: ['Chiroptera sp. M437']
+  parents:
+  - 727696
+2792197:
+  aliases: ['Chiroptera sp. M468']
+  parents:
+  - 727696
+2792190:
+  aliases: ['Chiroptera sp. M48']
+  parents:
+  - 727696
+2792208:
+  aliases: ['Chiroptera sp. M489']
+  parents:
+  - 727696
+2792199:
+  aliases: ['Chiroptera sp. M493']
+  parents:
+  - 727696
+2792209:
+  aliases: ['Chiroptera sp. M494']
+  parents:
+  - 727696
+2792200:
+  aliases: ['Chiroptera sp. M496']
+  parents:
+  - 727696
+2792210:
+  aliases: ['Chiroptera sp. M500']
+  parents:
+  - 727696
+2792185:
+  aliases: ['Chiroptera sp. M591']
+  parents:
+  - 727696
+2792193:
+  aliases: ['Chiroptera sp. M60']
+  parents:
+  - 727696
+2792211:
+  aliases: ['Chiroptera sp. M820']
+  parents:
+  - 727696
+2792212:
+  aliases: ['Chiroptera sp. M826']
+  parents:
+  - 727696
+2792201:
+  aliases: ['Chiroptera sp. M828']
+  parents:
+  - 727696
+2792172:
+  aliases: ['Chiroptera sp. M853']
+  parents:
+  - 727696
+2792213:
+  aliases: ['Chiroptera sp. M865']
+  parents:
+  - 727696
+2792183:
+  aliases: ['Chiroptera sp. M886']
+  parents:
+  - 727696
+2676382:
+  aliases: ['Chiroptera sp. MI-2019']
+  parents:
+  - 727696
+3418545:
+  aliases: ['Chiroptera sp. n. RL-2025']
+  parents:
+  - 727696
+3136025:
+  aliases: ['Cistugidae']
+  parents:
+  - 30560
+30562:
+  aliases: ['Emballonuridae']
+  parents:
+  - 30560
+148080:
+  aliases: ['Furipteridae']
+  parents:
+  - 30560
+981671:
+  aliases: ['Miniopteridae']
+  parents:
+  - 30560
+9436:
+  aliases: ['Molossidae']
+  parents:
+  - 30560
+59445:
+  aliases: ['Mormoopidae']
+  parents:
+  - 30560
+94959:
+  aliases: ['Mystacinidae']
+  parents:
+  - 30560
+155036:
+  aliases: ['Myzopodidae']
+  parents:
+  - 30560
+59446:
+  aliases: ['Natalidae']
+  parents:
+  - 30560
+94957:
+  aliases: ['Noctilionidae']
+  parents:
+  - 30560
+59447:
+  aliases: ['Nycteridae']
+  parents:
+  - 30560
+9415:
+  aliases: ['Phyllostomidae']
+  parents:
+  - 30560
+3136023:
+  aliases: ['Pteropodoidea']
+  parents:
+  - 30559
+3136022:
+  aliases: ['Rhinolophoidea']
+  parents:
+  - 30559
+124757:
+  aliases: ['Thyropteridae']
+  parents:
+  - 30560
+9431:
+  aliases: ['Vespertilionidae']
+  parents:
+  - 30560
+1617258:
+  aliases: ['bat environmental sample']
+  parents:
+  - 1617257
+2778563:
+  aliases: ['Afronycteris']
+  parents:
+  - 9431
+3685292:
+  aliases: ['Afropipistrellus']
+  parents:
+  - 9431
+9439:
+  aliases: ['Antrozous']
+  parents:
+  - 9431
+526815:
+  aliases: ['Arielulus']
+  parents:
+  - 9431
+3072824:
+  aliases: ['Baeodon']
+  parents:
+  - 9431
+59448:
+  aliases: ['Barbastella']
+  parents:
+  - 9431
+3135596:
+  aliases: ['Bauerus']
+  parents:
+  - 9431
+40235:
+  aliases: ['Brachyphyllinae']
+  parents:
+  - 9415
+40231:
+  aliases: ['Carolliinae']
+  parents:
+  - 9415
+2069572:
+  aliases: ['Cassistrellus']
+  parents:
+  - 9431
+50352:
+  aliases: ['Chalinolobus']
+  parents:
+  - 9431
+270767:
+  aliases: ['Cheiromeles']
+  parents:
+  - 9436
+290567:
+  aliases: ['Chilonatalus']
+  parents:
+  - 59446
+712047:
+  aliases: ['Cistugo']
+  parents:
+  - 3136025
+29077:
+  aliases: ['Cnephaeus']
+  parents:
+  - 9431
+233861:
+  aliases: ['Corynorhinus']
+  parents:
+  - 9431
+217614:
+  aliases: ['Craseonycteridae']
+  parents:
+  - 3136022
+303306:
+  aliases: ['Cynomops']
+  parents:
+  - 9436
+40237:
+  aliases: ['Desmodontinae']
+  parents:
+  - 9415
+461394:
+  aliases: ['Emballonurinae']
+  parents:
+  - 30562
+3371007:
+  aliases: ['Eptesicus']
+  parents:
+  - 9431
+153290:
+  aliases: ['Euderma']
+  parents:
+  - 9431
+633650:
+  aliases: ['Eudiscopus']
+  parents:
+  - 9431
+27618:
+  aliases: ['Eumops']
+  parents:
+  - 9436
+1310229:
+  aliases: ['Falsistrellus']
+  parents:
+  - 9431
+148081:
+  aliases: ['Furipterus']
+  parents:
+  - 148080
+909366:
+  aliases: ['Glauconycteris']
+  parents:
+  - 9431
+526817:
+  aliases: ['Glischropus']
+  parents:
+  - 9431
+40236:
+  aliases: ['Glossophaginae']
+  parents:
+  - 9415
+124748:
+  aliases: ['Harpiocephalus']
+  parents:
+  - 9431
+685776:
+  aliases: ['Harpiola']
+  parents:
+  - 9431
+526819:
+  aliases: ['Hesperoptenus']
+  parents:
+  - 9431
+186994:
+  aliases: ['Hipposideridae']
+  parents:
+  - 3136022
+258918:
+  aliases: ['Histiotus']
+  parents:
+  - 9431
+109484:
+  aliases: ['Hypsugo']
+  parents:
+  - 9431
+360966:
+  aliases: ['Ia']
+  parents:
+  - 9431
+27664:
+  aliases: ['Idionycteris']
+  parents:
+  - 9431
+59454:
+  aliases: ['Kerivoula']
+  parents:
+  - 9431
+258926:
+  aliases: ['Laephotis']
+  parents:
+  - 9431
+27666:
+  aliases: ['Lasionycteris']
+  parents:
+  - 9431
+72130:
+  aliases: ['Lasiurus']
+  parents:
+  - 9431
+138703:
+  aliases: ['Lonchophyllinae']
+  parents:
+  - 9415
+9409:
+  aliases: ['Megadermatidae']
+  parents:
+  - 3136022
+3371053:
+  aliases: ['Micronomus']
+  parents:
+  - 9436
+2093333:
+  aliases: ['Mimetillus']
+  parents:
+  - 9431
+9432:
+  aliases: ['Miniopterus']
+  parents:
+  - 981671
+2741457:
+  aliases: ['Mirostrellus']
+  parents:
+  - 9431
+249031:
+  aliases: ['Molossops']
+  parents:
+  - 9436
+27621:
+  aliases: ['Molossus']
+  parents:
+  - 9436
+258862:
+  aliases: ['Mops']
+  parents:
+  - 9436
+59459:
+  aliases: ['Mormoops']
+  parents:
+  - 59445
+27623:
+  aliases: ['Mormopterus']
+  parents:
+  - 9436
+59488:
+  aliases: ['Murina']
+  parents:
+  - 9431
+1115869:
+  aliases: ['Myopterus']
+  parents:
+  - 9436
+9434:
+  aliases: ['Myotis']
+  parents:
+  - 9431
+94960:
+  aliases: ['Mystacina']
+  parents:
+  - 94959
+155037:
+  aliases: ['Myzopoda']
+  parents:
+  - 155036
+59486:
+  aliases: ['Natalus']
+  parents:
+  - 59446
+3371080:
+  aliases: ['Neoeptesicus']
+  parents:
+  - 9431
+3111555:
+  aliases: ['Neoplatymops']
+  parents:
+  - 9436
+568926:
+  aliases: ['Neoromicia']
+  parents:
+  - 9431
+94958:
+  aliases: ['Noctilio']
+  parents:
+  - 94957
+51299:
+  aliases: ['Nyctalus']
+  parents:
+  - 9431
+59466:
+  aliases: ['Nycteris']
+  parents:
+  - 59447
+59468:
+  aliases: ['Nycticeinops']
+  parents:
+  - 9431
+27669:
+  aliases: ['Nycticeius']
+  parents:
+  - 9431
+290565:
+  aliases: ['Nyctiellus']
+  parents:
+  - 59446
+27625:
+  aliases: ['Nyctinomops']
+  parents:
+  - 9436
+59470:
+  aliases: ['Nyctophilus']
+  parents:
+  - 9431
+258866:
+  aliases: ['Otomops']
+  parents:
+  - 9436
+153292:
+  aliases: ['Otonycteris']
+  parents:
+  - 9431
+2689069:
+  aliases: ['Ozimops']
+  parents:
+  - 9436
+712815:
+  aliases: ['Parastrellus']
+  parents:
+  - 9431
+3371047:
+  aliases: ['Paremballonura']
+  parents:
+  - 30562
+2057181:
+  aliases: ['Perimyotis']
+  parents:
+  - 9431
+867863:
+  aliases: ['Philetor']
+  parents:
+  - 9431
+867874:
+  aliases: ['Phoniscus']
+  parents:
+  - 9431
+138700:
+  aliases: ['Phyllonycterinae']
+  parents:
+  - 9415
+40238:
+  aliases: ['Phyllostominae']
+  parents:
+  - 9415
+27671:
+  aliases: ['Pipistrellus']
+  parents:
+  - 9431
+27673:
+  aliases: ['Plecotus']
+  parents:
+  - 9431
+27628:
+  aliases: ['Promops']
+  parents:
+  - 9436
+2778566:
+  aliases: ['Pseudoromicia']
+  parents:
+  - 9431
+59475:
+  aliases: ['Pteronotus']
+  parents:
+  - 59445
+9398:
+  aliases: ['Pteropodidae']
+  parents:
+  - 3136023
+58055:
+  aliases: ['Rhinolophidae']
+  parents:
+  - 3136022
+1677019:
+  aliases: ['Rhinonycteridae']
+  parents:
+  - 3136022
+124754:
+  aliases: ['Rhinopomatidae']
+  parents:
+  - 3136022
+153294:
+  aliases: ['Rhogeessa']
+  parents:
+  - 9431
+3411094:
+  aliases: ['Rhyneptesicus']
+  parents:
+  - 9431
+999965:
+  aliases: ['Sauromys']
+  parents:
+  - 9436
+258954:
+  aliases: ['Scotoecus']
+  parents:
+  - 9431
+258956:
+  aliases: ['Scotomanes']
+  parents:
+  - 9431
+153296:
+  aliases: ['Scotophilus']
+  parents:
+  - 9431
+270779:
+  aliases: ['Scotorepens']
+  parents:
+  - 9431
+2830903:
+  aliases: ['Scotozous']
+  parents:
+  - 9431
+3371055:
+  aliases: ['Setirostris']
+  parents:
+  - 9436
+40234:
+  aliases: ['Stenodermatinae']
+  parents:
+  - 9415
+1636536:
+  aliases: ['Submyotodon']
+  parents:
+  - 9431
+9437:
+  aliases: ['Tadarida']
+  parents:
+  - 9436
+461395:
+  aliases: ['Taphozoinae']
+  parents:
+  - 30562
+3371075:
+  aliases: ['Thainycteris']
+  parents:
+  - 9431
+124758:
+  aliases: ['Thyroptera']
+  parents:
+  - 124757
+27631:
+  aliases: ['Tomopeas']
+  parents:
+  - 9436
+258958:
+  aliases: ['Tylonycteris']
+  parents:
+  - 9431
+2778577:
+  aliases: ['Vansonia']
+  parents:
+  - 9431
+2689072:
+  aliases: ['Vespadelus']
+  parents:
+  - 9431
+59484:
+  aliases: ['Vespertilio']
+  parents:
+  - 9431
+3242306:
+  aliases: ['unclassified Phyllostomidae']
+  parents:
+  - 9415
+1296580:
+  aliases: ['unclassified Vespertilionidae']
+  parents:
+  - 9431
+3369693:
+  aliases: ['Afronycteris nanus']
+  parents:
+  - 2778563
+3370421:
+  aliases: ['Afropipistrellus eisentrauti']
+  parents:
+  - 3685292
+2608642:
+  aliases: ['Afropipistrellus happoldorum']
+  parents:
+  - 3685292
+148022:
+  aliases: ['Ametrida']
+  parents:
+  - 40234
+27641:
+  aliases: ['Anoura']
+  parents:
+  - 40236
+302396:
+  aliases: ['Anthops']
+  parents:
+  - 186994
+9440:
+  aliases: ['Antrozous pallidus']
+  parents:
+  - 9439
+148023:
+  aliases: ['Ardops']
+  parents:
+  - 40234
+867814:
+  aliases: ['Arielulus circumdatus']
+  parents:
+  - 526815
+526816:
+  aliases: ['Arielulus cuprosus']
+  parents:
+  - 526815
+3369719:
+  aliases: ['Arielulus societatis']
+  parents:
+  - 526815
+148024:
+  aliases: ['Ariteus']
+  parents:
+  - 40234
+9416:
+  aliases: ['Artibeus']
+  parents:
+  - 40234
+578339:
+  aliases: ['Asellia']
+  parents:
+  - 186994
+188567:
+  aliases: ['Aselliscus']
+  parents:
+  - 186994
+153295:
+  aliases: ['Baeodon alleni']
+  parents:
+  - 3072824
+3072825:
+  aliases: ['Baeodon gracilis']
+  parents:
+  - 3072824
+148079:
+  aliases: ['Balantiopteryx']
+  parents:
+  - 461394
+59449:
+  aliases: ['Barbastella barbastellus']
+  parents:
+  - 59448
+452650:
+  aliases: ['Barbastella beijingensis']
+  parents:
+  - 59448
+2505955:
+  aliases: ['Barbastella caspica']
+  parents:
+  - 59448
+999320:
+  aliases: ['Barbastella darjelingensis']
+  parents:
+  - 59448
+187009:
+  aliases: ['Barbastella leucomelas']
+  parents:
+  - 59448
+2505956:
+  aliases: ['Barbastella pacifica']
+  parents:
+  - 59448
+249033:
+  aliases: ['Bauerus dubiaquercus']
+  parents:
+  - 3135596
+9420:
+  aliases: ['Brachyphylla']
+  parents:
+  - 40235
+270763:
+  aliases: ['Cardioderma']
+  parents:
+  - 9409
+40232:
+  aliases: ['Carollia']
+  parents:
+  - 40231
+712050:
+  aliases: ['Cassistrellus dimissus']
+  parents:
+  - 2069572
+2069573:
+  aliases: ['Cassistrellus yokdonensis']
+  parents:
+  - 2069572
+461396:
+  aliases: ['Centronycteris']
+  parents:
+  - 461394
+27643:
+  aliases: ['Centurio']
+  parents:
+  - 40234
+2717975:
+  aliases: ['Chalinolobus dwyeri']
+  parents:
+  - 50352
+258889:
+  aliases: ['Chalinolobus gouldii']
+  parents:
+  - 50352
+50353:
+  aliases: ['Chalinolobus morio']
+  parents:
+  - 50352
+2093326:
+  aliases: ['Chalinolobus neocaledonicus']
+  parents:
+  - 50352
+270775:
+  aliases: ['Chalinolobus nigrogriseus']
+  parents:
+  - 50352
+2717976:
+  aliases: ['Chalinolobus picatus']
+  parents:
+  - 50352
+143942:
+  aliases: ['Chalinolobus tuberculatus']
+  parents:
+  - 50352
+270769:
+  aliases: ['Cheiromeles parvidens']
+  parents:
+  - 270767
+270768:
+  aliases: ['Cheiromeles torquatus']
+  parents:
+  - 270767
+155039:
+  aliases: ['Chilonatalus micropus']
+  parents:
+  - 290567
+290568:
+  aliases: ['Chilonatalus tumidifrons']
+  parents:
+  - 290567
+27645:
+  aliases: ['Chiroderma']
+  parents:
+  - 40234
+148042:
+  aliases: ['Choeroniscus']
+  parents:
+  - 40236
+148043:
+  aliases: ['Choeronycteris']
+  parents:
+  - 40236
+148075:
+  aliases: ['Chrotopterus']
+  parents:
+  - 40238
+265731:
+  aliases: ['Cistugo lesueuri']
+  parents:
+  - 712047
+712048:
+  aliases: ['Cistugo seabrae']
+  parents:
+  - 712047
+302399:
+  aliases: ['Cloeotis']
+  parents:
+  - 1677019
+3371008:
+  aliases: ['Cnephaeus anatolicus']
+  parents:
+  - 29077
+3371009:
+  aliases: ['Cnephaeus bottae']
+  parents:
+  - 29077
+3371011:
+  aliases: ['Cnephaeus gobiensis']
+  parents:
+  - 29077
+3371012:
+  aliases: ['Cnephaeus hottentotus']
+  parents:
+  - 29077
+3371013:
+  aliases: ['Cnephaeus isabellinus']
+  parents:
+  - 29077
+3371014:
+  aliases: ['Cnephaeus japonensis']
+  parents:
+  - 29077
+3371016:
+  aliases: ['Cnephaeus nilssonii']
+  parents:
+  - 29077
+3371017:
+  aliases: ['Cnephaeus ognevi']
+  parents:
+  - 29077
+3371018:
+  aliases: ['Cnephaeus pachyomus']
+  parents:
+  - 29077
+3371021:
+  aliases: ['Cnephaeus serotinus']
+  parents:
+  - 29077
+3371022:
+  aliases: ['Cnephaeus tatei']
+  parents:
+  - 29077
+187001:
+  aliases: ['Coelops']
+  parents:
+  - 186994
+461397:
+  aliases: ['Coleura']
+  parents:
+  - 461394
+249011:
+  aliases: ['Cormura']
+  parents:
+  - 461394
+712049:
+  aliases: ['Corynorhinus mexicanus']
+  parents:
+  - 233861
+27674:
+  aliases: ['Corynorhinus rafinesquii']
+  parents:
+  - 233861
+124745:
+  aliases: ['Corynorhinus townsendii']
+  parents:
+  - 233861
+208971:
+  aliases: ['Craseonycteris']
+  parents:
+  - 217614
+748910:
+  aliases: ['Cynomops abrasus']
+  parents:
+  - 303306
+1833834:
+  aliases: ['Cynomops greenhalli']
+  parents:
+  - 303306
+2850156:
+  aliases: ['Cynomops kuizha']
+  parents:
+  - 303306
+1833835:
+  aliases: ['Cynomops mexicanus']
+  parents:
+  - 303306
+303307:
+  aliases: ['Cynomops paranus']
+  parents:
+  - 303306
+409018:
+  aliases: ['Cynomops planirostris']
+  parents:
+  - 303306
+3136027:
+  aliases: ['Cynopterinae']
+  parents:
+  - 9398
+409019:
+  aliases: ['Cyttarops']
+  parents:
+  - 461394
+563992:
+  aliases: ['Dermanura']
+  parents:
+  - 40234
+9429:
+  aliases: ['Desmodus']
+  parents:
+  - 40237
+148076:
+  aliases: ['Diaemus']
+  parents:
+  - 40237
+148078:
+  aliases: ['Diclidurus']
+  parents:
+  - 461394
+148077:
+  aliases: ['Diphylla']
+  parents:
+  - 40237
+2664496:
+  aliases: ['Doryrhina']
+  parents:
+  - 186994
+148025:
+  aliases: ['Ectophylla']
+  parents:
+  - 40234
+110939:
+  aliases: ['Emballonura']
+  parents:
+  - 461394
+3136030:
+  aliases: ['Epomophorinae']
+  parents:
+  - 9398
+3369970:
+  aliases: ['Eptesicus dutertreus']
+  parents:
+  - 3371007
+29078:
+  aliases: ['Eptesicus fuscus']
+  parents:
+  - 3371007
+148091:
+  aliases: ['Erophylla']
+  parents:
+  - 138700
+153291:
+  aliases: ['Euderma maculatum']
+  parents:
+  - 153290
+633651:
+  aliases: ['Eudiscopus denticulus']
+  parents:
+  - 633650
+124747:
+  aliases: ['Eumops auripendulus']
+  parents:
+  - 27618
+649740:
+  aliases: ['Eumops bonariensis']
+  parents:
+  - 27618
+1848987:
+  aliases: ['Eumops chimaera']
+  parents:
+  - 27618
+1115884:
+  aliases: ['Eumops dabbenei']
+  parents:
+  - 27618
+1115867:
+  aliases: ['Eumops ferox']
+  parents:
+  - 27618
+27619:
+  aliases: ['Eumops glaucinus']
+  parents:
+  - 27618
+409027:
+  aliases: ['Eumops hansae']
+  parents:
+  - 27618
+1001578:
+  aliases: ['Eumops maurus']
+  parents:
+  - 27618
+1246553:
+  aliases: ['Eumops nanus']
+  parents:
+  - 27618
+1115866:
+  aliases: ['Eumops patagonicus']
+  parents:
+  - 27618
+27620:
+  aliases: ['Eumops perotis']
+  parents:
+  - 27618
+507606:
+  aliases: ['Eumops underwoodi']
+  parents:
+  - 27618
+1115868:
+  aliases: ['Eumops wilsoni']
+  parents:
+  - 27618
+2491053:
+  aliases: ['Falsistrellus mackenziei']
+  parents:
+  - 1310229
+2491054:
+  aliases: ['Falsistrellus tasmaniensis']
+  parents:
+  - 1310229
+148082:
+  aliases: ['Furipterus horrens']
+  parents:
+  - 148081
+1920523:
+  aliases: ['Gardnerycteris']
+  parents:
+  - 40238
+2093328:
+  aliases: ['Glauconycteris alboguttata']
+  parents:
+  - 909366
+909367:
+  aliases: ['Glauconycteris argentata']
+  parents:
+  - 909366
+2093329:
+  aliases: ['Glauconycteris atra']
+  parents:
+  - 909366
+177182:
+  aliases: ['Glauconycteris beatrix']
+  parents:
+  - 909366
+2093340:
+  aliases: ['Glauconycteris cf. humeralis R13-46']
+  parents:
+  - 909366
+2093341:
+  aliases: ['Glauconycteris cf. humeralis R13-98']
+  parents:
+  - 909366
+2093330:
+  aliases: ['Glauconycteris curryae']
+  parents:
+  - 909366
+909368:
+  aliases: ['Glauconycteris egeria']
+  parents:
+  - 909366
+2093331:
+  aliases: ['Glauconycteris humeralis']
+  parents:
+  - 909366
+258909:
+  aliases: ['Glauconycteris poensis']
+  parents:
+  - 909366
+2448840:
+  aliases: ['Glauconycteris superba']
+  parents:
+  - 909366
+909369:
+  aliases: ['Glauconycteris variegata']
+  parents:
+  - 909366
+1699683:
+  aliases: ['Glischropus aquilus']
+  parents:
+  - 526817
+1699682:
+  aliases: ['Glischropus bucephalus']
+  parents:
+  - 526817
+526818:
+  aliases: ['Glischropus tylopus']
+  parents:
+  - 526817
+27637:
+  aliases: ['Glossophaga']
+  parents:
+  - 40236
+409028:
+  aliases: ['Glyphonycteris']
+  parents:
+  - 40238
+124749:
+  aliases: ['Harpiocephalus harpia']
+  parents:
+  - 124748
+294655:
+  aliases: ['Harpiocephalus mordax']
+  parents:
+  - 124748
+685777:
+  aliases: ['Harpiola isodon']
+  parents:
+  - 685776
+3136028:
+  aliases: ['Harpyionycterinae']
+  parents:
+  - 9398
+867821:
+  aliases: ['Hesperoptenus blanfordi']
+  parents:
+  - 526819
+3129213:
+  aliases: ['Hesperoptenus doriae']
+  parents:
+  - 526819
+867822:
+  aliases: ['Hesperoptenus tickelli']
+  parents:
+  - 526819
+526820:
+  aliases: ['Hesperoptenus tomesi']
+  parents:
+  - 526819
+58068:
+  aliases: ['Hipposideros']
+  parents:
+  - 186994
+3044321:
+  aliases: ['Histiotus diaphanopterus']
+  parents:
+  - 258918
+2764696:
+  aliases: ['Histiotus humboldti']
+  parents:
+  - 258918
+2969767:
+  aliases: ['Histiotus laephotis']
+  parents:
+  - 258918
+258919:
+  aliases: ['Histiotus macrotus']
+  parents:
+  - 258918
+909363:
+  aliases: ['Histiotus magellanicus']
+  parents:
+  - 258918
+2969768:
+  aliases: ['Histiotus mochica']
+  parents:
+  - 258918
+1161940:
+  aliases: ['Histiotus montanus']
+  parents:
+  - 258918
+742904:
+  aliases: ['Histiotus velatus']
+  parents:
+  - 258918
+1470803:
+  aliases: ['Hsunycteris']
+  parents:
+  - 138703
+148044:
+  aliases: ['Hylonycteris']
+  parents:
+  - 40236
+999321:
+  aliases: ['Hypsugo alaschanicus']
+  parents:
+  - 109484
+1928619:
+  aliases: ['Hypsugo arabicus']
+  parents:
+  - 109484
+412094:
+  aliases: ['Hypsugo ariel']
+  parents:
+  - 109484
+342860:
+  aliases: ['Hypsugo cadornae']
+  parents:
+  - 109484
+1897726:
+  aliases: ['Hypsugo dolichodon']
+  parents:
+  - 109484
+1788295:
+  aliases: ['Hypsugo macrotis']
+  parents:
+  - 109484
+1310230:
+  aliases: ['Hypsugo petersi']
+  parents:
+  - 109484
+867834:
+  aliases: ['Hypsugo pulveratus']
+  parents:
+  - 109484
+109485:
+  aliases: ['Hypsugo savii']
+  parents:
+  - 109484
+2917788:
+  aliases: ['Hypsugo stubbei']
+  parents:
+  - 109484
+360967:
+  aliases: ['Ia io']
+  parents:
+  - 360966
+27665:
+  aliases: ['Idionycteris phyllotis']
+  parents:
+  - 27664
+1429989:
+  aliases: ['Kerivoula argentata']
+  parents:
+  - 59454
+867835:
+  aliases: ['Kerivoula cf. hardwickii CMF-2010']
+  parents:
+  - 59454
+867836:
+  aliases: ['Kerivoula cf. lenis CMF-2010']
+  parents:
+  - 59454
+294654:
+  aliases: ['Kerivoula cf. papillosa']
+  parents:
+  - 59454
+1987007:
+  aliases: ['Kerivoula cuprosa']
+  parents:
+  - 59454
+2918677:
+  aliases: ['Kerivoula depressa']
+  parents:
+  - 59454
+2918678:
+  aliases: ['Kerivoula dongduongana']
+  parents:
+  - 59454
+2015597:
+  aliases: ['Kerivoula furva']
+  parents:
+  - 59454
+155035:
+  aliases: ['Kerivoula hardwickii']
+  parents:
+  - 59454
+481313:
+  aliases: ['Kerivoula intermedia']
+  parents:
+  - 59454
+867839:
+  aliases: ['Kerivoula kachinensis']
+  parents:
+  - 59454
+867840:
+  aliases: ['Kerivoula krauensis']
+  parents:
+  - 59454
+2591342:
+  aliases: ['Kerivoula lanosa']
+  parents:
+  - 59454
+481312:
+  aliases: ['Kerivoula lenis']
+  parents:
+  - 59454
+685729:
+  aliases: ['Kerivoula minuta']
+  parents:
+  - 59454
+59455:
+  aliases: ['Kerivoula papillosa']
+  parents:
+  - 59454
+258925:
+  aliases: ['Kerivoula pellucida']
+  parents:
+  - 59454
+3242297:
+  aliases: ['Kerivoula phalaena']
+  parents:
+  - 59454
+867838:
+  aliases: ['Kerivoula picta']
+  parents:
+  - 59454
+3242298:
+  aliases: ['Kerivoula smithii']
+  parents:
+  - 59454
+633648:
+  aliases: ['Kerivoula titania']
+  parents:
+  - 59454
+481314:
+  aliases: ['Kerivoula whiteheadi']
+  parents:
+  - 59454
+2943201:
+  aliases: ['Laephotis angolensis']
+  parents:
+  - 258926
+110938:
+  aliases: ['Laephotis capensis']
+  parents:
+  - 258926
+3416122:
+  aliases: ['Laephotis cf. kirinyaga']
+  parents:
+  - 258926
+2778571:
+  aliases: ['Laephotis kirinyaga']
+  parents:
+  - 258926
+2778564:
+  aliases: ['Laephotis malagasyensis']
+  parents:
+  - 258926
+1162378:
+  aliases: ['Laephotis matroka']
+  parents:
+  - 258926
+258927:
+  aliases: ['Laephotis namibensis']
+  parents:
+  - 258926
+2778648:
+  aliases: ['Laephotis robertsi']
+  parents:
+  - 258926
+2778565:
+  aliases: ['Laephotis stanleyi']
+  parents:
+  - 258926
+294650:
+  aliases: ['Laephotis wintoni']
+  parents:
+  - 258926
+27667:
+  aliases: ['Lasionycteris noctivagans']
+  parents:
+  - 27666
+2720563:
+  aliases: ['Lasiurus arequipae']
+  parents:
+  - 72130
+258931:
+  aliases: ['Lasiurus atratus']
+  parents:
+  - 72130
+258932:
+  aliases: ['Lasiurus blossevillii']
+  parents:
+  - 72130
+258930:
+  aliases: ['Lasiurus borealis']
+  parents:
+  - 72130
+257879:
+  aliases: ['Lasiurus cinereus']
+  parents:
+  - 72130
+258928:
+  aliases: ['Lasiurus ega']
+  parents:
+  - 72130
+461400:
+  aliases: ['Lasiurus egregius']
+  parents:
+  - 72130
+1691932:
+  aliases: ['Lasiurus frantzii']
+  parents:
+  - 72130
+1691930:
+  aliases: ['Lasiurus insularis']
+  parents:
+  - 72130
+592573:
+  aliases: ['Lasiurus intermedius']
+  parents:
+  - 72130
+1857021:
+  aliases: ['Lasiurus minor']
+  parents:
+  - 72130
+1691931:
+  aliases: ['Lasiurus pfeifferi']
+  parents:
+  - 72130
+258929:
+  aliases: ['Lasiurus seminolus']
+  parents:
+  - 72130
+2904792:
+  aliases: ['Lasiurus semotus']
+  parents:
+  - 72130
+1691933:
+  aliases: ['Lasiurus varius']
+  parents:
+  - 72130
+3370141:
+  aliases: ['Lasiurus villosissimus']
+  parents:
+  - 72130
+72131:
+  aliases: ['Lasiurus xanthinus']
+  parents:
+  - 72130
+1582324:
+  aliases: ['Lavia']
+  parents:
+  - 9409
+55053:
+  aliases: ['Leptonycteris']
+  parents:
+  - 40236
+148045:
+  aliases: ['Lichonycteris']
+  parents:
+  - 40236
+148084:
+  aliases: ['Lionycteris']
+  parents:
+  - 138703
+138704:
+  aliases: ['Lonchophylla']
+  parents:
+  - 138703
+148054:
+  aliases: ['Lonchorhina']
+  parents:
+  - 40238
+263450:
+  aliases: ['Lophostoma']
+  parents:
+  - 40238
+3371052:
+  aliases: ['Lyroderma']
+  parents:
+  - 9409
+9410:
+  aliases: ['Macroderma']
+  parents:
+  - 9409
+77241:
+  aliases: ['Macroglossinae']
+  parents:
+  - 9398
+2603868:
+  aliases: ['Macronycteris']
+  parents:
+  - 186994
+148055:
+  aliases: ['Macrophyllum']
+  parents:
+  - 40238
+9418:
+  aliases: ['Macrotus']
+  parents:
+  - 40238
+9412:
+  aliases: ['Megaderma']
+  parents:
+  - 9409
+148026:
+  aliases: ['Mesophylla']
+  parents:
+  - 40234
+3371116:
+  aliases: ['Micronomus norfolkensis']
+  parents:
+  - 3371053
+148056:
+  aliases: ['Micronycteris']
+  parents:
+  - 40238
+2093334:
+  aliases: ['Mimetillus moloneyi']
+  parents:
+  - 2093333
+148057:
+  aliases: ['Mimon']
+  parents:
+  - 40238
+647618:
+  aliases: ['Miniopterus aelleni']
+  parents:
+  - 9432
+441364:
+  aliases: ['Miniopterus africanus']
+  parents:
+  - 9432
+1574122:
+  aliases: ['Miniopterus ambohitrensis']
+  parents:
+  - 9432
+117605:
+  aliases: ['Miniopterus australis']
+  parents:
+  - 9432
+647619:
+  aliases: ['Miniopterus brachytragos']
+  parents:
+  - 9432
+1477904:
+  aliases: ['Miniopterus cf. aelleni A']
+  parents:
+  - 9432
+1477905:
+  aliases: ['Miniopterus cf. aelleni B']
+  parents:
+  - 9432
+1286219:
+  aliases: ['Miniopterus cf. arenarius VG-2013']
+  parents:
+  - 9432
+947062:
+  aliases: ['Miniopterus egeri']
+  parents:
+  - 9432
+258933:
+  aliases: ['Miniopterus fraterculus']
+  parents:
+  - 9432
+187007:
+  aliases: ['Miniopterus fuliginosus']
+  parents:
+  - 9432
+187008:
+  aliases: ['Miniopterus fuscus']
+  parents:
+  - 9432
+409372:
+  aliases: ['Miniopterus gleni']
+  parents:
+  - 9432
+666442:
+  aliases: ['Miniopterus griffithsi']
+  parents:
+  - 9432
+568717:
+  aliases: ['Miniopterus griveaudi']
+  parents:
+  - 9432
+221087:
+  aliases: ['Miniopterus inflatus']
+  parents:
+  - 9432
+291300:
+  aliases: ['Miniopterus macrocneme']
+  parents:
+  - 9432
+1471367:
+  aliases: ['Miniopterus maghrebensis']
+  parents:
+  - 9432
+438766:
+  aliases: ['Miniopterus magnater']
+  parents:
+  - 9432
+647620:
+  aliases: ['Miniopterus mahafaliensis']
+  parents:
+  - 9432
+409373:
+  aliases: ['Miniopterus majori']
+  parents:
+  - 9432
+291301:
+  aliases: ['Miniopterus manavi']
+  parents:
+  - 9432
+867841:
+  aliases: ['Miniopterus medius']
+  parents:
+  - 9432
+221086:
+  aliases: ['Miniopterus minor']
+  parents:
+  - 9432
+1434095:
+  aliases: ['Miniopterus mossambicus']
+  parents:
+  - 9432
+291302:
+  aliases: ['Miniopterus natalensis']
+  parents:
+  - 9432
+442103:
+  aliases: ['Miniopterus newtonii']
+  parents:
+  - 9432
+2813654:
+  aliases: ['Miniopterus nimbae']
+  parents:
+  - 9432
+2291841:
+  aliases: ['Miniopterus orianae']
+  parents:
+  - 9432
+2715946:
+  aliases: ['Miniopterus paululus']
+  parents:
+  - 9432
+647617:
+  aliases: ['Miniopterus petersoni']
+  parents:
+  - 9432
+221089:
+  aliases: ['Miniopterus propitristis']
+  parents:
+  - 9432
+258934:
+  aliases: ['Miniopterus pusillus']
+  parents:
+  - 9432
+9433:
+  aliases: ['Miniopterus schreibersii']
+  parents:
+  - 9432
+947061:
+  aliases: ['Miniopterus sororculus']
+  parents:
+  - 9432
+221088:
+  aliases: ['Miniopterus tristis']
+  parents:
+  - 9432
+1410045:
+  aliases: ['Miniopterus villiersi']
+  parents:
+  - 9432
+2741458:
+  aliases: ['Mirostrellus joffrei']
+  parents:
+  - 2741457
+3082059:
+  aliases: ['Molossops griseiventer']
+  parents:
+  - 249031
+1115885:
+  aliases: ['Molossops mattogrossensis']
+  parents:
+  - 249031
+409036:
+  aliases: ['Molossops neglectus']
+  parents:
+  - 249031
+1001576:
+  aliases: ['Molossops temminckii']
+  parents:
+  - 249031
+1552295:
+  aliases: ['Molossus alvarezi']
+  parents:
+  - 27621
+270771:
+  aliases: ['Molossus ater']
+  parents:
+  - 27621
+2116674:
+  aliases: ['Molossus aztecus']
+  parents:
+  - 27621
+1769916:
+  aliases: ['Molossus barnesi']
+  parents:
+  - 27621
+999954:
+  aliases: ['Molossus cf. coibensis']
+  parents:
+  - 27621
+999942:
+  aliases: ['Molossus coibensis']
+  parents:
+  - 27621
+1269259:
+  aliases: ['Molossus currentium']
+  parents:
+  - 27621
+2116675:
+  aliases: ['Molossus fentoni']
+  parents:
+  - 27621
+3062012:
+  aliases: ['Molossus fluminensis']
+  parents:
+  - 27621
+2834119:
+  aliases: ['Molossus melini']
+  parents:
+  - 27621
+2116676:
+  aliases: ['Molossus milleri']
+  parents:
+  - 27621
+27622:
+  aliases: ['Molossus molossus']
+  parents:
+  - 27621
+2997257:
+  aliases: ['Molossus nigricans']
+  parents:
+  - 27621
+1982945:
+  aliases: ['Molossus pretiosus']
+  parents:
+  - 27621
+124751:
+  aliases: ['Molossus rufus']
+  parents:
+  - 27621
+58076:
+  aliases: ['Molossus sinaloae']
+  parents:
+  - 27621
+2482672:
+  aliases: ['Molossus verrilli']
+  parents:
+  - 27621
+148046:
+  aliases: ['Monophyllus']
+  parents:
+  - 40236
+3370270:
+  aliases: ['Mops ansorgei']
+  parents:
+  - 258862
+3370271:
+  aliases: ['Mops atsinanana']
+  parents:
+  - 258862
+1004697:
+  aliases: ['Mops bakarii']
+  parents:
+  - 258862
+3370273:
+  aliases: ['Mops bivittatus']
+  parents:
+  - 258862
+3370274:
+  aliases: ['Mops brachypterus']
+  parents:
+  - 258862
+3370275:
+  aliases: ['Mops bregullae']
+  parents:
+  - 258862
+3242304:
+  aliases: ['Mops cf. nanulus']
+  parents:
+  - 258862
+2448875:
+  aliases: ['Mops cf. nanulus DMR-2017']
+  parents:
+  - 258862
+2448865:
+  aliases: ['Mops cf. pumilus DMR-2017']
+  parents:
+  - 258862
+2598438:
+  aliases: ['Mops cf. pumilus GIN-1704']
+  parents:
+  - 258862
+3370276:
+  aliases: ['Mops chapini']
+  parents:
+  - 258862
+258863:
+  aliases: ['Mops condylurus']
+  parents:
+  - 258862
+3370279:
+  aliases: ['Mops jobensis']
+  parents:
+  - 258862
+3370280:
+  aliases: ['Mops jobimena']
+  parents:
+  - 258862
+3370282:
+  aliases: ['Mops leucogaster']
+  parents:
+  - 258862
+452596:
+  aliases: ['Mops leucostigma']
+  parents:
+  - 258862
+452595:
+  aliases: ['Mops midas']
+  parents:
+  - 258862
+867842:
+  aliases: ['Mops mops']
+  parents:
+  - 258862
+3370286:
+  aliases: ['Mops nigeriae']
+  parents:
+  - 258862
+3370289:
+  aliases: ['Mops plicatus']
+  parents:
+  - 258862
+242384:
+  aliases: ['Mops pumilus']
+  parents:
+  - 258862
+1380905:
+  aliases: ['Mops pumilus s.l. TN-2013']
+  parents:
+  - 258862
+1495469:
+  aliases: ['Mops pumilus s.l. TN-2014']
+  parents:
+  - 258862
+3370290:
+  aliases: ['Mops pusillus']
+  parents:
+  - 258862
+3370294:
+  aliases: ['Mops spurrelli']
+  parents:
+  - 258862
+3370295:
+  aliases: ['Mops thersites']
+  parents:
+  - 258862
+3370296:
+  aliases: ['Mops tomensis']
+  parents:
+  - 258862
+118852:
+  aliases: ['Mormoops blainvillei']
+  parents:
+  - 59459
+59460:
+  aliases: ['Mormoops megalophylla']
+  parents:
+  - 59459
+525717:
+  aliases: ['Mormopterus acetabulosus']
+  parents:
+  - 27623
+524134:
+  aliases: ['Mormopterus francoismoutoui']
+  parents:
+  - 27623
+999964:
+  aliases: ['Mormopterus jugularis']
+  parents:
+  - 27623
+27624:
+  aliases: ['Mormopterus kalinowskii']
+  parents:
+  - 27623
+450943:
+  aliases: ['Mosia']
+  parents:
+  - 461394
+685730:
+  aliases: ['Murina aenea']
+  parents:
+  - 59488
+1986510:
+  aliases: ['Murina aff. cyclotis PS.12.227']
+  parents:
+  - 59488
+1986508:
+  aliases: ['Murina aff. cyclotis PS100419.3']
+  parents:
+  - 59488
+1986516:
+  aliases: ['Murina aff. cyclotis PS120111.2']
+  parents:
+  - 59488
+1986514:
+  aliases: ['Murina aff. cyclotis SB080103.4']
+  parents:
+  - 59488
+3375538:
+  aliases: ['Murina aff. huttonii']
+  parents:
+  - 59488
+3477261:
+  aliases: ['Murina alvarezi']
+  parents:
+  - 59488
+3370307:
+  aliases: ['Murina annamitica']
+  parents:
+  - 59488
+3477262:
+  aliases: ['Murina baletei']
+  parents:
+  - 59488
+685779:
+  aliases: ['Murina bicolor']
+  parents:
+  - 59488
+294656:
+  aliases: ['Murina cf. cyclotis']
+  parents:
+  - 59488
+867852:
+  aliases: ['Murina cf. cyclotis 2 CMF-2010']
+  parents:
+  - 59488
+1007697:
+  aliases: ['Murina cf. cyclotis BOLD:AAC4219']
+  parents:
+  - 59488
+1986509:
+  aliases: ['Murina cf. eleryi PS120928.1']
+  parents:
+  - 59488
+1167684:
+  aliases: ['Murina cf. huttoni']
+  parents:
+  - 59488
+867853:
+  aliases: ['Murina cf. huttoni CMF-2010']
+  parents:
+  - 59488
+1986513:
+  aliases: ['Murina cf. peninsularis PS.12.255']
+  parents:
+  - 59488
+1986507:
+  aliases: ['Murina cf. peninsularis PS.12.268']
+  parents:
+  - 59488
+1986515:
+  aliases: ['Murina cf. peninsularis PS.12.272']
+  parents:
+  - 59488
+1986517:
+  aliases: ['Murina cf. peninsularis PS120905.1']
+  parents:
+  - 59488
+1986512:
+  aliases: ['Murina cf. peninsularis PSUZC-MM2011.29']
+  parents:
+  - 59488
+867851:
+  aliases: ['Murina chrysochaetes']
+  parents:
+  - 59488
+177185:
+  aliases: ['Murina cyclotis']
+  parents:
+  - 59488
+744863:
+  aliases: ['Murina eleryi']
+  parents:
+  - 59488
+1752043:
+  aliases: ['Murina fanjingshanensis']
+  parents:
+  - 59488
+1453894:
+  aliases: ['Murina feae']
+  parents:
+  - 59488
+3370310:
+  aliases: ['Murina fionae']
+  parents:
+  - 59488
+187016:
+  aliases: ['Murina florium']
+  parents:
+  - 59488
+685780:
+  aliases: ['Murina gracilis']
+  parents:
+  - 59488
+867898:
+  aliases: ['Murina harpioloides']
+  parents:
+  - 59488
+2695399:
+  aliases: ['Murina harrisoni']
+  parents:
+  - 59488
+685731:
+  aliases: ['Murina hilgendorfi']
+  parents:
+  - 59488
+3477263:
+  aliases: ['Murina hilonghilong']
+  parents:
+  - 59488
+2201223:
+  aliases: ['Murina hkakaboraziensis']
+  parents:
+  - 59488
+258935:
+  aliases: ['Murina huttoni']
+  parents:
+  - 59488
+2933636:
+  aliases: ['Murina huttonii']
+  parents:
+  - 59488
+1167681:
+  aliases: ['Murina jaintiana']
+  parents:
+  - 59488
+2695400:
+  aliases: ['Murina jinchui']
+  parents:
+  - 59488
+1727179:
+  aliases: ['Murina kontumensis']
+  parents:
+  - 59488
+187017:
+  aliases: ['Murina leucogaster']
+  parents:
+  - 59488
+2580526:
+  aliases: ['Murina liboensis']
+  parents:
+  - 59488
+1046851:
+  aliases: ['Murina lorelieae']
+  parents:
+  - 59488
+3477264:
+  aliases: ['Murina luzonensis']
+  parents:
+  - 59488
+3477265:
+  aliases: ['Murina mindorensis']
+  parents:
+  - 59488
+685783:
+  aliases: ['Murina peninsularis']
+  parents:
+  - 59488
+3477266:
+  aliases: ['Murina philippinensis']
+  parents:
+  - 59488
+1167679:
+  aliases: ['Murina pluvialis']
+  parents:
+  - 59488
+187018:
+  aliases: ['Murina puta']
+  parents:
+  - 59488
+685781:
+  aliases: ['Murina recondita']
+  parents:
+  - 59488
+2695401:
+  aliases: ['Murina rongjiangensis']
+  parents:
+  - 59488
+526814:
+  aliases: ['Murina rozendaali']
+  parents:
+  - 59488
+187019:
+  aliases: ['Murina ryukyuana']
+  parents:
+  - 59488
+1046852:
+  aliases: ['Murina shuipuensis']
+  parents:
+  - 59488
+59489:
+  aliases: ['Murina suilla']
+  parents:
+  - 59488
+685785:
+  aliases: ['Murina tubinaris']
+  parents:
+  - 59488
+187021:
+  aliases: ['Murina ussuriensis']
+  parents:
+  - 59488
+3237278:
+  aliases: ['Murina walstoni']
+  parents:
+  - 59488
+148047:
+  aliases: ['Musonycteris']
+  parents:
+  - 40236
+1115870:
+  aliases: ['Myopterus daubentonii']
+  parents:
+  - 1115869
+59461:
+  aliases: ['Myotis adversus']
+  parents:
+  - 9434
+1436298:
+  aliases: ['Myotis aff. alcathoe']
+  parents:
+  - 9434
+159322:
+  aliases: ['Myotis albescens']
+  parents:
+  - 9434
+155916:
+  aliases: ['Myotis alcathoe']
+  parents:
+  - 9434
+415933:
+  aliases: ['Myotis altarium']
+  parents:
+  - 9434
+2516277:
+  aliases: ['Myotis ancricola']
+  parents:
+  - 9434
+864758:
+  aliases: ['Myotis anjouanensis']
+  parents:
+  - 9434
+633645:
+  aliases: ['Myotis annamiticus']
+  parents:
+  - 9434
+2782710:
+  aliases: ['Myotis annatessae']
+  parents:
+  - 9434
+265733:
+  aliases: ['Myotis annectans']
+  parents:
+  - 9434
+2977340:
+  aliases: ['Myotis arescens']
+  parents:
+  - 9434
+2785030:
+  aliases: ['Myotis armiensis']
+  parents:
+  - 9434
+384633:
+  aliases: ['Myotis atacamensis']
+  parents:
+  - 9434
+376141:
+  aliases: ['Myotis ater']
+  parents:
+  - 9434
+2940077:
+  aliases: ['Myotis attenboroughi']
+  parents:
+  - 9434
+321263:
+  aliases: ['Myotis auriculus']
+  parents:
+  - 9434
+258936:
+  aliases: ['Myotis austroriparius']
+  parents:
+  - 9434
+2250430:
+  aliases: ['Myotis badius']
+  parents:
+  - 9434
+3370334:
+  aliases: ['Myotis barquezi']
+  parents:
+  - 9434
+59462:
+  aliases: ['Myotis bechsteinii']
+  parents:
+  - 9434
+109482:
+  aliases: ['Myotis blythii']
+  parents:
+  - 9434
+153284:
+  aliases: ['Myotis bocagii']
+  parents:
+  - 9434
+392318:
+  aliases: ['Myotis bombinus']
+  parents:
+  - 9434
+2933637:
+  aliases: ['Myotis borneoensis']
+  parents:
+  - 9434
+109478:
+  aliases: ['Myotis brandtii']
+  parents:
+  - 9434
+2794209:
+  aliases: ['Myotis bucharensis']
+  parents:
+  - 9434
+257882:
+  aliases: ['Myotis californicus']
+  parents:
+  - 9434
+109477:
+  aliases: ['Myotis capaccinii']
+  parents:
+  - 9434
+3098845:
+  aliases: ['Myotis caucensis']
+  parents:
+  - 9434
+1239423:
+  aliases: ['Myotis cf. albescens']
+  parents:
+  - 9434
+1195383:
+  aliases: ['Myotis cf. alcathoe']
+  parents:
+  - 9434
+2782709:
+  aliases: ['Myotis cf. annatessae HNHM 25348']
+  parents:
+  - 9434
+2748575:
+  aliases: ['Myotis cf. annectans MNR-2020']
+  parents:
+  - 9434
+3074279:
+  aliases: ['Myotis cf. ater']
+  parents:
+  - 9434
+1007693:
+  aliases: ['Myotis cf. ater BOLD:AAA8748']
+  parents:
+  - 9434
+867855:
+  aliases: ['Myotis cf. ater CMF-2010']
+  parents:
+  - 9434
+1393937:
+  aliases: ['Myotis cf. ater MR-2013']
+  parents:
+  - 9434
+3029340:
+  aliases: ['Myotis cf. ater ZMMU S-189230']
+  parents:
+  - 9434
+3029341:
+  aliases: ['Myotis cf. ater ZMMU S-189231']
+  parents:
+  - 9434
+3029342:
+  aliases: ['Myotis cf. ater ZMMU S-189232']
+  parents:
+  - 9434
+1195384:
+  aliases: ['Myotis cf. aurascens']
+  parents:
+  - 9434
+386772:
+  aliases: ['Myotis cf. browni']
+  parents:
+  - 9434
+1239424:
+  aliases: ['Myotis cf. californicus']
+  parents:
+  - 9434
+2891921:
+  aliases: ['Myotis cf. californicus/ciliolabrum BL-2021']
+  parents:
+  - 9434
+2742335:
+  aliases: ['Myotis cf. davidii ZMB Mam 108328']
+  parents:
+  - 9434
+2742338:
+  aliases: ['Myotis cf. davidii ZMB Mam 108337']
+  parents:
+  - 9434
+2742339:
+  aliases: ['Myotis cf. davidii ZMB Mam 108341']
+  parents:
+  - 9434
+2742340:
+  aliases: ['Myotis cf. davidii ZMB Mam 108342']
+  parents:
+  - 9434
+2742341:
+  aliases: ['Myotis cf. davidii ZMB Mam 108346']
+  parents:
+  - 9434
+2742342:
+  aliases: ['Myotis cf. davidii ZMB Mam 108348']
+  parents:
+  - 9434
+2742343:
+  aliases: ['Myotis cf. davidii ZMB Mam 108349']
+  parents:
+  - 9434
+2742344:
+  aliases: ['Myotis cf. davidii ZMB Mam 108353']
+  parents:
+  - 9434
+2742345:
+  aliases: ['Myotis cf. davidii ZMB Mam 108354']
+  parents:
+  - 9434
+2742346:
+  aliases: ['Myotis cf. davidii ZMB Mam 108355']
+  parents:
+  - 9434
+2742347:
+  aliases: ['Myotis cf. davidii ZMB Mam 108356']
+  parents:
+  - 9434
+2742348:
+  aliases: ['Myotis cf. davidii ZMB Mam 108357']
+  parents:
+  - 9434
+2742349:
+  aliases: ['Myotis cf. davidii ZMB Mam 108358']
+  parents:
+  - 9434
+2742350:
+  aliases: ['Myotis cf. davidii ZMB Mam 108359']
+  parents:
+  - 9434
+2742318:
+  aliases: ['Myotis cf. davidii ZMB Mam 108361']
+  parents:
+  - 9434
+2742351:
+  aliases: ['Myotis cf. davidii ZMB Mam 108362']
+  parents:
+  - 9434
+2742352:
+  aliases: ['Myotis cf. davidii ZMB Mam 108363']
+  parents:
+  - 9434
+2742353:
+  aliases: ['Myotis cf. davidii ZMB Mam 108364']
+  parents:
+  - 9434
+2742354:
+  aliases: ['Myotis cf. davidii ZMB Mam 108365']
+  parents:
+  - 9434
+2742355:
+  aliases: ['Myotis cf. davidii ZMB Mam 108366']
+  parents:
+  - 9434
+2742357:
+  aliases: ['Myotis cf. davidii ZMB Mam 108401']
+  parents:
+  - 9434
+2742359:
+  aliases: ['Myotis cf. davidii ZMB Mam 108406']
+  parents:
+  - 9434
+2742360:
+  aliases: ['Myotis cf. davidii ZMB Mam 108407']
+  parents:
+  - 9434
+2742361:
+  aliases: ['Myotis cf. davidii ZMB Mam 108408']
+  parents:
+  - 9434
+2742362:
+  aliases: ['Myotis cf. davidii ZMB Mam 108410']
+  parents:
+  - 9434
+2742363:
+  aliases: ['Myotis cf. davidii ZMB Mam 108411']
+  parents:
+  - 9434
+2742364:
+  aliases: ['Myotis cf. davidii ZMB Mam 108412']
+  parents:
+  - 9434
+2742365:
+  aliases: ['Myotis cf. davidii ZMB Mam 108413']
+  parents:
+  - 9434
+2742366:
+  aliases: ['Myotis cf. davidii ZMB Mam 108414']
+  parents:
+  - 9434
+2742367:
+  aliases: ['Myotis cf. davidii ZMB Mam 108415']
+  parents:
+  - 9434
+2742368:
+  aliases: ['Myotis cf. davidii ZMB Mam 108416']
+  parents:
+  - 9434
+2742369:
+  aliases: ['Myotis cf. davidii ZMB Mam 108417']
+  parents:
+  - 9434
+2742370:
+  aliases: ['Myotis cf. davidii ZMB Mam 108418']
+  parents:
+  - 9434
+2742371:
+  aliases: ['Myotis cf. davidii ZMB Mam 108419']
+  parents:
+  - 9434
+2742331:
+  aliases: ['Myotis cf. davidii ZMB Mam 108423']
+  parents:
+  - 9434
+2742332:
+  aliases: ['Myotis cf. davidii ZMB Mam 108424']
+  parents:
+  - 9434
+2742372:
+  aliases: ['Myotis cf. davidii ZMB Mam 108427']
+  parents:
+  - 9434
+2742374:
+  aliases: ['Myotis cf. davidii ZMB Mam 108467']
+  parents:
+  - 9434
+2742375:
+  aliases: ['Myotis cf. davidii ZMB Mam 108471']
+  parents:
+  - 9434
+2742376:
+  aliases: ['Myotis cf. davidii ZMB Mam 108472']
+  parents:
+  - 9434
+2742379:
+  aliases: ['Myotis cf. davidii ZMB Mam 108507']
+  parents:
+  - 9434
+2742384:
+  aliases: ['Myotis cf. davidii ZMB Mam 108517']
+  parents:
+  - 9434
+2742385:
+  aliases: ['Myotis cf. davidii ZMB Mam 108518']
+  parents:
+  - 9434
+2742387:
+  aliases: ['Myotis cf. davidii ZMB Mam 108522']
+  parents:
+  - 9434
+2742388:
+  aliases: ['Myotis cf. davidii ZMB Mam 108523']
+  parents:
+  - 9434
+2742389:
+  aliases: ['Myotis cf. davidii ZMB Mam 108524']
+  parents:
+  - 9434
+2742324:
+  aliases: ['Myotis cf. davidii ZMB Mam 108525']
+  parents:
+  - 9434
+2742390:
+  aliases: ['Myotis cf. davidii ZMB Mam 108527']
+  parents:
+  - 9434
+2742391:
+  aliases: ['Myotis cf. davidii ZMB Mam 108528']
+  parents:
+  - 9434
+2742392:
+  aliases: ['Myotis cf. davidii ZMB Mam 108529']
+  parents:
+  - 9434
+2742393:
+  aliases: ['Myotis cf. davidii ZMB Mam 108530']
+  parents:
+  - 9434
+2742411:
+  aliases: ['Myotis cf. davidii ZMB Mam 108556']
+  parents:
+  - 9434
+2742412:
+  aliases: ['Myotis cf. davidii ZMB Mam 108558']
+  parents:
+  - 9434
+2742321:
+  aliases: ['Myotis cf. davidii ZMB Mam 108559']
+  parents:
+  - 9434
+2742333:
+  aliases: ['Myotis cf. davidii ZMB Mam 108582']
+  parents:
+  - 9434
+2742322:
+  aliases: ['Myotis cf. davidii ZMB Mam 108584']
+  parents:
+  - 9434
+2742323:
+  aliases: ['Myotis cf. davidii ZMB Mam 108586']
+  parents:
+  - 9434
+2742334:
+  aliases: ['Myotis cf. davidii ZMB Mam 108603']
+  parents:
+  - 9434
+2923480:
+  aliases: ['Myotis cf. elegans QCAZ Mamm9168']
+  parents:
+  - 9434
+2923481:
+  aliases: ['Myotis cf. elegans QCAZ Mamm9169']
+  parents:
+  - 9434
+1393938:
+  aliases: ['Myotis cf. formosus MR-2013']
+  parents:
+  - 9434
+2748576:
+  aliases: ['Myotis cf. frater MNR-2020']
+  parents:
+  - 9434
+2785031:
+  aliases: ['Myotis cf. ikonnikovi CC-2020']
+  parents:
+  - 9434
+1239425:
+  aliases: ['Myotis cf. keaysi']
+  parents:
+  - 9434
+867856:
+  aliases: ['Myotis cf. laniger CMF-2010']
+  parents:
+  - 9434
+1393939:
+  aliases: ['Myotis cf. laniger MR-2013']
+  parents:
+  - 9434
+1393940:
+  aliases: ['Myotis cf. longipes MR-2013']
+  parents:
+  - 9434
+1393941:
+  aliases: ['Myotis cf. montivagus MR-2013']
+  parents:
+  - 9434
+386773:
+  aliases: ['Myotis cf. muricola']
+  parents:
+  - 9434
+1007699:
+  aliases: ['Myotis cf. muricola BOLD:AAA8747']
+  parents:
+  - 9434
+1007698:
+  aliases: ['Myotis cf. muricola BOLD:AAA8748']
+  parents:
+  - 9434
+2742336:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108329']
+  parents:
+  - 9434
+2742337:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108330']
+  parents:
+  - 9434
+2742356:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108389']
+  parents:
+  - 9434
+2742358:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108403']
+  parents:
+  - 9434
+2742373:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108460']
+  parents:
+  - 9434
+2742377:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108484']
+  parents:
+  - 9434
+2742378:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108485']
+  parents:
+  - 9434
+2742380:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108513']
+  parents:
+  - 9434
+2742381:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108514']
+  parents:
+  - 9434
+2742382:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108515']
+  parents:
+  - 9434
+2742383:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108516']
+  parents:
+  - 9434
+2742386:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108519']
+  parents:
+  - 9434
+2742394:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108532']
+  parents:
+  - 9434
+2742395:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108533']
+  parents:
+  - 9434
+2742319:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108534']
+  parents:
+  - 9434
+2742327:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108535']
+  parents:
+  - 9434
+2742328:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108536']
+  parents:
+  - 9434
+2742320:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108537']
+  parents:
+  - 9434
+2742329:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108538']
+  parents:
+  - 9434
+2742396:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108539']
+  parents:
+  - 9434
+2742397:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108540']
+  parents:
+  - 9434
+2742330:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108541']
+  parents:
+  - 9434
+2742398:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108542']
+  parents:
+  - 9434
+2742399:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108543']
+  parents:
+  - 9434
+2742400:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108544']
+  parents:
+  - 9434
+2742401:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108545']
+  parents:
+  - 9434
+2742402:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108546']
+  parents:
+  - 9434
+2742403:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108547']
+  parents:
+  - 9434
+2742404:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108548']
+  parents:
+  - 9434
+2742405:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108549']
+  parents:
+  - 9434
+2742406:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108550']
+  parents:
+  - 9434
+2742407:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108551']
+  parents:
+  - 9434
+2742408:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108552']
+  parents:
+  - 9434
+2742409:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108553']
+  parents:
+  - 9434
+2742410:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108554']
+  parents:
+  - 9434
+2742413:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108569']
+  parents:
+  - 9434
+2742325:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108588']
+  parents:
+  - 9434
+2742326:
+  aliases: ['Myotis cf. mystacinus ZMB Mam 108592']
+  parents:
+  - 9434
+1110707:
+  aliases: ['Myotis cf. nattereri IC-2011']
+  parents:
+  - 9434
+1342385:
+  aliases: ['Myotis cf. nattereri IS-2013']
+  parents:
+  - 9434
+1004919:
+  aliases: ['Myotis cf. nattereri TD-2011']
+  parents:
+  - 9434
+1239426:
+  aliases: ['Myotis cf. nigricans']
+  parents:
+  - 9434
+306063:
+  aliases: ['Myotis cf. nipalensis']
+  parents:
+  - 9434
+392005:
+  aliases: ['Myotis cf. pequinius']
+  parents:
+  - 9434
+126404:
+  aliases: ['Myotis cf. punicus']
+  parents:
+  - 9434
+1239427:
+  aliases: ['Myotis cf. riparius']
+  parents:
+  - 9434
+1239428:
+  aliases: ['Myotis cf. simus']
+  parents:
+  - 9434
+1239429:
+  aliases: ['Myotis cf. thysanodes']
+  parents:
+  - 9434
+2781042:
+  aliases: ['Myotis cf. tschuliensis PSU 914']
+  parents:
+  - 9434
+2781043:
+  aliases: ['Myotis cf. tschuliensis PSU 915']
+  parents:
+  - 9434
+2781044:
+  aliases: ['Myotis cf. tschuliensis PSU 918']
+  parents:
+  - 9434
+2781045:
+  aliases: ['Myotis cf. tschuliensis PSU 946']
+  parents:
+  - 9434
+2781046:
+  aliases: ['Myotis cf. tschuliensis PSU 947']
+  parents:
+  - 9434
+2781047:
+  aliases: ['Myotis cf. tschuliensis PSU 948']
+  parents:
+  - 9434
+2781048:
+  aliases: ['Myotis cf. tschuliensis PSU 953']
+  parents:
+  - 9434
+1239430:
+  aliases: ['Myotis cf. yumanensis']
+  parents:
+  - 9434
+384634:
+  aliases: ['Myotis chiloensis']
+  parents:
+  - 9434
+225399:
+  aliases: ['Myotis chinensis']
+  parents:
+  - 9434
+257884:
+  aliases: ['Myotis ciliolabrum']
+  parents:
+  - 9434
+2940078:
+  aliases: ['Myotis clydejonesi']
+  parents:
+  - 9434
+2528591:
+  aliases: ['Myotis crypticus']
+  parents:
+  - 9434
+633646:
+  aliases: ['Myotis csorbai']
+  parents:
+  - 9434
+159324:
+  aliases: ['Myotis dasycneme']
+  parents:
+  - 9434
+98922:
+  aliases: ['Myotis daubentonii']
+  parents:
+  - 9434
+225400:
+  aliases: ['Myotis davidii']
+  parents:
+  - 9434
+2916631:
+  aliases: ['Myotis diminutus']
+  parents:
+  - 9434
+2940079:
+  aliases: ['Myotis dinellii']
+  parents:
+  - 9434
+159325:
+  aliases: ['Myotis dominicensis']
+  parents:
+  - 9434
+258937:
+  aliases: ['Myotis elegans']
+  parents:
+  - 9434
+109480:
+  aliases: ['Myotis emarginatus']
+  parents:
+  - 9434
+508772:
+  aliases: ['Myotis escalerai']
+  parents:
+  - 9434
+257883:
+  aliases: ['Myotis evotis']
+  parents:
+  - 9434
+3086133:
+  aliases: ['Myotis federatus']
+  parents:
+  - 9434
+452653:
+  aliases: ['Myotis fimbriatus']
+  parents:
+  - 9434
+3085897:
+  aliases: ['Myotis findleyi']
+  parents:
+  - 9434
+519446:
+  aliases: ['Myotis flavus']
+  parents:
+  - 9434
+225401:
+  aliases: ['Myotis formosus']
+  parents:
+  - 9434
+258938:
+  aliases: ['Myotis fortidens']
+  parents:
+  - 9434
+187012:
+  aliases: ['Myotis frater']
+  parents:
+  - 9434
+867857:
+  aliases: ['Myotis gomantongensis']
+  parents:
+  - 9434
+203698:
+  aliases: ['Myotis goudotii']
+  parents:
+  - 9434
+384635:
+  aliases: ['Myotis grisescens']
+  parents:
+  - 9434
+2986393:
+  aliases: ['Myotis handleyi']
+  parents:
+  - 9434
+159326:
+  aliases: ['Myotis hasseltii']
+  parents:
+  - 9434
+138977:
+  aliases: ['Myotis horsfieldii']
+  parents:
+  - 9434
+2510967:
+  aliases: ['Myotis hoveli']
+  parents:
+  - 9434
+2974270:
+  aliases: ['Myotis huariorum']
+  parents:
+  - 9434
+1849040:
+  aliases: ['Myotis hyrcanicus']
+  parents:
+  - 9434
+155915:
+  aliases: ['Myotis ikonnikovi']
+  parents:
+  - 9434
+1890223:
+  aliases: ['Myotis indochinensis']
+  parents:
+  - 9434
+2771586:
+  aliases: ['Myotis izecksohni']
+  parents:
+  - 9434
+159327:
+  aliases: ['Myotis keaysi']
+  parents:
+  - 9434
+257881:
+  aliases: ['Myotis keenii']
+  parents:
+  - 9434
+452654:
+  aliases: ['Myotis laniger']
+  parents:
+  - 9434
+2940080:
+  aliases: ['Myotis larensis']
+  parents:
+  - 9434
+2294180:
+  aliases: ['Myotis lavali']
+  parents:
+  - 9434
+27668:
+  aliases: ['Myotis leibii']
+  parents:
+  - 9434
+153285:
+  aliases: ['Myotis levis']
+  parents:
+  - 9434
+2794210:
+  aliases: ['Myotis longicaudatus']
+  parents:
+  - 9434
+587652:
+  aliases: ['Myotis longipes']
+  parents:
+  - 9434
+59463:
+  aliases: ['Myotis lucifugus']
+  parents:
+  - 9434
+187014:
+  aliases: ['Myotis macrodactylus']
+  parents:
+  - 9434
+138979:
+  aliases: ['Myotis macropus']
+  parents:
+  - 9434
+159328:
+  aliases: ['Myotis macrotarsus']
+  parents:
+  - 9434
+385035:
+  aliases: ['Myotis martiniquensis']
+  parents:
+  - 9434
+1442609:
+  aliases: ['Myotis melanorhinus']
+  parents:
+  - 9434
+2910750:
+  aliases: ['Myotis midastactus']
+  parents:
+  - 9434
+712103:
+  aliases: ['Myotis moluccarum']
+  parents:
+  - 9434
+159329:
+  aliases: ['Myotis montivagus']
+  parents:
+  - 9434
+2910751:
+  aliases: ['Myotis moratellii']
+  parents:
+  - 9434
+159330:
+  aliases: ['Myotis muricola']
+  parents:
+  - 9434
+51298:
+  aliases: ['Myotis myotis']
+  parents:
+  - 9434
+1507424:
+  aliases: ['Myotis myotis/blythii']
+  parents:
+  - 9434
+109479:
+  aliases: ['Myotis mystacinus']
+  parents:
+  - 9434
+109481:
+  aliases: ['Myotis nattereri']
+  parents:
+  - 9434
+1163727:
+  aliases: ['Myotis nesopolus']
+  parents:
+  - 9434
+153286:
+  aliases: ['Myotis nigricans']
+  parents:
+  - 9434
+1053984:
+  aliases: ['Myotis nigricans PS1']
+  parents:
+  - 9434
+1158978:
+  aliases: ['Myotis nigricans PS2']
+  parents:
+  - 9434
+2804329:
+  aliases: ['Myotis nimbaensis']
+  parents:
+  - 9434
+306062:
+  aliases: ['Myotis nipalensis']
+  parents:
+  - 9434
+3115248:
+  aliases: ['Myotis nustrale']
+  parents:
+  - 9434
+2497118:
+  aliases: ['Myotis occultus']
+  parents:
+  - 9434
+412095:
+  aliases: ['Myotis oxygnathus']
+  parents:
+  - 9434
+159332:
+  aliases: ['Myotis oxyotus']
+  parents:
+  - 9434
+2890400:
+  aliases: ['Myotis peninsularis']
+  parents:
+  - 9434
+392004:
+  aliases: ['Myotis pequinius']
+  parents:
+  - 9434
+526407:
+  aliases: ['Myotis petax']
+  parents:
+  - 9434
+2291616:
+  aliases: ['Myotis peytoni']
+  parents:
+  - 9434
+572313:
+  aliases: ['Myotis phanluongi']
+  parents:
+  - 9434
+2940081:
+  aliases: ['Myotis pilosatibialis']
+  parents:
+  - 9434
+203696:
+  aliases: ['Myotis pilosus']
+  parents:
+  - 9434
+1209081:
+  aliases: ['Myotis planiceps']
+  parents:
+  - 9434
+196298:
+  aliases: ['Myotis pruinosus']
+  parents:
+  - 9434
+386774:
+  aliases: ['Myotis punicus']
+  parents:
+  - 9434
+258939:
+  aliases: ['Myotis ridleyi']
+  parents:
+  - 9434
+124752:
+  aliases: ['Myotis riparius']
+  parents:
+  - 9434
+409037:
+  aliases: ['Myotis riparius PS1']
+  parents:
+  - 9434
+409038:
+  aliases: ['Myotis riparius PS2']
+  parents:
+  - 9434
+409039:
+  aliases: ['Myotis riparius PS3']
+  parents:
+  - 9434
+633647:
+  aliases: ['Myotis rosseti']
+  parents:
+  - 9434
+159333:
+  aliases: ['Myotis ruber']
+  parents:
+  - 9434
+1633875:
+  aliases: ['Myotis rufoniger']
+  parents:
+  - 9434
+159334:
+  aliases: ['Myotis schaubi']
+  parents:
+  - 9434
+294648:
+  aliases: ['Myotis scotti']
+  parents:
+  - 9434
+1633780:
+  aliases: ['Myotis secundus']
+  parents:
+  - 9434
+258941:
+  aliases: ['Myotis septentrionalis']
+  parents:
+  - 9434
+3380546:
+  aliases: ['Myotis sibiricus']
+  parents:
+  - 9434
+294649:
+  aliases: ['Myotis sicarius']
+  parents:
+  - 9434
+258940:
+  aliases: ['Myotis siligorensis']
+  parents:
+  - 9434
+270776:
+  aliases: ['Myotis simus']
+  parents:
+  - 9434
+385036:
+  aliases: ['Myotis sodalis']
+  parents:
+  - 9434
+1633781:
+  aliases: ['Myotis soror']
+  parents:
+  - 9434
+153287:
+  aliases: ['Myotis thysanodes']
+  parents:
+  - 9434
+233765:
+  aliases: ['Myotis tricolor']
+  parents:
+  - 9434
+2510970:
+  aliases: ['Myotis tschuliensis']
+  parents:
+  - 9434
+9435:
+  aliases: ['Myotis velifer']
+  parents:
+  - 9434
+233766:
+  aliases: ['Myotis vivesi']
+  parents:
+  - 9434
+159335:
+  aliases: ['Myotis volans']
+  parents:
+  - 9434
+519445:
+  aliases: ['Myotis watasei']
+  parents:
+  - 9434
+160974:
+  aliases: ['Myotis welwitschii']
+  parents:
+  - 9434
+187015:
+  aliases: ['Myotis yanbarensis']
+  parents:
+  - 9434
+159337:
+  aliases: ['Myotis yumanensis']
+  parents:
+  - 9434
+2528592:
+  aliases: ['Myotis zenatius']
+  parents:
+  - 9434
+94961:
+  aliases: ['Mystacina tuberculata']
+  parents:
+  - 94960
+155038:
+  aliases: ['Myzopoda aurita']
+  parents:
+  - 155037
+344224:
+  aliases: ['Myzopoda schliemanni']
+  parents:
+  - 155037
+290563:
+  aliases: ['Natalus jamaicensis']
+  parents:
+  - 59486
+2907237:
+  aliases: ['Natalus macrourus']
+  parents:
+  - 59486
+290562:
+  aliases: ['Natalus major']
+  parents:
+  - 59486
+1051665:
+  aliases: ['Natalus mexicanus']
+  parents:
+  - 59486
+290564:
+  aliases: ['Natalus saturatus']
+  parents:
+  - 59486
+155040:
+  aliases: ['Natalus stramineus']
+  parents:
+  - 59486
+59487:
+  aliases: ['Natalus tumidirostris']
+  parents:
+  - 59486
+3371119:
+  aliases: ['Neoeptesicus andinus']
+  parents:
+  - 3371080
+3371120:
+  aliases: ['Neoeptesicus brasiliensis']
+  parents:
+  - 3371080
+3371121:
+  aliases: ['Neoeptesicus chiriquinus']
+  parents:
+  - 3371080
+3371122:
+  aliases: ['Neoeptesicus diminutus']
+  parents:
+  - 3371080
+3371123:
+  aliases: ['Neoeptesicus furinalis']
+  parents:
+  - 3371080
+3371124:
+  aliases: ['Neoeptesicus innoxius']
+  parents:
+  - 3371080
+3371126:
+  aliases: ['Neoeptesicus orinocensis']
+  parents:
+  - 3371080
+3371128:
+  aliases: ['Neoeptesicus ulapesensis']
+  parents:
+  - 3371080
+2943202:
+  aliases: ['Neoromicia anchietae']
+  parents:
+  - 568926
+3370373:
+  aliases: ['Neoromicia bemainty']
+  parents:
+  - 568926
+3026396:
+  aliases: ['Neoromicia cf. anchietae Dom_M_07/UP14546']
+  parents:
+  - 568926
+3026397:
+  aliases: ['Neoromicia cf. anchietae Dom_M_23/UP14549']
+  parents:
+  - 568926
+2943210:
+  aliases: ['Neoromicia cf. anchietae ES-2022']
+  parents:
+  - 568926
+3026398:
+  aliases: ['Neoromicia cf. anchietae IYSIS_M_018/UP14538']
+  parents:
+  - 568926
+3026399:
+  aliases: ['Neoromicia cf. anchietae IYSIS_M_019/UP14539']
+  parents:
+  - 568926
+3026400:
+  aliases: ['Neoromicia cf. anchietae IYSIS_M_021/UP14541']
+  parents:
+  - 568926
+3026401:
+  aliases: ['Neoromicia cf. anchietae IYSIS_M_026/UP14542']
+  parents:
+  - 568926
+3026402:
+  aliases: ['Neoromicia cf. anchietae IYSIS_M_027/UP14543']
+  parents:
+  - 568926
+3026403:
+  aliases: ['Neoromicia cf. anchietae IYSIS_M_035/UP14544']
+  parents:
+  - 568926
+2448876:
+  aliases: ['Neoromicia cf. guineensisa DMR-2017']
+  parents:
+  - 568926
+1578730:
+  aliases: ['Neoromicia cf. melckorum KMN-2014']
+  parents:
+  - 568926
+1838144:
+  aliases: ['Neoromicia cf. somalica JA-2016a']
+  parents:
+  - 568926
+1332054:
+  aliases: ['Neoromicia guineensis']
+  parents:
+  - 568926
+1381466:
+  aliases: ['Neoromicia helios']
+  parents:
+  - 568926
+3076792:
+  aliases: ['Neoromicia hlandzeni']
+  parents:
+  - 568926
+258944:
+  aliases: ['Neoromicia somalicus']
+  parents:
+  - 568926
+1162377:
+  aliases: ['Neoromicia zuluensis']
+  parents:
+  - 568926
+3371070:
+  aliases: ['Nesonycteris']
+  parents:
+  - 9398
+94962:
+  aliases: ['Noctilio albiventris']
+  parents:
+  - 94958
+409040:
+  aliases: ['Noctilio albiventris PS1']
+  parents:
+  - 94958
+409042:
+  aliases: ['Noctilio albiventris PS2']
+  parents:
+  - 94958
+94963:
+  aliases: ['Noctilio leporinus']
+  parents:
+  - 94958
+187010:
+  aliases: ['Nyctalus aviator']
+  parents:
+  - 51299
+297253:
+  aliases: ['Nyctalus azoreum']
+  parents:
+  - 51299
+59464:
+  aliases: ['Nyctalus lasiopterus']
+  parents:
+  - 51299
+59465:
+  aliases: ['Nyctalus leisleri']
+  parents:
+  - 51299
+51300:
+  aliases: ['Nyctalus noctula']
+  parents:
+  - 51299
+375553:
+  aliases: ['Nyctalus plancyi']
+  parents:
+  - 51299
+249028:
+  aliases: ['Nycteris arge']
+  parents:
+  - 59466
+2596769:
+  aliases: ['Nycteris arge complex sp. 1 TD-2019']
+  parents:
+  - 59466
+2596770:
+  aliases: ['Nycteris arge complex sp. 2 TD-2019']
+  parents:
+  - 59466
+2596765:
+  aliases: ['Nycteris cf. hispida/aurita TD-2019']
+  parents:
+  - 59466
+2448878:
+  aliases: ['Nycteris cf. nana DMR-2017']
+  parents:
+  - 59466
+2596766:
+  aliases: ['Nycteris cf. thebaica 1 TD-2019']
+  parents:
+  - 59466
+2596767:
+  aliases: ['Nycteris cf. thebaica 2 TD-2019']
+  parents:
+  - 59466
+2596768:
+  aliases: ['Nycteris cf. thebaica 3 TD-2019']
+  parents:
+  - 59466
+178896:
+  aliases: ['Nycteris grandis']
+  parents:
+  - 59466
+270766:
+  aliases: ['Nycteris hispida']
+  parents:
+  - 59466
+2603853:
+  aliases: ['Nycteris hispida/aurita complex sp. TD-2019']
+  parents:
+  - 59466
+302404:
+  aliases: ['Nycteris javanica']
+  parents:
+  - 59466
+175523:
+  aliases: ['Nycteris macrotis']
+  parents:
+  - 59466
+2596771:
+  aliases: ['Nycteris macrotis complex sp. 1 TD-2019']
+  parents:
+  - 59466
+2596772:
+  aliases: ['Nycteris macrotis complex sp. 2 TD-2019']
+  parents:
+  - 59466
+2596773:
+  aliases: ['Nycteris macrotis complex sp. 3 TD-2019']
+  parents:
+  - 59466
+2860346:
+  aliases: ['Nycteris madagascariensis']
+  parents:
+  - 59466
+3370416:
+  aliases: ['Nycteris major']
+  parents:
+  - 59466
+2596774:
+  aliases: ['Nycteris nana complex sp. 1 TD-2019']
+  parents:
+  - 59466
+2596775:
+  aliases: ['Nycteris nana complex sp. 2 TD-2019']
+  parents:
+  - 59466
+59467:
+  aliases: ['Nycteris thebaica']
+  parents:
+  - 59466
+2603854:
+  aliases: ['Nycteris thebaica complex sp. 1 TD-2019']
+  parents:
+  - 59466
+2603855:
+  aliases: ['Nycteris thebaica complex sp. 2 TD-2019']
+  parents:
+  - 59466
+2596776:
+  aliases: ['Nycteris thebaica complex sp. 3 TD-2019']
+  parents:
+  - 59466
+2596777:
+  aliases: ['Nycteris thebaica complex sp. 4 TD-2019']
+  parents:
+  - 59466
+2596778:
+  aliases: ['Nycteris thebaica complex sp. 5 TD-2019']
+  parents:
+  - 59466
+2596779:
+  aliases: ['Nycteris thebaica complex sp. 6 TD-2019']
+  parents:
+  - 59466
+479723:
+  aliases: ['Nycteris tragata']
+  parents:
+  - 59466
+3370420:
+  aliases: ['Nycticeinops bellieri']
+  parents:
+  - 59468
+3416128:
+  aliases: ['Nycticeinops cf. crassulus']
+  parents:
+  - 59468
+2608643:
+  aliases: ['Nycticeinops cf. grandidieri JJA-2019']
+  parents:
+  - 59468
+3416123:
+  aliases: ['Nycticeinops cf. schlieffenii']
+  parents:
+  - 59468
+1286224:
+  aliases: ['Nycticeinops crassulus']
+  parents:
+  - 59468
+2778562:
+  aliases: ['Nycticeinops grandidieri']
+  parents:
+  - 59468
+3079008:
+  aliases: ['Nycticeinops macrocephalus']
+  parents:
+  - 59468
+153288:
+  aliases: ['Nycticeinops schlieffeni']
+  parents:
+  - 59468
+27670:
+  aliases: ['Nycticeius humeralis']
+  parents:
+  - 27669
+290566:
+  aliases: ['Nyctiellus lepidus']
+  parents:
+  - 290565
+3136026:
+  aliases: ['Nyctimeninae']
+  parents:
+  - 9398
+27626:
+  aliases: ['Nyctinomops aurispinosus']
+  parents:
+  - 27625
+258865:
+  aliases: ['Nyctinomops femorosaccus']
+  parents:
+  - 27625
+27627:
+  aliases: ['Nyctinomops laticaudatus']
+  parents:
+  - 27625
+124753:
+  aliases: ['Nyctinomops macrotis']
+  parents:
+  - 27625
+270777:
+  aliases: ['Nyctophilus arnhemensis']
+  parents:
+  - 59470
+2720893:
+  aliases: ['Nyctophilus bifax']
+  parents:
+  - 59470
+2720894:
+  aliases: ['Nyctophilus corbeni']
+  parents:
+  - 59470
+2720895:
+  aliases: ['Nyctophilus daedalus']
+  parents:
+  - 59470
+258945:
+  aliases: ['Nyctophilus geoffroyi']
+  parents:
+  - 59470
+59471:
+  aliases: ['Nyctophilus gouldi']
+  parents:
+  - 59470
+2720897:
+  aliases: ['Nyctophilus holtorum']
+  parents:
+  - 59470
+3079449:
+  aliases: ['Nyctophilus microdon']
+  parents:
+  - 59470
+3079505:
+  aliases: ['Nyctophilus microtis']
+  parents:
+  - 59470
+436904:
+  aliases: ['Otomops cf. formosus']
+  parents:
+  - 258866
+2218597:
+  aliases: ['Otomops harrisoni']
+  parents:
+  - 258866
+423244:
+  aliases: ['Otomops madagascariensis']
+  parents:
+  - 258866
+258867:
+  aliases: ['Otomops martiensseni']
+  parents:
+  - 258866
+436903:
+  aliases: ['Otomops wroughtoni']
+  parents:
+  - 258866
+153293:
+  aliases: ['Otonycteris hemprichii']
+  parents:
+  - 153292
+798163:
+  aliases: ['Otonycteris leucophaea']
+  parents:
+  - 153292
+3370473:
+  aliases: ['Ozimops beccarii']
+  parents:
+  - 2689069
+3370474:
+  aliases: ['Ozimops cobourgianus']
+  parents:
+  - 2689069
+3370475:
+  aliases: ['Ozimops halli']
+  parents:
+  - 2689069
+3370476:
+  aliases: ['Ozimops kitcheneri']
+  parents:
+  - 2689069
+3370477:
+  aliases: ['Ozimops loriae']
+  parents:
+  - 2689069
+3370478:
+  aliases: ['Ozimops lumsdenae']
+  parents:
+  - 2689069
+3056754:
+  aliases: ['Ozimops petersi']
+  parents:
+  - 2689069
+3370479:
+  aliases: ['Ozimops planiceps']
+  parents:
+  - 2689069
+3370480:
+  aliases: ['Ozimops ridei']
+  parents:
+  - 2689069
+712816:
+  aliases: ['Parastrellus hesperus']
+  parents:
+  - 712815
+1615588:
+  aliases: ['Paratriaenops']
+  parents:
+  - 1677019
+3371137:
+  aliases: ['Paremballonura atrata']
+  parents:
+  - 3371047
+3371138:
+  aliases: ['Paremballonura tiavato']
+  parents:
+  - 3371047
+27672:
+  aliases: ['Perimyotis subflavus']
+  parents:
+  - 2057181
+249013:
+  aliases: ['Peropteryx']
+  parents:
+  - 461394
+867864:
+  aliases: ['Philetor brachypterus']
+  parents:
+  - 867863
+867875:
+  aliases: ['Phoniscus jagorii']
+  parents:
+  - 867874
+148058:
+  aliases: ['Phylloderma']
+  parents:
+  - 40238
+138701:
+  aliases: ['Phyllonycteris']
+  parents:
+  - 138700
+148027:
+  aliases: ['Phyllops']
+  parents:
+  - 40234
+3242307:
+  aliases: ['Phyllostomidae sp.']
+  parents:
+  - 3242306
+9422:
+  aliases: ['Phyllostomus']
+  parents:
+  - 40238
+105295:
+  aliases: ['Pipistrellus abramus']
+  parents:
+  - 27671
+1081694:
+  aliases: ['Pipistrellus ceylonicus']
+  parents:
+  - 27671
+2748577:
+  aliases: ['Pipistrellus cf. ceylonicus MNR-2020']
+  parents:
+  - 27671
+867882:
+  aliases: ['Pipistrellus cf. coromandra CMF-2010']
+  parents:
+  - 27671
+2614833:
+  aliases: ['Pipistrellus cf. coromandra RM-2019']
+  parents:
+  - 27671
+203695:
+  aliases: ['Pipistrellus cf. javanicus']
+  parents:
+  - 27671
+1195385:
+  aliases: ['Pipistrellus cf. kuhlii']
+  parents:
+  - 27671
+1195386:
+  aliases: ['Pipistrellus cf. pygmaeus']
+  parents:
+  - 27671
+1007692:
+  aliases: ['Pipistrellus cf. tenuis BOLD:AAB2554']
+  parents:
+  - 27671
+258946:
+  aliases: ['Pipistrellus coromandra']
+  parents:
+  - 27671
+1928620:
+  aliases: ['Pipistrellus dhofarensis']
+  parents:
+  - 27671
+2902603:
+  aliases: ['Pipistrellus endoi']
+  parents:
+  - 27671
+412090:
+  aliases: ['Pipistrellus hanaki']
+  parents:
+  - 27671
+294653:
+  aliases: ['Pipistrellus hesperidus']
+  parents:
+  - 27671
+258947:
+  aliases: ['Pipistrellus javanicus']
+  parents:
+  - 27671
+270778:
+  aliases: ['Pipistrellus javanicus x tenuis']
+  parents:
+  - 27671
+59472:
+  aliases: ['Pipistrellus kuhlii']
+  parents:
+  - 27671
+183555:
+  aliases: ['Pipistrellus maderensis']
+  parents:
+  - 27671
+1001556:
+  aliases: ['Pipistrellus nanulus']
+  parents:
+  - 27671
+59473:
+  aliases: ['Pipistrellus nathusii']
+  parents:
+  - 27671
+867883:
+  aliases: ['Pipistrellus paterculus']
+  parents:
+  - 27671
+59474:
+  aliases: ['Pipistrellus pipistrellus']
+  parents:
+  - 27671
+246814:
+  aliases: ['Pipistrellus pygmaeus']
+  parents:
+  - 27671
+169058:
+  aliases: ['Pipistrellus pygmaeus x mediterraneus']
+  parents:
+  - 27671
+1578729:
+  aliases: ['Pipistrellus raceyi']
+  parents:
+  - 27671
+372076:
+  aliases: ['Pipistrellus rusticus']
+  parents:
+  - 27671
+526821:
+  aliases: ['Pipistrellus stenopterus']
+  parents:
+  - 27671
+258948:
+  aliases: ['Pipistrellus tenuis']
+  parents:
+  - 27671
+148085:
+  aliases: ['Platalina']
+  parents:
+  - 138703
+27657:
+  aliases: ['Platyrrhinus']
+  parents:
+  - 40234
+61862:
+  aliases: ['Plecotus auritus']
+  parents:
+  - 27673
+109483:
+  aliases: ['Plecotus austriacus']
+  parents:
+  - 27673
+196419:
+  aliases: ['Plecotus balensis']
+  parents:
+  - 27673
+231882:
+  aliases: ['Plecotus cf. kolombatovici']
+  parents:
+  - 27673
+1195387:
+  aliases: ['Plecotus cf. kozlovi']
+  parents:
+  - 27673
+272803:
+  aliases: ['Plecotus christii']
+  parents:
+  - 27673
+272799:
+  aliases: ['Plecotus gaisleri']
+  parents:
+  - 27673
+2918439:
+  aliases: ['Plecotus gobiensis']
+  parents:
+  - 27673
+360157:
+  aliases: ['Plecotus homochrous']
+  parents:
+  - 27673
+169060:
+  aliases: ['Plecotus kolombatovici']
+  parents:
+  - 27673
+360158:
+  aliases: ['Plecotus kozlovi']
+  parents:
+  - 27673
+242915:
+  aliases: ['Plecotus macrobullaris']
+  parents:
+  - 27673
+360160:
+  aliases: ['Plecotus ognevi']
+  parents:
+  - 27673
+360159:
+  aliases: ['Plecotus sacrimontis']
+  parents:
+  - 27673
+221272:
+  aliases: ['Plecotus sardus']
+  parents:
+  - 27673
+360163:
+  aliases: ['Plecotus strelkovi']
+  parents:
+  - 27673
+187391:
+  aliases: ['Plecotus teneriffae']
+  parents:
+  - 27673
+360161:
+  aliases: ['Plecotus turkmenicus']
+  parents:
+  - 27673
+231883:
+  aliases: ['Plecotus wardi']
+  parents:
+  - 27673
+27629:
+  aliases: ['Promops centralis']
+  parents:
+  - 27628
+2499806:
+  aliases: ['Promops davisoni']
+  parents:
+  - 27628
+1700841:
+  aliases: ['Promops nasutus']
+  parents:
+  - 27628
+2778567:
+  aliases: ['Pseudoromicia brunnea']
+  parents:
+  - 2778566
+1286221:
+  aliases: ['Pseudoromicia cf. rendalli SaSt-2013']
+  parents:
+  - 2778566
+3370647:
+  aliases: ['Pseudoromicia isabella']
+  parents:
+  - 2778566
+2778568:
+  aliases: ['Pseudoromicia kityoi']
+  parents:
+  - 2778566
+3024965:
+  aliases: ['Pseudoromicia mbamminkom']
+  parents:
+  - 2778566
+2778569:
+  aliases: ['Pseudoromicia nyanza']
+  parents:
+  - 2778566
+2911689:
+  aliases: ['Pseudoromicia principis']
+  parents:
+  - 2778566
+258943:
+  aliases: ['Pseudoromicia rendalli']
+  parents:
+  - 2778566
+1286220:
+  aliases: ['Pseudoromicia roseveari']
+  parents:
+  - 2778566
+3370648:
+  aliases: ['Pseudoromicia tenuipinnis']
+  parents:
+  - 2778566
+2203464:
+  aliases: ['Pteronotus alitonus']
+  parents:
+  - 59475
+94956:
+  aliases: ['Pteronotus davyi']
+  parents:
+  - 59475
+280979:
+  aliases: ['Pteronotus fuliginosus']
+  parents:
+  - 59475
+1884723:
+  aliases: ['Pteronotus fulvus']
+  parents:
+  - 59475
+118855:
+  aliases: ['Pteronotus gymnonotus']
+  parents:
+  - 59475
+118853:
+  aliases: ['Pteronotus macleayii']
+  parents:
+  - 59475
+1884717:
+  aliases: ['Pteronotus mesoamericanus']
+  parents:
+  - 59475
+59476:
+  aliases: ['Pteronotus parnellii']
+  parents:
+  - 59475
+118856:
+  aliases: ['Pteronotus personatus']
+  parents:
+  - 59475
+1884722:
+  aliases: ['Pteronotus psilotis']
+  parents:
+  - 59475
+280975:
+  aliases: ['Pteronotus pusillus']
+  parents:
+  - 59475
+118854:
+  aliases: ['Pteronotus quadridens']
+  parents:
+  - 59475
+280976:
+  aliases: ['Pteronotus rubiginosus']
+  parents:
+  - 59475
+77225:
+  aliases: ['Pteropodinae']
+  parents:
+  - 9398
+148028:
+  aliases: ['Pygoderma']
+  parents:
+  - 40234
+186995:
+  aliases: ['Rhinolophinae']
+  parents:
+  - 58055
+271602:
+  aliases: ['Rhinonicteris']
+  parents:
+  - 1677019
+138698:
+  aliases: ['Rhinophylla']
+  parents:
+  - 40231
+124755:
+  aliases: ['Rhinopoma']
+  parents:
+  - 124754
+2933650:
+  aliases: ['Rhogeessa aenea']
+  parents:
+  - 153294
+1905273:
+  aliases: ['Rhogeessa bickhami']
+  parents:
+  - 153294
+433358:
+  aliases: ['Rhogeessa genowaysi']
+  parents:
+  - 153294
+261758:
+  aliases: ['Rhogeessa io']
+  parents:
+  - 153294
+3072823:
+  aliases: ['Rhogeessa menchuae']
+  parents:
+  - 153294
+258949:
+  aliases: ['Rhogeessa mira']
+  parents:
+  - 153294
+153298:
+  aliases: ['Rhogeessa parvula']
+  parents:
+  - 153294
+3072452:
+  aliases: ['Rhogeessa permutandis']
+  parents:
+  - 153294
+153299:
+  aliases: ['Rhogeessa tumida']
+  parents:
+  - 153294
+433360:
+  aliases: ['Rhogeessa velilla']
+  parents:
+  - 153294
+249016:
+  aliases: ['Rhynchonycteris']
+  parents:
+  - 461394
+568178:
+  aliases: ['Rhyneptesicus nasutus']
+  parents:
+  - 3411094
+3136029:
+  aliases: ['Rousettinae']
+  parents:
+  - 9398
+446909:
+  aliases: ['Saccolaimus']
+  parents:
+  - 461395
+59481:
+  aliases: ['Saccopteryx']
+  parents:
+  - 461394
+258869:
+  aliases: ['Sauromys petrophilus']
+  parents:
+  - 999965
+2448838:
+  aliases: ['Scotoecus albofuscus']
+  parents:
+  - 258954
+1975661:
+  aliases: ['Scotoecus cf. hirundo AN-2017']
+  parents:
+  - 258954
+2664495:
+  aliases: ['Scotoecus hindei']
+  parents:
+  - 258954
+258955:
+  aliases: ['Scotoecus hirundo']
+  parents:
+  - 258954
+258957:
+  aliases: ['Scotomanes ornatus']
+  parents:
+  - 258956
+2559805:
+  aliases: ['Scotophilus andrewreborii']
+  parents:
+  - 153296
+258951:
+  aliases: ['Scotophilus borbonicus']
+  parents:
+  - 153296
+258952:
+  aliases: ['Scotophilus dinganii']
+  parents:
+  - 153296
+159339:
+  aliases: ['Scotophilus heathii']
+  parents:
+  - 153296
+153297:
+  aliases: ['Scotophilus kuhlii']
+  parents:
+  - 153296
+249034:
+  aliases: ['Scotophilus leucogaster']
+  parents:
+  - 153296
+2559806:
+  aliases: ['Scotophilus livingstonii']
+  parents:
+  - 153296
+565071:
+  aliases: ['Scotophilus marovaza']
+  parents:
+  - 153296
+380359:
+  aliases: ['Scotophilus nigrita']
+  parents:
+  - 153296
+1850281:
+  aliases: ['Scotophilus nucella']
+  parents:
+  - 153296
+258953:
+  aliases: ['Scotophilus nux']
+  parents:
+  - 153296
+565068:
+  aliases: ['Scotophilus robustus']
+  parents:
+  - 153296
+565070:
+  aliases: ['Scotophilus tandrefana']
+  parents:
+  - 153296
+2559807:
+  aliases: ['Scotophilus trujilloi']
+  parents:
+  - 153296
+312069:
+  aliases: ['Scotophilus viridis']
+  parents:
+  - 153296
+2830904:
+  aliases: ['Scotozous dormeri']
+  parents:
+  - 2830903
+3371159:
+  aliases: ['Setirostris eleryi']
+  parents:
+  - 3371055
+148029:
+  aliases: ['Sphaeronycteris']
+  parents:
+  - 40234
+148030:
+  aliases: ['Stenoderma']
+  parents:
+  - 40234
+27659:
+  aliases: ['Sturnira']
+  parents:
+  - 40234
+2783556:
+  aliases: ['Submyotodon caliginosus']
+  parents:
+  - 1636536
+385037:
+  aliases: ['Submyotodon latirostris']
+  parents:
+  - 1636536
+2783555:
+  aliases: ['Submyotodon moupinensis']
+  parents:
+  - 1636536
+302412:
+  aliases: ['Tadarida aegyptiaca']
+  parents:
+  - 9437
+1582105:
+  aliases: ['Tadarida australis']
+  parents:
+  - 9437
+9438:
+  aliases: ['Tadarida brasiliensis']
+  parents:
+  - 9437
+565237:
+  aliases: ['Tadarida fulminans']
+  parents:
+  - 9437
+187006:
+  aliases: ['Tadarida insignis']
+  parents:
+  - 9437
+2049285:
+  aliases: ['Tadarida latouchei']
+  parents:
+  - 9437
+59483:
+  aliases: ['Tadarida teniotis']
+  parents:
+  - 9437
+13280:
+  aliases: ['Taphozous']
+  parents:
+  - 461395
+867897:
+  aliases: ['Thainycteris aureocollaris']
+  parents:
+  - 3371075
+3371162:
+  aliases: ['Thainycteris torquata']
+  parents:
+  - 3371075
+155041:
+  aliases: ['Thyroptera discifera']
+  parents:
+  - 124758
+302413:
+  aliases: ['Thyroptera lavali']
+  parents:
+  - 124758
+124759:
+  aliases: ['Thyroptera tricolor']
+  parents:
+  - 124758
+1945625:
+  aliases: ['Thyroptera wynneae']
+  parents:
+  - 124758
+3370919:
+  aliases: ['Tomopeas ravum']
+  parents:
+  - 27631
+9425:
+  aliases: ['Tonatia']
+  parents:
+  - 40238
+148059:
+  aliases: ['Trachops']
+  parents:
+  - 40238
+258842:
+  aliases: ['Triaenops']
+  parents:
+  - 1677019
+3477446:
+  aliases: ['Trinycteris']
+  parents:
+  - 40238
+1964258:
+  aliases: ['Tylonycteris fulvida']
+  parents:
+  - 258958
+1964257:
+  aliases: ['Tylonycteris malayana']
+  parents:
+  - 258958
+258959:
+  aliases: ['Tylonycteris pachypus']
+  parents:
+  - 258958
+526822:
+  aliases: ['Tylonycteris robustula']
+  parents:
+  - 258958
+1964259:
+  aliases: ['Tylonycteris tonkinensis']
+  parents:
+  - 258958
+27662:
+  aliases: ['Uroderma']
+  parents:
+  - 40234
+148031:
+  aliases: ['Vampyressa']
+  parents:
+  - 40234
+148032:
+  aliases: ['Vampyrodes']
+  parents:
+  - 40234
+148060:
+  aliases: ['Vampyrum']
+  parents:
+  - 40238
+3416124:
+  aliases: ['Vansonia cf. rueppellii']
+  parents:
+  - 2778577
+412089:
+  aliases: ['Vansonia rueppellii']
+  parents:
+  - 2778577
+2720888:
+  aliases: ['Vespadelus darlingtoni']
+  parents:
+  - 2689072
+2720889:
+  aliases: ['Vespadelus finlaysoni']
+  parents:
+  - 2689072
+2720890:
+  aliases: ['Vespadelus pumilus']
+  parents:
+  - 2689072
+138978:
+  aliases: ['Vespadelus regulus']
+  parents:
+  - 2689072
+2765311:
+  aliases: ['Vespadelus troughtoni']
+  parents:
+  - 2689072
+258942:
+  aliases: ['Vespadelus vulturnus']
+  parents:
+  - 2689072
+59485:
+  aliases: ['Vespertilio murinus']
+  parents:
+  - 59484
+105273:
+  aliases: ['Vespertilio sinensis']
+  parents:
+  - 59484
+3117228:
+  aliases: ['Vespertilionidae sp.']
+  parents:
+  - 1296580
+1296583:
+  aliases: ['Vespertilionidae sp. BOLD:AAC0445']
+  parents:
+  - 1296580
+1296581:
+  aliases: ['Vespertilionidae sp. BOLD:AAH8358']
+  parents:
+  - 1296580
+1296582:
+  aliases: ['Vespertilionidae sp. SMM103-12']
+  parents:
+  - 1296580
+1470992:
+  aliases: ['Xeronycteris']
+  parents:
+  - 138703
+2648285:
+  aliases: ['unclassified Arielulus']
+  parents:
+  - 526815
+2677011:
+  aliases: ['unclassified Barbastella']
+  parents:
+  - 59448
+3411095:
+  aliases: ['unclassified Cnephaeus']
+  parents:
+  - 29077
+2648417:
+  aliases: ['unclassified Cynomops']
+  parents:
+  - 303306
+2643748:
+  aliases: ['unclassified Eptesicus']
+  parents:
+  - 3371007
+2619363:
+  aliases: ['unclassified Eumops']
+  parents:
+  - 27618
+2634626:
+  aliases: ['unclassified Glauconycteris']
+  parents:
+  - 909366
+2969770:
+  aliases: ['unclassified Histiotus']
+  parents:
+  - 258918
+2620613:
+  aliases: ['unclassified Hypsugo']
+  parents:
+  - 109484
+2618055:
+  aliases: ['unclassified Kerivoula']
+  parents:
+  - 59454
+2778580:
+  aliases: ['unclassified Laephotis']
+  parents:
+  - 258926
+2688611:
+  aliases: ['unclassified Lasiurus (in: bats)']
+  parents:
+  - 72130
+2645810:
+  aliases: ['unclassified Miniopterus']
+  parents:
+  - 9432
+2737245:
+  aliases: ['unclassified Molossops']
+  parents:
+  - 249031
+2625157:
+  aliases: ['unclassified Molossus']
+  parents:
+  - 27621
+2632858:
+  aliases: ['unclassified Mops']
+  parents:
+  - 258862
+2646271:
+  aliases: ['unclassified Mormopterus']
+  parents:
+  - 27623
+2685208:
+  aliases: ['unclassified Murina']
+  parents:
+  - 59488
+867169:
+  aliases: ['unclassified Myotis']
+  parents:
+  - 9434
+2625265:
+  aliases: ['unclassified Natalus']
+  parents:
+  - 59486
+3111556:
+  aliases: ['unclassified Neoplatymops']
+  parents:
+  - 3111555
+2636793:
+  aliases: ['unclassified Neoromicia']
+  parents:
+  - 568926
+2618540:
+  aliases: ['unclassified Nyctalus']
+  parents:
+  - 51299
+2623095:
+  aliases: ['unclassified Nycteris']
+  parents:
+  - 59466
+2968822:
+  aliases: ['unclassified Nyctinomops']
+  parents:
+  - 27625
+2720896:
+  aliases: ['unclassified Nyctophilus']
+  parents:
+  - 59470
+1032380:
+  aliases: ['unclassified Pipistrellus']
+  parents:
+  - 27671
+1032398:
+  aliases: ['unclassified Plecotus']
+  parents:
+  - 27673
+2907245:
+  aliases: ['unclassified Promops']
+  parents:
+  - 27628
+2778575:
+  aliases: ['unclassified Pseudoromicia']
+  parents:
+  - 2778566
+2632027:
+  aliases: ['unclassified Pteronotus']
+  parents:
+  - 59475
+3136031:
+  aliases: ['unclassified Pteropodidae']
+  parents:
+  - 9398
+1296575:
+  aliases: ['unclassified Rhinolophidae']
+  parents:
+  - 58055
+2622910:
+  aliases: ['unclassified Rhogeessa']
+  parents:
+  - 153294
+2636109:
+  aliases: ['unclassified Scotoecus']
+  parents:
+  - 258954
+2645158:
+  aliases: ['unclassified Scotophilus']
+  parents:
+  - 153296
+2636263:
+  aliases: ['unclassified Scotorepens']
+  parents:
+  - 270779
+2951462:
+  aliases: ['unclassified Submyotodon']
+  parents:
+  - 1636536
+2636308:
+  aliases: ['unclassified Tadarida']
+  parents:
+  - 9437
+58056:
+  aliases: ['Acerodon']
+  parents:
+  - 77225
+77226:
+  aliases: ['Aethalops']
+  parents:
+  - 3136027
+662936:
+  aliases: ['Alionycteris']
+  parents:
+  - 3136027
+148033:
+  aliases: ['Ametrida centurio']
+  parents:
+  - 148022
+3045830:
+  aliases: ['Anoura aequatoris']
+  parents:
+  - 27641
+2563022:
+  aliases: ['Anoura cadenai']
+  parents:
+  - 27641
+27642:
+  aliases: ['Anoura caudifer']
+  parents:
+  - 27641
+999941:
+  aliases: ['Anoura cultrata']
+  parents:
+  - 27641
+2563023:
+  aliases: ['Anoura fistulata']
+  parents:
+  - 27641
+148021:
+  aliases: ['Anoura geoffroyi']
+  parents:
+  - 27641
+409016:
+  aliases: ['Anoura latidens']
+  parents:
+  - 27641
+2563024:
+  aliases: ['Anoura luismanueli']
+  parents:
+  - 27641
+2718989:
+  aliases: ['Anoura peruana']
+  parents:
+  - 27641
+302397:
+  aliases: ['Anthops ornatus']
+  parents:
+  - 302396
+2980641:
+  aliases: ['Antrozous pallidus pacificus']
+  parents:
+  - 9440
+2980642:
+  aliases: ['Antrozous pallidus pallidus']
+  parents:
+  - 9440
+58058:
+  aliases: ['Aproteles']
+  parents:
+  - 77225
+148034:
+  aliases: ['Ardops nichollsi']
+  parents:
+  - 148023
+2093339:
+  aliases: ['Arielulus sp. GS16483']
+  parents:
+  - 2648285
+3425205:
+  aliases: ['Arielulus sp. j RL-2025']
+  parents:
+  - 2648285
+148035:
+  aliases: ['Ariteus flavescens']
+  parents:
+  - 148024
+3369720:
+  aliases: ['Artibeus aequatorialis']
+  parents:
+  - 9416
+283491:
+  aliases: ['Artibeus amplus']
+  parents:
+  - 9416
+51015:
+  aliases: ['Artibeus anderseni']
+  parents:
+  - 9416
+40239:
+  aliases: ['Artibeus aztecus']
+  parents:
+  - 9416
+416809:
+  aliases: ['Artibeus cf. jamaicensis']
+  parents:
+  - 9416
+410850:
+  aliases: ['Artibeus cf. obscurus']
+  parents:
+  - 9416
+40224:
+  aliases: ['Artibeus cinereus']
+  parents:
+  - 9416
+40225:
+  aliases: ['Artibeus concolor']
+  parents:
+  - 9416
+51010:
+  aliases: ['Artibeus fimbriatus']
+  parents:
+  - 9416
+51011:
+  aliases: ['Artibeus fraterculus']
+  parents:
+  - 9416
+40226:
+  aliases: ['Artibeus glaucus']
+  parents:
+  - 9416
+27654:
+  aliases: ['Artibeus hartii']
+  parents:
+  - 9416
+51012:
+  aliases: ['Artibeus hirsutus']
+  parents:
+  - 9416
+51013:
+  aliases: ['Artibeus inopinatus']
+  parents:
+  - 9416
+51014:
+  aliases: ['Artibeus intermedius']
+  parents:
+  - 9416
+9417:
+  aliases: ['Artibeus jamaicensis']
+  parents:
+  - 9416
+27634:
+  aliases: ['Artibeus lituratus']
+  parents:
+  - 9416
+40228:
+  aliases: ['Artibeus obscurus']
+  parents:
+  - 9416
+40230:
+  aliases: ['Artibeus planirostris']
+  parents:
+  - 9416
+406813:
+  aliases: ['Artibeus schwartzi']
+  parents:
+  - 9416
+40240:
+  aliases: ['Artibeus toltecus']
+  parents:
+  - 9416
+1932780:
+  aliases: ['Asellia arabica']
+  parents:
+  - 578339
+1932781:
+  aliases: ['Asellia italosomalica']
+  parents:
+  - 578339
+578340:
+  aliases: ['Asellia tridens']
+  parents:
+  - 578339
+1873076:
+  aliases: ['Aselliscus dongbacanus']
+  parents:
+  - 188567
+188568:
+  aliases: ['Aselliscus stoliczkanus']
+  parents:
+  - 188567
+409885:
+  aliases: ['Aselliscus tricuspidatus']
+  parents:
+  - 188567
+463802:
+  aliases: ['Balantiopteryx infusca']
+  parents:
+  - 148079
+463801:
+  aliases: ['Balantiopteryx io']
+  parents:
+  - 148079
+249010:
+  aliases: ['Balantiopteryx plicata']
+  parents:
+  - 148079
+77228:
+  aliases: ['Balionycteris']
+  parents:
+  - 3136027
+187022:
+  aliases: ['Barbastella sp. 7184']
+  parents:
+  - 2677011
+270781:
+  aliases: ['Boneia']
+  parents:
+  - 77225
+9421:
+  aliases: ['Brachyphylla cavernarum']
+  parents:
+  - 9420
+290570:
+  aliases: ['Brachyphylla nana']
+  parents:
+  - 9420
+270764:
+  aliases: ['Cardioderma cor']
+  parents:
+  - 270763
+348608:
+  aliases: ['Carollia benkeithi']
+  parents:
+  - 40232
+138695:
+  aliases: ['Carollia brevicauda']
+  parents:
+  - 40232
+409058:
+  aliases: ['Carollia brevicauda PS1']
+  parents:
+  - 40232
+409059:
+  aliases: ['Carollia brevicauda PS2']
+  parents:
+  - 40232
+138696:
+  aliases: ['Carollia castanea']
+  parents:
+  - 40232
+1331094:
+  aliases: ['Carollia manu']
+  parents:
+  - 40232
+40233:
+  aliases: ['Carollia perspicillata']
+  parents:
+  - 40232
+208969:
+  aliases: ['Carollia sowelli']
+  parents:
+  - 40232
+138697:
+  aliases: ['Carollia subrufa']
+  parents:
+  - 40232
+1091508:
+  aliases: ['Casinycteris']
+  parents:
+  - 3136029
+463805:
+  aliases: ['Centronycteris centralis']
+  parents:
+  - 461396
+461398:
+  aliases: ['Centronycteris maximiliani']
+  parents:
+  - 461396
+27644:
+  aliases: ['Centurio senex']
+  parents:
+  - 27643
+33544:
+  aliases: ['Chiroderma doriae']
+  parents:
+  - 27645
+2723912:
+  aliases: ['Chiroderma gorgasi']
+  parents:
+  - 27645
+33545:
+  aliases: ['Chiroderma improvisum']
+  parents:
+  - 27645
+27646:
+  aliases: ['Chiroderma salvini']
+  parents:
+  - 27645
+2771405:
+  aliases: ['Chiroderma scopaeum']
+  parents:
+  - 27645
+27647:
+  aliases: ['Chiroderma trinitatum']
+  parents:
+  - 27645
+33546:
+  aliases: ['Chiroderma villosum']
+  parents:
+  - 27645
+170235:
+  aliases: ['Chironax']
+  parents:
+  - 3136027
+148049:
+  aliases: ['Choeroniscus godmani']
+  parents:
+  - 148042
+249003:
+  aliases: ['Choeroniscus minor']
+  parents:
+  - 148042
+148050:
+  aliases: ['Choeronycteris mexicana']
+  parents:
+  - 148043
+148086:
+  aliases: ['Chrotopterus auritus']
+  parents:
+  - 148075
+302400:
+  aliases: ['Cloeotis percivali']
+  parents:
+  - 302399
+568167:
+  aliases: ['Cnephaeus bottae hingstoni']
+  parents:
+  - 3371009
+568166:
+  aliases: ['Cnephaeus bottae innesi']
+  parents:
+  - 3371009
+1332043:
+  aliases: ['Cnephaeus bottae omanensis']
+  parents:
+  - 3371009
+568165:
+  aliases: ['Cnephaeus bottae taftanimontis']
+  parents:
+  - 3371009
+1332047:
+  aliases: ['Cnephaeus hottentotus hottentotus']
+  parents:
+  - 3371012
+1332048:
+  aliases: ['Cnephaeus hottentotus pallidior']
+  parents:
+  - 3371012
+568169:
+  aliases: ['Cnephaeus isabellinus boscai']
+  parents:
+  - 3371013
+568168:
+  aliases: ['Cnephaeus isabellinus isabellinus']
+  parents:
+  - 3371013
+568173:
+  aliases: ['Cnephaeus serotinus andersoni']
+  parents:
+  - 3371021
+568171:
+  aliases: ['Cnephaeus serotinus mirza']
+  parents:
+  - 3371021
+1332050:
+  aliases: ['Cnephaeus serotinus pallens']
+  parents:
+  - 3371021
+568170:
+  aliases: ['Cnephaeus serotinus turcomanus']
+  parents:
+  - 3371021
+867837:
+  aliases: ['Cnephaeus sp. A JLE-2010']
+  parents:
+  - 3411095
+3043885:
+  aliases: ['Cnephaeus sp. AMNH M-183876']
+  parents:
+  - 3411095
+2662407:
+  aliases: ['Cnephaeus sp. AMNH M-278521']
+  parents:
+  - 3411095
+2662408:
+  aliases: ['Cnephaeus sp. AMNH M-278524']
+  parents:
+  - 3411095
+2801925:
+  aliases: ['Cnephaeus sp. Culul134']
+  parents:
+  - 3411095
+2801926:
+  aliases: ['Cnephaeus sp. Culul140']
+  parents:
+  - 3411095
+2801927:
+  aliases: ['Cnephaeus sp. Culul142']
+  parents:
+  - 3411095
+3043883:
+  aliases: ['Cnephaeus sp. FMNH 174918']
+  parents:
+  - 3411095
+2871750:
+  aliases: ['Cnephaeus sp. MNKM-5584']
+  parents:
+  - 3411095
+2871754:
+  aliases: ['Cnephaeus sp. MNKM-5585']
+  parents:
+  - 3411095
+2871752:
+  aliases: ['Cnephaeus sp. MNKM-5587']
+  parents:
+  - 3411095
+2871753:
+  aliases: ['Cnephaeus sp. MNKM-5588']
+  parents:
+  - 3411095
+2871751:
+  aliases: ['Cnephaeus sp. MNKM-5592']
+  parents:
+  - 3411095
+2801933:
+  aliases: ['Cnephaeus sp. Santa Fe195']
+  parents:
+  - 3411095
+3043884:
+  aliases: ['Cnephaeus sp. USNM 548682']
+  parents:
+  - 3411095
+3043886:
+  aliases: ['Cnephaeus sp. USNM 548683']
+  parents:
+  - 3411095
+1964285:
+  aliases: ['Cnephaeus sp. VN11-0076']
+  parents:
+  - 3411095
+3042451:
+  aliases: ['Cnephaeus sp. i XY-2023']
+  parents:
+  - 3411095
+1332053:
+  aliases: ['Cnephaues serotinus serotinus']
+  parents:
+  - 3371021
+187002:
+  aliases: ['Coelops frithii']
+  parents:
+  - 187001
+1116470:
+  aliases: ['Coelops robinsoni']
+  parents:
+  - 187001
+907075:
+  aliases: ['Coleura afra']
+  parents:
+  - 461397
+1244808:
+  aliases: ['Coleura kibomalandy']
+  parents:
+  - 461397
+1116479:
+  aliases: ['Coleura seychellensis']
+  parents:
+  - 461397
+249012:
+  aliases: ['Cormura brevirostris']
+  parents:
+  - 249011
+1282260:
+  aliases: ['Corynorhinus townsendii australis']
+  parents:
+  - 124745
+1684320:
+  aliases: ['Corynorhinus townsendii ingens']
+  parents:
+  - 124745
+451111:
+  aliases: ['Corynorhinus townsendii pallescens']
+  parents:
+  - 124745
+451110:
+  aliases: ['Corynorhinus townsendii townsendii']
+  parents:
+  - 124745
+3079487:
+  aliases: ['Corynorhinus townsendii virginianus']
+  parents:
+  - 124745
+208972:
+  aliases: ['Craseonycteris thonglongyai']
+  parents:
+  - 208971
+1833836:
+  aliases: ['Cynomops abrasus mastivus']
+  parents:
+  - 748910
+1833840:
+  aliases: ['Cynomops paranus milleri']
+  parents:
+  - 303307
+1833841:
+  aliases: ['Cynomops sp. PN181']
+  parents:
+  - 2648417
+1833842:
+  aliases: ['Cynomops sp. PN293']
+  parents:
+  - 2648417
+1833843:
+  aliases: ['Cynomops sp. PN299']
+  parents:
+  - 2648417
+1833844:
+  aliases: ['Cynomops sp. PN305']
+  parents:
+  - 2648417
+1833845:
+  aliases: ['Cynomops sp. PN310']
+  parents:
+  - 2648417
+1833846:
+  aliases: ['Cynomops sp. PN316']
+  parents:
+  - 2648417
+1833847:
+  aliases: ['Cynomops sp. PN73']
+  parents:
+  - 2648417
+1833848:
+  aliases: ['Cynomops sp. PN73B']
+  parents:
+  - 2648417
+1833849:
+  aliases: ['Cynomops sp. PN88']
+  parents:
+  - 2648417
+1848985:
+  aliases: ['Cynomops sp. USNM 319084']
+  parents:
+  - 2648417
+9399:
+  aliases: ['Cynopterus']
+  parents:
+  - 3136027
+409020:
+  aliases: ['Cyttarops alecto']
+  parents:
+  - 409019
+2066583:
+  aliases: ['Dasypterus intermedius floridanus']
+  parents:
+  - 592573
+2738915:
+  aliases: ['Dasypterus intermedius intermedius']
+  parents:
+  - 592573
+409017:
+  aliases: ['Dermanura bogotensis']
+  parents:
+  - 563992
+3369931:
+  aliases: ['Dermanura gnomus']
+  parents:
+  - 563992
+594609:
+  aliases: ['Dermanura incomitata']
+  parents:
+  - 563992
+40229:
+  aliases: ['Dermanura phaeotis']
+  parents:
+  - 563992
+563994:
+  aliases: ['Dermanura rava']
+  parents:
+  - 563992
+515994:
+  aliases: ['Desmalopex']
+  parents:
+  - 77225
+9430:
+  aliases: ['Desmodus rotundus']
+  parents:
+  - 9429
+148087:
+  aliases: ['Diaemus youngi']
+  parents:
+  - 148076
+148088:
+  aliases: ['Diclidurus albus']
+  parents:
+  - 148078
+463803:
+  aliases: ['Diclidurus ingens']
+  parents:
+  - 148078
+409021:
+  aliases: ['Diclidurus isabella']
+  parents:
+  - 148078
+210810:
+  aliases: ['Diclidurus scutatus']
+  parents:
+  - 148078
+148089:
+  aliases: ['Diphylla ecaudata']
+  parents:
+  - 148077
+42146:
+  aliases: ['Dobsonia']
+  parents:
+  - 77225
+2664497:
+  aliases: ['Doryrhina camerunensis']
+  parents:
+  - 2664496
+2735189:
+  aliases: ['Doryrhina cf. camerunensis TD-2020']
+  parents:
+  - 2664496
+249021:
+  aliases: ['Doryrhina cyclops']
+  parents:
+  - 2664496
+2735198:
+  aliases: ['Doryrhina cyclops complex sp. lineage 2']
+  parents:
+  - 2664496
+326080:
+  aliases: ['Dyacopterus']
+  parents:
+  - 3136027
+148036:
+  aliases: ['Ectophylla alba']
+  parents:
+  - 148025
+58062:
+  aliases: ['Eidolon']
+  parents:
+  - 77225
+187004:
+  aliases: ['Emballonura alecto']
+  parents:
+  - 110939
+446907:
+  aliases: ['Emballonura beccarii']
+  parents:
+  - 110939
+1116478:
+  aliases: ['Emballonura dianae']
+  parents:
+  - 110939
+175525:
+  aliases: ['Emballonura monticola']
+  parents:
+  - 110939
+446908:
+  aliases: ['Emballonura raffrayana']
+  parents:
+  - 110939
+170234:
+  aliases: ['Emballonura semicaudata']
+  parents:
+  - 110939
+450945:
+  aliases: ['Emballonura serii']
+  parents:
+  - 110939
+58064:
+  aliases: ['Eonycteris']
+  parents:
+  - 3136029
+1246964:
+  aliases: ['Epomophorini']
+  parents:
+  - 3136030
+3079504:
+  aliases: ['Eptesicus fuscus bernardinus']
+  parents:
+  - 29078
+2871749:
+  aliases: ['Eptesicus fuscus fuscus']
+  parents:
+  - 29078
+2871748:
+  aliases: ['Eptesicus fuscus miradorensis']
+  parents:
+  - 29078
+3242296:
+  aliases: ['Eptesicus fuscus wetmorei']
+  parents:
+  - 29078
+3042450:
+  aliases: ['Eptesicus sp.']
+  parents:
+  - 2643748
+290569:
+  aliases: ['Erophylla bombifrons']
+  parents:
+  - 148091
+148092:
+  aliases: ['Erophylla sezekorni']
+  parents:
+  - 148091
+507607:
+  aliases: ['Eumops glaucinus floridanus']
+  parents:
+  - 27619
+1504290:
+  aliases: ['Eumops sp. LMM-2014a']
+  parents:
+  - 2619363
+507608:
+  aliases: ['Eumops sp. MMM-2008']
+  parents:
+  - 2619363
+148071:
+  aliases: ['Gardnerycteris crenulata']
+  parents:
+  - 1920523
+2358194:
+  aliases: ['Gardnerycteris keenani']
+  parents:
+  - 1920523
+2358195:
+  aliases: ['Gardnerycteris koepckeae']
+  parents:
+  - 1920523
+3465175:
+  aliases: ['Glauconycteris sp.']
+  parents:
+  - 2634626
+2448870:
+  aliases: ['Glauconycteris sp. DMR-2017']
+  parents:
+  - 2634626
+177159:
+  aliases: ['Glossophaga commissarisi']
+  parents:
+  - 27637
+177160:
+  aliases: ['Glossophaga leachii']
+  parents:
+  - 27637
+177161:
+  aliases: ['Glossophaga longirostris']
+  parents:
+  - 27637
+177162:
+  aliases: ['Glossophaga morenoi']
+  parents:
+  - 27637
+2994998:
+  aliases: ['Glossophaga mutica']
+  parents:
+  - 27637
+27638:
+  aliases: ['Glossophaga soricina']
+  parents:
+  - 27637
+148064:
+  aliases: ['Glyphonycteris daviesi']
+  parents:
+  - 409028
+409029:
+  aliases: ['Glyphonycteris sylvestris']
+  parents:
+  - 409028
+301157:
+  aliases: ['Haplonycteris']
+  parents:
+  - 3136027
+378749:
+  aliases: ['Harpyionycteris']
+  parents:
+  - 3136028
+249020:
+  aliases: ['Hipposideros abae']
+  parents:
+  - 58068
+1001821:
+  aliases: ['Hipposideros aff. ruber']
+  parents:
+  - 58068
+1197849:
+  aliases: ['Hipposideros alongensis']
+  parents:
+  - 58068
+186990:
+  aliases: ['Hipposideros armiger']
+  parents:
+  - 58068
+279184:
+  aliases: ['Hipposideros ater']
+  parents:
+  - 58068
+635128:
+  aliases: ['Hipposideros beatus']
+  parents:
+  - 58068
+2735199:
+  aliases: ['Hipposideros beatus complex sp. lineage 2']
+  parents:
+  - 58068
+157961:
+  aliases: ['Hipposideros bicolor']
+  parents:
+  - 58068
+869068:
+  aliases: ["Hipposideros bicolor '131 KHz'"]
+  parents:
+  - 58068
+869067:
+  aliases: ["Hipposideros bicolor '142 KHz'"]
+  parents:
+  - 58068
+1116360:
+  aliases: ['Hipposideros boeadii']
+  parents:
+  - 58068
+302402:
+  aliases: ['Hipposideros caffer']
+  parents:
+  - 58068
+2735201:
+  aliases: ['Hipposideros caffer complex sp. lineage 1']
+  parents:
+  - 58068
+2735202:
+  aliases: ['Hipposideros caffer complex sp. lineage 2']
+  parents:
+  - 58068
+2735203:
+  aliases: ['Hipposideros caffer complex sp. lineage 3']
+  parents:
+  - 58068
+2735204:
+  aliases: ['Hipposideros caffer complex sp. lineage 5']
+  parents:
+  - 58068
+2735205:
+  aliases: ['Hipposideros caffer complex sp. lineage 6']
+  parents:
+  - 58068
+2735206:
+  aliases: ['Hipposideros caffer complex sp. lineage 7']
+  parents:
+  - 58068
+2735207:
+  aliases: ['Hipposideros caffer complex sp. lineage 8']
+  parents:
+  - 58068
+334198:
+  aliases: ['Hipposideros calcaratus']
+  parents:
+  - 58068
+170233:
+  aliases: ['Hipposideros cervinus']
+  parents:
+  - 58068
+2974923:
+  aliases: ['Hipposideros cf. abae ZMMU S-189528']
+  parents:
+  - 58068
+2973845:
+  aliases: ['Hipposideros cf. armiger ZMMU S-167159']
+  parents:
+  - 58068
+867823:
+  aliases: ['Hipposideros cf. ater CMF-2010']
+  parents:
+  - 58068
+2735190:
+  aliases: ['Hipposideros cf. bicolor TD-2020']
+  parents:
+  - 58068
+2735191:
+  aliases: ['Hipposideros cf. cervinus TD-2020']
+  parents:
+  - 58068
+867825:
+  aliases: ['Hipposideros cf. cineraceus CMF-2010']
+  parents:
+  - 58068
+3025977:
+  aliases: ['Hipposideros cf. grandis S-195419']
+  parents:
+  - 58068
+3025978:
+  aliases: ['Hipposideros cf. grandis S-195420']
+  parents:
+  - 58068
+2973841:
+  aliases: ['Hipposideros cf. grandis ZMMU S-195421']
+  parents:
+  - 58068
+2973842:
+  aliases: ['Hipposideros cf. griffini ZMMU S-195483']
+  parents:
+  - 58068
+3117227:
+  aliases: ['Hipposideros cf. larvatus']
+  parents:
+  - 58068
+2821768:
+  aliases: ['Hipposideros cf. larvatus BM.2019.05.07']
+  parents:
+  - 58068
+3025988:
+  aliases: ['Hipposideros cf. larvatus CLC17']
+  parents:
+  - 58068
+3025967:
+  aliases: ['Hipposideros cf. larvatus CLC18']
+  parents:
+  - 58068
+3025971:
+  aliases: ['Hipposideros cf. larvatus NTS14']
+  parents:
+  - 58068
+3025972:
+  aliases: ['Hipposideros cf. larvatus NTS15']
+  parents:
+  - 58068
+3025987:
+  aliases: ['Hipposideros cf. larvatus NTS23']
+  parents:
+  - 58068
+3025973:
+  aliases: ['Hipposideros cf. larvatus NTS51']
+  parents:
+  - 58068
+3025991:
+  aliases: ['Hipposideros cf. larvatus S-195977']
+  parents:
+  - 58068
+3025992:
+  aliases: ['Hipposideros cf. larvatus S-195978']
+  parents:
+  - 58068
+3025993:
+  aliases: ['Hipposideros cf. larvatus VN17-278']
+  parents:
+  - 58068
+3025994:
+  aliases: ['Hipposideros cf. larvatus VN17-279']
+  parents:
+  - 58068
+3025974:
+  aliases: ['Hipposideros cf. larvatus Y1']
+  parents:
+  - 58068
+3025985:
+  aliases: ['Hipposideros cf. larvatus Y2']
+  parents:
+  - 58068
+3025986:
+  aliases: ['Hipposideros cf. larvatus Y22']
+  parents:
+  - 58068
+2528455:
+  aliases: ['Hipposideros cf. obscurus MRMD2479']
+  parents:
+  - 58068
+1007696:
+  aliases: ['Hipposideros cf. pomona BOLD:AAS6441']
+  parents:
+  - 58068
+3025965:
+  aliases: ['Hipposideros cf. poutensis BTL65']
+  parents:
+  - 58068
+3025966:
+  aliases: ['Hipposideros cf. poutensis BTL71']
+  parents:
+  - 58068
+3025975:
+  aliases: ['Hipposideros cf. poutensis M100']
+  parents:
+  - 58068
+3025976:
+  aliases: ['Hipposideros cf. poutensis M107']
+  parents:
+  - 58068
+3025968:
+  aliases: ['Hipposideros cf. poutensis NTS135']
+  parents:
+  - 58068
+3025969:
+  aliases: ['Hipposideros cf. poutensis NTS136']
+  parents:
+  - 58068
+3025970:
+  aliases: ['Hipposideros cf. poutensis NTS137']
+  parents:
+  - 58068
+3025989:
+  aliases: ['Hipposideros cf. poutensis S-190295']
+  parents:
+  - 58068
+3025990:
+  aliases: ['Hipposideros cf. poutensis S-190297']
+  parents:
+  - 58068
+3025980:
+  aliases: ['Hipposideros cf. poutensis SVK-18-069']
+  parents:
+  - 58068
+3025981:
+  aliases: ['Hipposideros cf. poutensis SVK-18-070']
+  parents:
+  - 58068
+3025982:
+  aliases: ['Hipposideros cf. poutensis SVK-18-073']
+  parents:
+  - 58068
+3025983:
+  aliases: ['Hipposideros cf. poutensis SVK-18-077']
+  parents:
+  - 58068
+1536428:
+  aliases: ['Hipposideros cf. ruber']
+  parents:
+  - 58068
+2973844:
+  aliases: ['Hipposideros cf. ruber ZMMU S-192897']
+  parents:
+  - 58068
+270698:
+  aliases: ['Hipposideros cineraceus']
+  parents:
+  - 58068
+1207988:
+  aliases: ['Hipposideros coronatus']
+  parents:
+  - 58068
+279183:
+  aliases: ['Hipposideros coxi']
+  parents:
+  - 58068
+1539854:
+  aliases: ['Hipposideros demissus']
+  parents:
+  - 58068
+59453:
+  aliases: ['Hipposideros diadema']
+  parents:
+  - 58068
+270735:
+  aliases: ['Hipposideros dinops']
+  parents:
+  - 58068
+646525:
+  aliases: ['Hipposideros doriae']
+  parents:
+  - 58068
+1980583:
+  aliases: ['Hipposideros durgadasi']
+  parents:
+  - 58068
+279182:
+  aliases: ['Hipposideros dyacorum']
+  parents:
+  - 58068
+3030809:
+  aliases: ['Hipposideros einnaythu']
+  parents:
+  - 58068
+584995:
+  aliases: ['Hipposideros fuliginosus']
+  parents:
+  - 58068
+599854:
+  aliases: ['Hipposideros fulvus']
+  parents:
+  - 58068
+58069:
+  aliases: ['Hipposideros galeritus']
+  parents:
+  - 58068
+2921318:
+  aliases: ['Hipposideros gentilis']
+  parents:
+  - 58068
+1197857:
+  aliases: ['Hipposideros griffini']
+  parents:
+  - 58068
+867827:
+  aliases: ['Hipposideros halophyllus']
+  parents:
+  - 58068
+1548708:
+  aliases: ['Hipposideros hypophyllus']
+  parents:
+  - 58068
+584997:
+  aliases: ['Hipposideros jonesi']
+  parents:
+  - 58068
+334199:
+  aliases: ['Hipposideros khaokhouayensis']
+  parents:
+  - 58068
+3030810:
+  aliases: ['Hipposideros kingstonae']
+  parents:
+  - 58068
+2448887:
+  aliases: ['Hipposideros kunzi']
+  parents:
+  - 58068
+1536425:
+  aliases: ['Hipposideros lamottei']
+  parents:
+  - 58068
+867828:
+  aliases: ['Hipposideros lankadiva']
+  parents:
+  - 58068
+354741:
+  aliases: ['Hipposideros larvatus sensu lato']
+  parents:
+  - 58068
+1207989:
+  aliases: ['Hipposideros lekaguli']
+  parents:
+  - 58068
+867829:
+  aliases: ['Hipposideros lylei']
+  parents:
+  - 58068
+1536426:
+  aliases: ['Hipposideros marisae']
+  parents:
+  - 58068
+3037311:
+  aliases: ['Hipposideros nicobarulae']
+  parents:
+  - 58068
+1116357:
+  aliases: ['Hipposideros obscurus']
+  parents:
+  - 58068
+1116358:
+  aliases: ['Hipposideros pelingensis']
+  parents:
+  - 58068
+867831:
+  aliases: ['Hipposideros pendleburyi']
+  parents:
+  - 58068
+334201:
+  aliases: ['Hipposideros pomona']
+  parents:
+  - 58068
+2970948:
+  aliases: ['Hipposideros poutensis']
+  parents:
+  - 58068
+188569:
+  aliases: ['Hipposideros pratti']
+  parents:
+  - 58068
+1207990:
+  aliases: ['Hipposideros pygmaeus']
+  parents:
+  - 58068
+279181:
+  aliases: ['Hipposideros ridleyi']
+  parents:
+  - 58068
+334200:
+  aliases: ['Hipposideros rotalis']
+  parents:
+  - 58068
+463808:
+  aliases: ['Hipposideros ruber']
+  parents:
+  - 58068
+2735208:
+  aliases: ['Hipposideros ruber complex sp. lineage 1']
+  parents:
+  - 58068
+2735209:
+  aliases: ['Hipposideros ruber complex sp. lineage 2']
+  parents:
+  - 58068
+2735210:
+  aliases: ['Hipposideros ruber complex sp. lineage 4']
+  parents:
+  - 58068
+1116359:
+  aliases: ['Hipposideros scutinares']
+  parents:
+  - 58068
+394056:
+  aliases: ['Hipposideros speoris']
+  parents:
+  - 58068
+185215:
+  aliases: ['Hipposideros turpis']
+  parents:
+  - 58068
+3043887:
+  aliases: ['Histiotus montanus inambarus']
+  parents:
+  - 1161940
+3044320:
+  aliases: ['Histiotus sp.']
+  parents:
+  - 2969770
+1470804:
+  aliases: ['Hsunycteris cadenai']
+  parents:
+  - 1470803
+2161707:
+  aliases: ['Hsunycteris dashe']
+  parents:
+  - 1470803
+1470994:
+  aliases: ['Hsunycteris pattoni']
+  parents:
+  - 1470803
+138705:
+  aliases: ['Hsunycteris thomasi']
+  parents:
+  - 1470803
+148051:
+  aliases: ['Hylonycteris underwoodi']
+  parents:
+  - 148044
+867833:
+  aliases: ['Hypsugo sp. A CMF-2010']
+  parents:
+  - 2620613
+509027:
+  aliases: ['Hypsugo sp. C1']
+  parents:
+  - 2620613
+509028:
+  aliases: ['Hypsugo sp. C2']
+  parents:
+  - 2620613
+509029:
+  aliases: ['Hypsugo sp. C4']
+  parents:
+  - 2620613
+412093:
+  aliases: ['Hypsugo sp. FFM-2006A']
+  parents:
+  - 2620613
+412092:
+  aliases: ['Hypsugo sp. FFM-2006B']
+  parents:
+  - 2620613
+1048812:
+  aliases: ['Hypsugo sp. Hsav-III-1']
+  parents:
+  - 2620613
+1838143:
+  aliases: ['Hypsugo sp. JA-2016a']
+  parents:
+  - 2620613
+509030:
+  aliases: ['Hypsugo sp. N1']
+  parents:
+  - 2620613
+509031:
+  aliases: ['Hypsugo sp. N2']
+  parents:
+  - 2620613
+509032:
+  aliases: ['Hypsugo sp. N7']
+  parents:
+  - 2620613
+509033:
+  aliases: ['Hypsugo sp. R1']
+  parents:
+  - 2620613
+2991276:
+  aliases: ['Hypsugo sp. SD-2022']
+  parents:
+  - 2620613
+3572148:
+  aliases: ['Kerivoula sp.']
+  parents:
+  - 2618055
+910446:
+  aliases: ['Kerivoula sp. FAK-2010']
+  parents:
+  - 2618055
+2069574:
+  aliases: ['Kerivoula sp. FMNH 190110']
+  parents:
+  - 2618055
+2069576:
+  aliases: ['Kerivoula sp. T017154']
+  parents:
+  - 2618055
+1691934:
+  aliases: ['Lasiurus blossevillii salinae']
+  parents:
+  - 258932
+1673613:
+  aliases: ['Lasiurus cinereus cinereus']
+  parents:
+  - 257879
+160977:
+  aliases: ['Lasiurus sp. (in: bats)']
+  parents:
+  - 2688611
+159319:
+  aliases: ['Lasiurus sp. MVZ_AD522']
+  parents:
+  - 2688611
+556918:
+  aliases: ['Latidens']
+  parents:
+  - 3136027
+1582325:
+  aliases: ['Lavia frons']
+  parents:
+  - 1582324
+55054:
+  aliases: ['Leptonycteris curasoae']
+  parents:
+  - 55053
+59456:
+  aliases: ['Leptonycteris nivalis']
+  parents:
+  - 55053
+700936:
+  aliases: ['Leptonycteris yerbabuenae']
+  parents:
+  - 55053
+1001577:
+  aliases: ['Lichonycteris obscura']
+  parents:
+  - 148045
+148090:
+  aliases: ['Lionycteris spurrelli']
+  parents:
+  - 148084
+237984:
+  aliases: ['Lonchophylla chocoana']
+  parents:
+  - 138704
+1303335:
+  aliases: ['Lonchophylla concava']
+  parents:
+  - 138704
+1654710:
+  aliases: ['Lonchophylla dekeyseri']
+  parents:
+  - 138704
+190507:
+  aliases: ['Lonchophylla handleyi']
+  parents:
+  - 138704
+1470801:
+  aliases: ['Lonchophylla hesperia']
+  parents:
+  - 138704
+190508:
+  aliases: ['Lonchophylla mordax']
+  parents:
+  - 138704
+1470802:
+  aliases: ['Lonchophylla orienticollina']
+  parents:
+  - 138704
+190509:
+  aliases: ['Lonchophylla robusta']
+  parents:
+  - 138704
+148061:
+  aliases: ['Lonchorhina aurita']
+  parents:
+  - 148054
+409030:
+  aliases: ['Lonchorhina inusitata']
+  parents:
+  - 148054
+249006:
+  aliases: ['Lonchorhina orinocensis']
+  parents:
+  - 148054
+409031:
+  aliases: ['Lophostoma brasiliense']
+  parents:
+  - 263450
+409032:
+  aliases: ['Lophostoma carrikeri']
+  parents:
+  - 263450
+3370176:
+  aliases: ['Lophostoma evote']
+  parents:
+  - 263450
+3370179:
+  aliases: ['Lophostoma occidentale']
+  parents:
+  - 263450
+409033:
+  aliases: ['Lophostoma schulzi']
+  parents:
+  - 263450
+3370180:
+  aliases: ['Lophostoma silvicola']
+  parents:
+  - 263450
+3371112:
+  aliases: ['Lyroderma lyra']
+  parents:
+  - 3371052
+3381542:
+  aliases: ['Lyroderma sinense']
+  parents:
+  - 3371052
+9411:
+  aliases: ['Macroderma gigas']
+  parents:
+  - 9410
+29075:
+  aliases: ['Macroglossus']
+  parents:
+  - 77241
+110941:
+  aliases: ['Macronycteris commersonii']
+  parents:
+  - 2603868
+2735188:
+  aliases: ['Macronycteris cryptovalorona']
+  parents:
+  - 2603868
+584996:
+  aliases: ['Macronycteris gigas']
+  parents:
+  - 2603868
+2603869:
+  aliases: ['Macronycteris vittatus']
+  parents:
+  - 2603868
+148062:
+  aliases: ['Macrophyllum macrophyllum']
+  parents:
+  - 148055
+9419:
+  aliases: ['Macrotus californicus']
+  parents:
+  - 9418
+124750:
+  aliases: ['Macrotus waterhousii']
+  parents:
+  - 9418
+9414:
+  aliases: ['Megaderma spasma']
+  parents:
+  - 9412
+77232:
+  aliases: ['Megaerops']
+  parents:
+  - 3136027
+58074:
+  aliases: ['Melonycteris']
+  parents:
+  - 77241
+148094:
+  aliases: ['Mesophylla macconnelli']
+  parents:
+  - 148026
+148063:
+  aliases: ['Micronycteris brachyotis']
+  parents:
+  - 148056
+257473:
+  aliases: ['Micronycteris brosseti']
+  parents:
+  - 148056
+948073:
+  aliases: ['Micronycteris buriri']
+  parents:
+  - 148056
+338418:
+  aliases: ['Micronycteris cf. schmidtorum']
+  parents:
+  - 148056
+260821:
+  aliases: ['Micronycteris giovanniae']
+  parents:
+  - 148056
+148065:
+  aliases: ['Micronycteris hirsuta']
+  parents:
+  - 148056
+249007:
+  aliases: ['Micronycteris homezi']
+  parents:
+  - 148056
+338419:
+  aliases: ['Micronycteris matses']
+  parents:
+  - 148056
+148066:
+  aliases: ['Micronycteris megalotis']
+  parents:
+  - 148056
+249008:
+  aliases: ['Micronycteris microtis']
+  parents:
+  - 148056
+148067:
+  aliases: ['Micronycteris minuta']
+  parents:
+  - 148056
+2294179:
+  aliases: ['Micronycteris sanborni']
+  parents:
+  - 148056
+148069:
+  aliases: ['Micronycteris schmidtorum']
+  parents:
+  - 148056
+2748164:
+  aliases: ['Micronycteris simmonsae']
+  parents:
+  - 148056
+2748165:
+  aliases: ['Micronycteris tresamici']
+  parents:
+  - 148056
+1365274:
+  aliases: ['Micronycteris yatesi']
+  parents:
+  - 148056
+410851:
+  aliases: ['Mimon bennettii']
+  parents:
+  - 148057
+999935:
+  aliases: ['Mimon cozumelae']
+  parents:
+  - 148057
+645311:
+  aliases: ['Miniopterus griveaudi griveaudi']
+  parents:
+  - 568717
+1715694:
+  aliases: ['Miniopterus inflatus rufus']
+  parents:
+  - 221087
+1286218:
+  aliases: ['Miniopterus natalensis arenarius']
+  parents:
+  - 291302
+117601:
+  aliases: ['Miniopterus orianae bassanii']
+  parents:
+  - 2291841
+117603:
+  aliases: ['Miniopterus orianae oceanensis']
+  parents:
+  - 2291841
+117602:
+  aliases: ['Miniopterus schreibersii blepotis']
+  parents:
+  - 9433
+291299:
+  aliases: ['Miniopterus schreibersii pallidus']
+  parents:
+  - 9433
+559842:
+  aliases: ['Miniopterus schreibersii schreibersii']
+  parents:
+  - 9433
+3075049:
+  aliases: ['Miniopterus sp.']
+  parents:
+  - 2645810
+3062232:
+  aliases: ['Miniopterus sp. A TD-2023']
+  parents:
+  - 2645810
+3062233:
+  aliases: ['Miniopterus sp. B TD-2023']
+  parents:
+  - 2645810
+1975658:
+  aliases: ['Miniopterus sp. B165']
+  parents:
+  - 2645810
+1975654:
+  aliases: ['Miniopterus sp. B76']
+  parents:
+  - 2645810
+1975655:
+  aliases: ['Miniopterus sp. B96']
+  parents:
+  - 2645810
+221090:
+  aliases: ['Miniopterus sp. BBRA-2002']
+  parents:
+  - 2645810
+3062234:
+  aliases: ['Miniopterus sp. C TD-2023']
+  parents:
+  - 2645810
+581158:
+  aliases: ['Miniopterus sp. Comoros clade 2']
+  parents:
+  - 2645810
+3062235:
+  aliases: ['Miniopterus sp. D TD-2023']
+  parents:
+  - 2645810
+2448874:
+  aliases: ['Miniopterus sp. DMR-2017']
+  parents:
+  - 2645810
+3062236:
+  aliases: ['Miniopterus sp. E TD-2023']
+  parents:
+  - 2645810
+645309:
+  aliases: ['Miniopterus sp. FMNH 167450']
+  parents:
+  - 2645810
+645310:
+  aliases: ['Miniopterus sp. FMNH 172602']
+  parents:
+  - 2645810
+1002346:
+  aliases: ['Miniopterus sp. IVK-2011']
+  parents:
+  - 2645810
+1477906:
+  aliases: ['Miniopterus sp. P3']
+  parents:
+  - 2645810
+1477907:
+  aliases: ['Miniopterus sp. P4']
+  parents:
+  - 2645810
+1477908:
+  aliases: ['Miniopterus sp. P5']
+  parents:
+  - 2645810
+1477909:
+  aliases: ['Miniopterus sp. P6']
+  parents:
+  - 2645810
+1477910:
+  aliases: ['Miniopterus sp. P7']
+  parents:
+  - 2645810
+1574125:
+  aliases: ['Miniopterus sp. SMG-2014a']
+  parents:
+  - 2645810
+1477911:
+  aliases: ['Miniopterus sp. X3']
+  parents:
+  - 2645810
+2715948:
+  aliases: ['Miniopterus sp. clade 1 TD-2020']
+  parents:
+  - 2645810
+2715949:
+  aliases: ['Miniopterus sp. clade 10 TD-2020']
+  parents:
+  - 2645810
+2715950:
+  aliases: ['Miniopterus sp. clade 2 TD-2020']
+  parents:
+  - 2645810
+2715951:
+  aliases: ['Miniopterus sp. clade 3 TD-2020']
+  parents:
+  - 2645810
+2715952:
+  aliases: ['Miniopterus sp. clade 4 TD-2020']
+  parents:
+  - 2645810
+2715953:
+  aliases: ['Miniopterus sp. clade 5 TD-2020']
+  parents:
+  - 2645810
+2715954:
+  aliases: ['Miniopterus sp. clade 6 TD-2020']
+  parents:
+  - 2645810
+2715955:
+  aliases: ['Miniopterus sp. clade 7 TD-2020']
+  parents:
+  - 2645810
+2715956:
+  aliases: ['Miniopterus sp. clade 8 TD-2020']
+  parents:
+  - 2645810
+2715957:
+  aliases: ['Miniopterus sp. clade 9 TD-2020']
+  parents:
+  - 2645810
+2768032:
+  aliases: ['Miniopterus sp. n. TM-2020']
+  parents:
+  - 2645810
+2899231:
+  aliases: ['Miniopterus sp. p KDU-2021']
+  parents:
+  - 2645810
+3043828:
+  aliases: ['Miniopterus sp. s BS-2023']
+  parents:
+  - 2645810
+409374:
+  aliases: ['Miniopterus sp. sororculus']
+  parents:
+  - 2645810
+1496136:
+  aliases: ['Mirimiri']
+  parents:
+  - 77225
+2737246:
+  aliases: ['Molossops sp. MN1']
+  parents:
+  - 2737245
+1554505:
+  aliases: ['Molossus currentium bondae']
+  parents:
+  - 1269259
+1554504:
+  aliases: ['Molossus molossus daulensis']
+  parents:
+  - 27622
+1552296:
+  aliases: ['Molossus molossus molossus']
+  parents:
+  - 27622
+1554503:
+  aliases: ['Molossus molossus tropidorhynchus']
+  parents:
+  - 27622
+3041509:
+  aliases: ['Molossus sp.']
+  parents:
+  - 2625157
+409060:
+  aliases: ['Molossus sp. BOLD:AAX4787']
+  parents:
+  - 2625157
+245180:
+  aliases: ['Molossus sp. CRB2031']
+  parents:
+  - 2625157
+2801923:
+  aliases: ['Molossus sp. Esperanza129']
+  parents:
+  - 2625157
+2801924:
+  aliases: ['Molossus sp. Esperanza130']
+  parents:
+  - 2625157
+1920528:
+  aliases: ['Molossus sp. LL-2016']
+  parents:
+  - 2625157
+2801928:
+  aliases: ['Molossus sp. Santa Fe177']
+  parents:
+  - 2625157
+2801929:
+  aliases: ['Molossus sp. Santa Fe190']
+  parents:
+  - 2625157
+2801930:
+  aliases: ['Molossus sp. Santa Fe192']
+  parents:
+  - 2625157
+2801931:
+  aliases: ['Molossus sp. Santa Fe193']
+  parents:
+  - 2625157
+2801932:
+  aliases: ['Molossus sp. Santa Fe194']
+  parents:
+  - 2625157
+2801934:
+  aliases: ['Molossus sp. Santa Fe196']
+  parents:
+  - 2625157
+2801935:
+  aliases: ['Molossus sp. Santa Fe197']
+  parents:
+  - 2625157
+2801936:
+  aliases: ['Molossus sp. Santa Fe198']
+  parents:
+  - 2625157
+2801937:
+  aliases: ['Molossus sp. Santa Fe199']
+  parents:
+  - 2625157
+177163:
+  aliases: ['Monophyllus plethodon']
+  parents:
+  - 148046
+148052:
+  aliases: ['Monophyllus redmani']
+  parents:
+  - 148046
+3392088:
+  aliases: ['Mops brachypterus leonis']
+  parents:
+  - 3370274
+1495468:
+  aliases: ['Mops pumilus elphicki']
+  parents:
+  - 242384
+1495466:
+  aliases: ['Mops pumilus langi']
+  parents:
+  - 242384
+1495464:
+  aliases: ['Mops pumilus limbata']
+  parents:
+  - 242384
+1495465:
+  aliases: ['Mops pumilus naivashae']
+  parents:
+  - 242384
+3075048:
+  aliases: ['Mops sp.']
+  parents:
+  - 2632858
+2448866:
+  aliases: ['Mops sp. DMR-2017']
+  parents:
+  - 2632858
+1002343:
+  aliases: ['Mops sp. IVK-2011']
+  parents:
+  - 2632858
+2952391:
+  aliases: ['Mops sp. NG010_NGR']
+  parents:
+  - 2632858
+2952392:
+  aliases: ['Mops sp. NG014_NGR']
+  parents:
+  - 2632858
+2952393:
+  aliases: ['Mops sp. NG017_NGR']
+  parents:
+  - 2632858
+2952394:
+  aliases: ['Mops sp. NG019_NGR']
+  parents:
+  - 2632858
+2952395:
+  aliases: ['Mops sp. NG020_NGR']
+  parents:
+  - 2632858
+2952396:
+  aliases: ['Mops sp. NG022_NGR']
+  parents:
+  - 2632858
+2952389:
+  aliases: ['Mops sp. NG05_NGR']
+  parents:
+  - 2632858
+2952390:
+  aliases: ['Mops sp. NG07_NGR']
+  parents:
+  - 2632858
+2952397:
+  aliases: ['Mops sp. NGB024_NGR']
+  parents:
+  - 2632858
+450944:
+  aliases: ['Mosia nigrescens']
+  parents:
+  - 450943
+1837108:
+  aliases: ['Murina huttoni rubella']
+  parents:
+  - 258935
+3412428:
+  aliases: ['Murina huttonii rubella']
+  parents:
+  - 2933636
+3412434:
+  aliases: ['Murina sp.']
+  parents:
+  - 2685208
+3375539:
+  aliases: ['Murina sp. 2 PL-2024']
+  parents:
+  - 2685208
+3375540:
+  aliases: ['Murina sp. 3 PL-2024']
+  parents:
+  - 2685208
+187020:
+  aliases: ['Murina sp. 7386']
+  parents:
+  - 2685208
+2856836:
+  aliases: ['Murina sp. A BL-2021']
+  parents:
+  - 2685208
+867846:
+  aliases: ['Murina sp. A CMF-2010']
+  parents:
+  - 2685208
+1167678:
+  aliases: ['Murina sp. A MR-2012']
+  parents:
+  - 2685208
+1986511:
+  aliases: ['Murina sp. APBL060517-04']
+  parents:
+  - 2685208
+2856837:
+  aliases: ['Murina sp. B BL-2021']
+  parents:
+  - 2685208
+867847:
+  aliases: ['Murina sp. B CMF-2010']
+  parents:
+  - 2685208
+867848:
+  aliases: ['Murina sp. D CMF-2010']
+  parents:
+  - 2685208
+867849:
+  aliases: ['Murina sp. E JLE-2010']
+  parents:
+  - 2685208
+867850:
+  aliases: ['Murina sp. F JLE-2010']
+  parents:
+  - 2685208
+2069575:
+  aliases: ['Murina sp. FMNH 177476']
+  parents:
+  - 2685208
+3477260:
+  aliases: ['Murina sp. G BL-2025']
+  parents:
+  - 2685208
+375554:
+  aliases: ['Murina sp. GGJ-2006']
+  parents:
+  - 2685208
+479479:
+  aliases: ['Murina sp. GGL-2007']
+  parents:
+  - 2685208
+584771:
+  aliases: ['Murina sp. HZ-2008']
+  parents:
+  - 2685208
+479725:
+  aliases: ['Murina sp. V4']
+  parents:
+  - 2685208
+1453895:
+  aliases: ['Murina sp. VTT-2014a']
+  parents:
+  - 2685208
+3412431:
+  aliases: ['Murina sp. b TL-2025']
+  parents:
+  - 2685208
+3375541:
+  aliases: ['Murina sp. c PL-2024']
+  parents:
+  - 2685208
+3425207:
+  aliases: ['Murina sp. d RL-2025']
+  parents:
+  - 2685208
+460136:
+  aliases: ['Murina sp. hn1151']
+  parents:
+  - 2685208
+3390067:
+  aliases: ['Murina sp. l XM-2024']
+  parents:
+  - 2685208
+3425206:
+  aliases: ['Murina sp. m RL-2025']
+  parents:
+  - 2685208
+3412432:
+  aliases: ['Murina sp. me TL-2025']
+  parents:
+  - 2685208
+3412433:
+  aliases: ['Murina sp. mi TL-2025']
+  parents:
+  - 2685208
+3412430:
+  aliases: ['Murina sp. y TL-2025']
+  parents:
+  - 2685208
+3242755:
+  aliases: ['Murina sp. y XM-2024']
+  parents:
+  - 2685208
+3108934:
+  aliases: ['Murina sp. y XW-2023']
+  parents:
+  - 2685208
+148053:
+  aliases: ['Musonycteris harrisoni']
+  parents:
+  - 148047
+1246961:
+  aliases: ['Myonycterini']
+  parents:
+  - 3136030
+941652:
+  aliases: ['Myotis adversus adversus']
+  parents:
+  - 59461
+867861:
+  aliases: ['Myotis adversus taiwanensis']
+  parents:
+  - 59461
+941653:
+  aliases: ['Myotis adversus tanimbarensis']
+  parents:
+  - 59461
+392007:
+  aliases: ['Myotis blythii ancilla']
+  parents:
+  - 109482
+126576:
+  aliases: ['Myotis blythii blythii']
+  parents:
+  - 109482
+359394:
+  aliases: ['Myotis blythii omari']
+  parents:
+  - 109482
+1393934:
+  aliases: ['Myotis bocagii cupreolus']
+  parents:
+  - 153284
+392319:
+  aliases: ['Myotis bombinus amurensis']
+  parents:
+  - 392318
+2516278:
+  aliases: ['Myotis brandtii brandtii']
+  parents:
+  - 109478
+306064:
+  aliases: ['Myotis cf. nipalensis kukunorensis']
+  parents:
+  - 306063
+2980668:
+  aliases: ['Myotis ciliolabrum melanorhinus']
+  parents:
+  - 257884
+478518:
+  aliases: ['Myotis daubentonii daubentonii']
+  parents:
+  - 98922
+159318:
+  aliases: ['Myotis daubentonii nathalinae']
+  parents:
+  - 98922
+2510965:
+  aliases: ['Myotis escalerai cabrerae']
+  parents:
+  - 508772
+2510966:
+  aliases: ['Myotis escalerai escalerai']
+  parents:
+  - 508772
+1442610:
+  aliases: ['Myotis evotis milleri']
+  parents:
+  - 257883
+1393935:
+  aliases: ['Myotis horsfieldii deignani']
+  parents:
+  - 138977
+1393936:
+  aliases: ['Myotis horsfieldii horsfieldii']
+  parents:
+  - 138977
+384940:
+  aliases: ['Myotis lucifugus alascensis']
+  parents:
+  - 59463
+164660:
+  aliases: ['Myotis lucifugus carissima']
+  parents:
+  - 59463
+384942:
+  aliases: ['Myotis lucifugus lucifugus']
+  parents:
+  - 59463
+384941:
+  aliases: ['Myotis lucifugus relictus']
+  parents:
+  - 59463
+1163725:
+  aliases: ['Myotis martiniquensis nyctor']
+  parents:
+  - 385035
+159331:
+  aliases: ['Myotis muricola browni']
+  parents:
+  - 159330
+126574:
+  aliases: ['Myotis myotis myotis']
+  parents:
+  - 51298
+2510968:
+  aliases: ['Myotis nattereri helverseni']
+  parents:
+  - 109481
+2510969:
+  aliases: ['Myotis nattereri nattereri']
+  parents:
+  - 109481
+1163729:
+  aliases: ['Myotis nesopolus nesopolus']
+  parents:
+  - 1163727
+2976338:
+  aliases: ['Myotis nigricans osculatii']
+  parents:
+  - 153286
+1908665:
+  aliases: ['Myotis oxyotus gardneri']
+  parents:
+  - 159332
+572371:
+  aliases: ['Myotis siligorensis alticraniatus']
+  parents:
+  - 258940
+1911917:
+  aliases: ['Myotis sp.']
+  parents:
+  - 867169
+887567:
+  aliases: ['Myotis sp. 07BC0899YU']
+  parents:
+  - 867169
+670388:
+  aliases: ['Myotis sp. 1 HEN0826']
+  parents:
+  - 867169
+1393942:
+  aliases: ['Myotis sp. 1 MR-2013']
+  parents:
+  - 867169
+1239993:
+  aliases: ['Myotis sp. 1 Venezuela']
+  parents:
+  - 867169
+631201:
+  aliases: ['Myotis sp. 1 ZZ-2009']
+  parents:
+  - 867169
+2926351:
+  aliases: ['Myotis sp. 1031/20_CAS']
+  parents:
+  - 867169
+2926352:
+  aliases: ['Myotis sp. 1038/20_CAS']
+  parents:
+  - 867169
+2926353:
+  aliases: ['Myotis sp. 1040/20_CAS']
+  parents:
+  - 867169
+2926354:
+  aliases: ['Myotis sp. 1138/20_SOC']
+  parents:
+  - 867169
+2926355:
+  aliases: ['Myotis sp. 1145/20_SP']
+  parents:
+  - 867169
+2926356:
+  aliases: ['Myotis sp. 1256/20_JAI']
+  parents:
+  - 867169
+2926357:
+  aliases: ['Myotis sp. 1267/20_CAS']
+  parents:
+  - 867169
+2926358:
+  aliases: ['Myotis sp. 1272/20_CAS']
+  parents:
+  - 867169
+2926359:
+  aliases: ['Myotis sp. 1315/20_CAS']
+  parents:
+  - 867169
+2926360:
+  aliases: ['Myotis sp. 1354/20_ASO']
+  parents:
+  - 867169
+2926361:
+  aliases: ['Myotis sp. 1399/20_SP']
+  parents:
+  - 867169
+2926362:
+  aliases: ['Myotis sp. 1586/20_PAA']
+  parents:
+  - 867169
+1239994:
+  aliases: ['Myotis sp. 2 E Ecuador']
+  parents:
+  - 867169
+1393943:
+  aliases: ['Myotis sp. 2 MR-2013']
+  parents:
+  - 867169
+1239434:
+  aliases: ['Myotis sp. 2 RJL-2012']
+  parents:
+  - 867169
+1239995:
+  aliases: ['Myotis sp. 2 W Ecuador']
+  parents:
+  - 867169
+631203:
+  aliases: ['Myotis sp. 2 ZZ-2009']
+  parents:
+  - 867169
+2094007:
+  aliases: ['Myotis sp. 20130819_553']
+  parents:
+  - 867169
+2094006:
+  aliases: ['Myotis sp. 20130819_554']
+  parents:
+  - 867169
+2094004:
+  aliases: ['Myotis sp. 20130819_555']
+  parents:
+  - 867169
+2094005:
+  aliases: ['Myotis sp. 20130819_556']
+  parents:
+  - 867169
+2926363:
+  aliases: ['Myotis sp. 2276/21_SOC']
+  parents:
+  - 867169
+2926364:
+  aliases: ['Myotis sp. 2373/21_SP']
+  parents:
+  - 867169
+2926365:
+  aliases: ['Myotis sp. 2384/21_PAA']
+  parents:
+  - 867169
+2926366:
+  aliases: ['Myotis sp. 2615/21_SOC']
+  parents:
+  - 867169
+2926367:
+  aliases: ['Myotis sp. 2738/21_JAI']
+  parents:
+  - 867169
+2926368:
+  aliases: ['Myotis sp. 2825/21_SOC']
+  parents:
+  - 867169
+2926369:
+  aliases: ['Myotis sp. 2853/21_JAI']
+  parents:
+  - 867169
+1393944:
+  aliases: ['Myotis sp. 3 MR-2013']
+  parents:
+  - 867169
+1239996:
+  aliases: ['Myotis sp. 3 W Ecuador']
+  parents:
+  - 867169
+3049286:
+  aliases: ['Myotis sp. 4 CC-2023']
+  parents:
+  - 867169
+1393945:
+  aliases: ['Myotis sp. 4 MR-2013']
+  parents:
+  - 867169
+1239997:
+  aliases: ['Myotis sp. 4 W Ecuador']
+  parents:
+  - 867169
+1239998:
+  aliases: ['Myotis sp. 5 Mexico']
+  parents:
+  - 867169
+2924044:
+  aliases: ['Myotis sp. 56_My']
+  parents:
+  - 867169
+1239999:
+  aliases: ['Myotis sp. 6 Paraguay']
+  parents:
+  - 867169
+1240000:
+  aliases: ['Myotis sp. 6 Peru']
+  parents:
+  - 867169
+2924043:
+  aliases: ['Myotis sp. 61_My']
+  parents:
+  - 867169
+1240001:
+  aliases: ['Myotis sp. 7 W Ecuador']
+  parents:
+  - 867169
+1240002:
+  aliases: ['Myotis sp. 8 W Ecuador']
+  parents:
+  - 867169
+2926350:
+  aliases: ['Myotis sp. 927/20_JAI']
+  parents:
+  - 867169
+138980:
+  aliases: ['Myotis sp. AM_M15111']
+  parents:
+  - 867169
+138981:
+  aliases: ['Myotis sp. AM_M21963']
+  parents:
+  - 867169
+1002701:
+  aliases: ['Myotis sp. AVB-2011']
+  parents:
+  - 867169
+2942954:
+  aliases: ['Myotis sp. B12']
+  parents:
+  - 867169
+2942955:
+  aliases: ['Myotis sp. B13']
+  parents:
+  - 867169
+2942952:
+  aliases: ['Myotis sp. B60']
+  parents:
+  - 867169
+2942953:
+  aliases: ['Myotis sp. B64']
+  parents:
+  - 867169
+509034:
+  aliases: ['Myotis sp. C1']
+  parents:
+  - 867169
+509035:
+  aliases: ['Myotis sp. C2']
+  parents:
+  - 867169
+509036:
+  aliases: ['Myotis sp. C3']
+  parents:
+  - 867169
+509037:
+  aliases: ['Myotis sp. C4']
+  parents:
+  - 867169
+509038:
+  aliases: ['Myotis sp. C5']
+  parents:
+  - 867169
+245070:
+  aliases: ['Myotis sp. CRB1612']
+  parents:
+  - 867169
+867854:
+  aliases: ['Myotis sp. E CMF-2010']
+  parents:
+  - 867169
+412096:
+  aliases: ['Myotis sp. FFM-2006']
+  parents:
+  - 867169
+415935:
+  aliases: ['Myotis sp. GZNU200306']
+  parents:
+  - 867169
+187013:
+  aliases: ['Myotis sp. KK0005']
+  parents:
+  - 867169
+1032363:
+  aliases: ['Myotis sp. MIBZPL01211']
+  parents:
+  - 867169
+1032364:
+  aliases: ['Myotis sp. MIBZPL01214']
+  parents:
+  - 867169
+1032365:
+  aliases: ['Myotis sp. MIBZPL01216']
+  parents:
+  - 867169
+1032366:
+  aliases: ['Myotis sp. MIBZPL01221']
+  parents:
+  - 867169
+1032367:
+  aliases: ['Myotis sp. MIBZPL01222']
+  parents:
+  - 867169
+1032368:
+  aliases: ['Myotis sp. MIBZPL01223']
+  parents:
+  - 867169
+1032378:
+  aliases: ['Myotis sp. MIBZPL01228']
+  parents:
+  - 867169
+1032379:
+  aliases: ['Myotis sp. MIBZPL01230']
+  parents:
+  - 867169
+1032369:
+  aliases: ['Myotis sp. MIBZPL01235']
+  parents:
+  - 867169
+1032370:
+  aliases: ['Myotis sp. MIBZPL01256']
+  parents:
+  - 867169
+1032371:
+  aliases: ['Myotis sp. MIBZPL01281']
+  parents:
+  - 867169
+1032372:
+  aliases: ['Myotis sp. MIBZPL01287']
+  parents:
+  - 867169
+1032373:
+  aliases: ['Myotis sp. MIBZPL01289']
+  parents:
+  - 867169
+1032374:
+  aliases: ['Myotis sp. MIBZPL01301']
+  parents:
+  - 867169
+1032375:
+  aliases: ['Myotis sp. MIBZPL01302']
+  parents:
+  - 867169
+1032376:
+  aliases: ['Myotis sp. MIBZPL01303']
+  parents:
+  - 867169
+1032377:
+  aliases: ['Myotis sp. MIBZPL01319']
+  parents:
+  - 867169
+999958:
+  aliases: ['Myotis sp. MMMD-2011']
+  parents:
+  - 867169
+2785032:
+  aliases: ['Myotis sp. MSB Mamm 42790']
+  parents:
+  - 867169
+2969769:
+  aliases: ['Myotis sp. MVZ Mamm 224796']
+  parents:
+  - 867169
+2785034:
+  aliases: ['Myotis sp. MVZ Mamm 226977']
+  parents:
+  - 867169
+2924045:
+  aliases: ['Myotis sp. Muestra11_My']
+  parents:
+  - 867169
+509039:
+  aliases: ['Myotis sp. N1']
+  parents:
+  - 867169
+509040:
+  aliases: ['Myotis sp. N2']
+  parents:
+  - 867169
+509041:
+  aliases: ['Myotis sp. N3']
+  parents:
+  - 867169
+364774:
+  aliases: ['Myotis sp. PH-2006']
+  parents:
+  - 867169
+2923478:
+  aliases: ['Myotis sp. QCAZ Mamm9159']
+  parents:
+  - 867169
+2923479:
+  aliases: ['Myotis sp. QCAZ Mamm9623']
+  parents:
+  - 867169
+509042:
+  aliases: ['Myotis sp. R1']
+  parents:
+  - 867169
+1163723:
+  aliases: ['Myotis sp. RJL-2012']
+  parents:
+  - 867169
+3456272:
+  aliases: ['Myotis sp. T72096-1']
+  parents:
+  - 867169
+3456273:
+  aliases: ['Myotis sp. T72096-2']
+  parents:
+  - 867169
+258961:
+  aliases: ['Myotis sp. TK 48587']
+  parents:
+  - 867169
+2785033:
+  aliases: ['Myotis sp. TTU Mamm 47514']
+  parents:
+  - 867169
+3238590:
+  aliases: ['Myotis sp. g NB-2024']
+  parents:
+  - 867169
+3387500:
+  aliases: ['Myotis sp. h MR-2024']
+  parents:
+  - 867169
+2980669:
+  aliases: ['Myotis yumanensis yumanensis']
+  parents:
+  - 159337
+1115701:
+  aliases: ['Natalus sp. LMGC-2011']
+  parents:
+  - 2625265
+3111557:
+  aliases: ['Neoplatymops sp.']
+  parents:
+  - 3111556
+2747555:
+  aliases: ['Neopteryx']
+  parents:
+  - 77225
+3075050:
+  aliases: ['Neoromicia sp.']
+  parents:
+  - 2636793
+1286222:
+  aliases: ['Neoromicia sp. 1 SaSt-2013']
+  parents:
+  - 2636793
+1975659:
+  aliases: ['Neoromicia sp. B168']
+  parents:
+  - 2636793
+1975660:
+  aliases: ['Neoromicia sp. B169']
+  parents:
+  - 2636793
+2448877:
+  aliases: ['Neoromicia sp. DMR-2017']
+  parents:
+  - 2636793
+1002347:
+  aliases: ['Neoromicia sp. IVK-2011']
+  parents:
+  - 2636793
+1838145:
+  aliases: ['Neoromicia sp. JA-2016a']
+  parents:
+  - 2636793
+3387231:
+  aliases: ['Nesonycteris ardoulisi']
+  parents:
+  - 3371070
+3371130:
+  aliases: ['Nesonycteris fardoulisi']
+  parents:
+  - 3371070
+3371131:
+  aliases: ['Nesonycteris maccoyi']
+  parents:
+  - 3371070
+3371132:
+  aliases: ['Nesonycteris mengermani']
+  parents:
+  - 3371070
+3401145:
+  aliases: ['Noctilio albiventris cabrerai']
+  parents:
+  - 94962
+3079500:
+  aliases: ['Noctilio albiventris minor']
+  parents:
+  - 94962
+3079474:
+  aliases: ['Noctilio leporinus mastivus']
+  parents:
+  - 94963
+58077:
+  aliases: ['Notopteris']
+  parents:
+  - 77241
+402030:
+  aliases: ['Nyctalus leisleri verrucosus']
+  parents:
+  - 59465
+187011:
+  aliases: ['Nyctalus plancyi velutinus']
+  parents:
+  - 375553
+867862:
+  aliases: ['Nyctalus sp. A JLE-2010']
+  parents:
+  - 2618540
+3242305:
+  aliases: ['Nycteris sp.']
+  parents:
+  - 2623095
+2448879:
+  aliases: ['Nycteris sp. DMR-2017']
+  parents:
+  - 2623095
+48987:
+  aliases: ['Nyctimene']
+  parents:
+  - 3136026
+3079460:
+  aliases: ['Nyctinomops laticaudatus europs']
+  parents:
+  - 27627
+2968823:
+  aliases: ['Nyctinomops sp. m IT-2022']
+  parents:
+  - 2968822
+328967:
+  aliases: ['Otopteropus']
+  parents:
+  - 3136027
+270784:
+  aliases: ['Paranyctimene']
+  parents:
+  - 3136026
+329872:
+  aliases: ['Paratriaenops auritus']
+  parents:
+  - 1615588
+3370493:
+  aliases: ['Paratriaenops furcula']
+  parents:
+  - 1615588
+326150:
+  aliases: ['Penthetor']
+  parents:
+  - 3136027
+3079465:
+  aliases: ['Perimyotis subflavus floridanus']
+  parents:
+  - 27672
+249014:
+  aliases: ['Peropteryx kappleri']
+  parents:
+  - 249013
+409046:
+  aliases: ['Peropteryx leucoptera']
+  parents:
+  - 249013
+249015:
+  aliases: ['Peropteryx macrotis']
+  parents:
+  - 249013
+3370519:
+  aliases: ['Peropteryx pallidoptera']
+  parents:
+  - 249013
+463804:
+  aliases: ['Peropteryx trinitatis']
+  parents:
+  - 249013
+148072:
+  aliases: ['Phylloderma stenops']
+  parents:
+  - 148058
+409047:
+  aliases: ['Phylloderma stenops PS1']
+  parents:
+  - 148058
+409048:
+  aliases: ['Phylloderma stenops PS2']
+  parents:
+  - 148058
+138702:
+  aliases: ['Phyllonycteris aphylla']
+  parents:
+  - 138701
+869459:
+  aliases: ['Phyllonycteris obtusa']
+  parents:
+  - 138701
+270774:
+  aliases: ['Phyllonycteris poeyi']
+  parents:
+  - 138701
+270772:
+  aliases: ['Phyllops falcatus']
+  parents:
+  - 148027
+89673:
+  aliases: ['Phyllostomus discolor']
+  parents:
+  - 9422
+187005:
+  aliases: ['Phyllostomus elongatus']
+  parents:
+  - 9422
+9423:
+  aliases: ['Phyllostomus hastatus']
+  parents:
+  - 9422
+999937:
+  aliases: ['Phyllostomus latifolius']
+  parents:
+  - 9422
+1838146:
+  aliases: ['Pipistrellus cf. grandidieri JA-2016a']
+  parents:
+  - 1032380
+2933643:
+  aliases: ['Pipistrellus hanaki creticus']
+  parents:
+  - 412090
+867881:
+  aliases: ['Pipistrellus javanicus babu']
+  parents:
+  - 258947
+1707946:
+  aliases: ['Pipistrellus kuhlii kuhlii']
+  parents:
+  - 59472
+983528:
+  aliases: ['Pipistrellus kuhlii lepidus']
+  parents:
+  - 59472
+3075051:
+  aliases: ['Pipistrellus sp.']
+  parents:
+  - 1032380
+1286223:
+  aliases: ['Pipistrellus sp. 1 SaSt-2013']
+  parents:
+  - 1032380
+2856838:
+  aliases: ['Pipistrellus sp. A BL-2021']
+  parents:
+  - 1032380
+1001580:
+  aliases: ['Pipistrellus sp. AVB-2011']
+  parents:
+  - 1032380
+2856839:
+  aliases: ['Pipistrellus sp. B BL-2021']
+  parents:
+  - 1032380
+246822:
+  aliases: ['Pipistrellus sp. Be_2129']
+  parents:
+  - 1032380
+258773:
+  aliases: ['Pipistrellus sp. Be_2136_8']
+  parents:
+  - 1032380
+258774:
+  aliases: ['Pipistrellus sp. Be_2137_9']
+  parents:
+  - 1032380
+258771:
+  aliases: ['Pipistrellus sp. Be_2142_10']
+  parents:
+  - 1032380
+246823:
+  aliases: ['Pipistrellus sp. Be_2145']
+  parents:
+  - 1032380
+258772:
+  aliases: ['Pipistrellus sp. Be_2151_13']
+  parents:
+  - 1032380
+246816:
+  aliases: ['Pipistrellus sp. Be_2152']
+  parents:
+  - 1032380
+515826:
+  aliases: ['Pipistrellus sp. CO1']
+  parents:
+  - 1032380
+515827:
+  aliases: ['Pipistrellus sp. CO2']
+  parents:
+  - 1032380
+515828:
+  aliases: ['Pipistrellus sp. CO3']
+  parents:
+  - 1032380
+2448880:
+  aliases: ['Pipistrellus sp. DMR-2017']
+  parents:
+  - 1032380
+1125842:
+  aliases: ['Pipistrellus sp. DR-2011']
+  parents:
+  - 1032380
+412091:
+  aliases: ['Pipistrellus sp. FFM-2006']
+  parents:
+  - 1032380
+867880:
+  aliases: ['Pipistrellus sp. G CMF-2010']
+  parents:
+  - 1032380
+3040052:
+  aliases: ['Pipistrellus sp. Guangxi 1046']
+  parents:
+  - 1032380
+3040053:
+  aliases: ['Pipistrellus sp. Guizhou 83']
+  parents:
+  - 1032380
+1002348:
+  aliases: ['Pipistrellus sp. IVK-2011']
+  parents:
+  - 1032380
+2661590:
+  aliases: ['Pipistrellus sp. LIK54']
+  parents:
+  - 1032380
+1032395:
+  aliases: ['Pipistrellus sp. MIBZPL01239']
+  parents:
+  - 1032380
+1032396:
+  aliases: ['Pipistrellus sp. MIBZPL01241']
+  parents:
+  - 1032380
+1032397:
+  aliases: ['Pipistrellus sp. MIBZPL02288']
+  parents:
+  - 1032380
+1032381:
+  aliases: ['Pipistrellus sp. MIBZPL03815']
+  parents:
+  - 1032380
+1032382:
+  aliases: ['Pipistrellus sp. MIBZPL03816']
+  parents:
+  - 1032380
+1032383:
+  aliases: ['Pipistrellus sp. MIBZPL03817']
+  parents:
+  - 1032380
+1032384:
+  aliases: ['Pipistrellus sp. MIBZPL03818']
+  parents:
+  - 1032380
+1032385:
+  aliases: ['Pipistrellus sp. MIBZPL03819']
+  parents:
+  - 1032380
+1032386:
+  aliases: ['Pipistrellus sp. MIBZPL03820']
+  parents:
+  - 1032380
+1032387:
+  aliases: ['Pipistrellus sp. MIBZPL03821']
+  parents:
+  - 1032380
+1032388:
+  aliases: ['Pipistrellus sp. MIBZPL03822']
+  parents:
+  - 1032380
+1032389:
+  aliases: ['Pipistrellus sp. MIBZPL03823']
+  parents:
+  - 1032380
+1032390:
+  aliases: ['Pipistrellus sp. MIBZPL03824']
+  parents:
+  - 1032380
+1032391:
+  aliases: ['Pipistrellus sp. MIBZPL03825']
+  parents:
+  - 1032380
+1032392:
+  aliases: ['Pipistrellus sp. MIBZPL03826']
+  parents:
+  - 1032380
+1032393:
+  aliases: ['Pipistrellus sp. MIBZPL03827']
+  parents:
+  - 1032380
+1032394:
+  aliases: ['Pipistrellus sp. MIBZPL03828']
+  parents:
+  - 1032380
+436908:
+  aliases: ['Pipistrellus sp. PH-2007']
+  parents:
+  - 1032380
+2678253:
+  aliases: ['Pipistrellus sp. PU 5_OR']
+  parents:
+  - 1032380
+1158136:
+  aliases: ['Pipistrellus sp. YPZ-2012']
+  parents:
+  - 1032380
+1079722:
+  aliases: ['Pipistrellus sp. kuhlii/deserti Pkuh-I']
+  parents:
+  - 1032380
+1079723:
+  aliases: ['Pipistrellus sp. kuhlii/deserti Pkuh-II']
+  parents:
+  - 1032380
+2748932:
+  aliases: ['Pipistrellus tenuis mimus']
+  parents:
+  - 258948
+190511:
+  aliases: ['Platalina genovensium']
+  parents:
+  - 148085
+574073:
+  aliases: ['Platyrrhinus albericoi']
+  parents:
+  - 27657
+679017:
+  aliases: ['Platyrrhinus angustirostris']
+  parents:
+  - 27657
+409049:
+  aliases: ['Platyrrhinus aurarius']
+  parents:
+  - 27657
+249009:
+  aliases: ['Platyrrhinus brachycephalus']
+  parents:
+  - 27657
+2772522:
+  aliases: ['Platyrrhinus chocoensis']
+  parents:
+  - 27657
+362823:
+  aliases: ['Platyrrhinus dorsalis']
+  parents:
+  - 27657
+679018:
+  aliases: ['Platyrrhinus fusciventris']
+  parents:
+  - 27657
+1505192:
+  aliases: ['Platyrrhinus guianensis']
+  parents:
+  - 27657
+27658:
+  aliases: ['Platyrrhinus helleri']
+  parents:
+  - 27657
+409050:
+  aliases: ['Platyrrhinus helleri PS1']
+  parents:
+  - 27657
+409051:
+  aliases: ['Platyrrhinus helleri PS2']
+  parents:
+  - 27657
+409052:
+  aliases: ['Platyrrhinus helleri PS3']
+  parents:
+  - 27657
+574072:
+  aliases: ['Platyrrhinus incarum']
+  parents:
+  - 27657
+574060:
+  aliases: ['Platyrrhinus infuscus']
+  parents:
+  - 27657
+574075:
+  aliases: ['Platyrrhinus ismaeli']
+  parents:
+  - 27657
+410852:
+  aliases: ['Platyrrhinus lineatus']
+  parents:
+  - 27657
+574080:
+  aliases: ['Platyrrhinus masu']
+  parents:
+  - 27657
+574081:
+  aliases: ['Platyrrhinus matapalensis']
+  parents:
+  - 27657
+574064:
+  aliases: ['Platyrrhinus recifinus']
+  parents:
+  - 27657
+2448888:
+  aliases: ['Platyrrhinus umbratus']
+  parents:
+  - 27657
+574065:
+  aliases: ['Platyrrhinus vittatus']
+  parents:
+  - 27657
+169059:
+  aliases: ['Plecotus austriacus austriacus']
+  parents:
+  - 109483
+272800:
+  aliases: ['Plecotus macrobullaris macrobullaris']
+  parents:
+  - 242915
+2917802:
+  aliases: ['Plecotus ognevi nomrogi']
+  parents:
+  - 360160
+232091:
+  aliases: ['Plecotus sp.']
+  parents:
+  - 1032398
+233183:
+  aliases: ['Plecotus sp. JJJ-2003']
+  parents:
+  - 1032398
+1032399:
+  aliases: ['Plecotus sp. MIBZPL00262']
+  parents:
+  - 1032398
+1032400:
+  aliases: ['Plecotus sp. MIBZPL00265']
+  parents:
+  - 1032398
+1032401:
+  aliases: ['Plecotus sp. MIBZPL00268']
+  parents:
+  - 1032398
+1032402:
+  aliases: ['Plecotus sp. MIBZPL00269']
+  parents:
+  - 1032398
+1032403:
+  aliases: ['Plecotus sp. MIBZPL00270']
+  parents:
+  - 1032398
+1032404:
+  aliases: ['Plecotus sp. MIBZPL01189']
+  parents:
+  - 1032398
+1032405:
+  aliases: ['Plecotus sp. MIBZPL03414']
+  parents:
+  - 1032398
+479724:
+  aliases: ['Plecotus sp. V3']
+  parents:
+  - 1032398
+1812309:
+  aliases: ['Plerotes']
+  parents:
+  - 3136029
+2907246:
+  aliases: ['Promops sp. IP1204/2015']
+  parents:
+  - 2907245
+3392253:
+  aliases: ['Pseudoromicia sp.']
+  parents:
+  - 2778575
+2778576:
+  aliases: ['Pseudoromicia sp. Tanzania']
+  parents:
+  - 2778575
+132906:
+  aliases: ['Ptenochirus']
+  parents:
+  - 3136027
+58080:
+  aliases: ['Pteralopex']
+  parents:
+  - 77225
+1884719:
+  aliases: ['Pteronotus parnellii fuscus']
+  parents:
+  - 59476
+1884721:
+  aliases: ['Pteronotus parnellii mexicanus']
+  parents:
+  - 59476
+1884718:
+  aliases: ['Pteronotus parnellii portoricensis']
+  parents:
+  - 59476
+1884720:
+  aliases: ['Pteronotus sp.']
+  parents:
+  - 2632027
+1769917:
+  aliases: ['Pteronotus sp. 3 BdT-2015']
+  parents:
+  - 2632027
+1921178:
+  aliases: ['Pteronotus sp. PV-RO-BRA']
+  parents:
+  - 2632027
+261759:
+  aliases: ['Pteropodidae sp. TTS-2004']
+  parents:
+  - 3136031
+9401:
+  aliases: ['Pteropus']
+  parents:
+  - 77225
+148037:
+  aliases: ['Pygoderma bilabiatum']
+  parents:
+  - 148028
+1296576:
+  aliases: ['Rhinolophidae sp. BOLD:AAB6249']
+  parents:
+  - 1296575
+1296578:
+  aliases: ['Rhinolophidae sp. BOLD:AAB9127']
+  parents:
+  - 1296575
+1296577:
+  aliases: ['Rhinolophidae sp. BOLD:AAD3329']
+  parents:
+  - 1296575
+1296579:
+  aliases: ['Rhinolophidae sp. SMM045-12']
+  parents:
+  - 1296575
+49442:
+  aliases: ['Rhinolophus']
+  parents:
+  - 186995
+270786:
+  aliases: ['Rhinonicteris aurantia']
+  parents:
+  - 271602
+138699:
+  aliases: ['Rhinophylla alethina']
+  parents:
+  - 138698
+138706:
+  aliases: ['Rhinophylla fischerae']
+  parents:
+  - 138698
+138707:
+  aliases: ['Rhinophylla pumilio']
+  parents:
+  - 138698
+1034335:
+  aliases: ['Rhinopoma cystops']
+  parents:
+  - 124755
+1436297:
+  aliases: ['Rhinopoma hadramauticum']
+  parents:
+  - 124755
+124756:
+  aliases: ['Rhinopoma hardwickii']
+  parents:
+  - 124755
+3370735:
+  aliases: ['Rhinopoma macinnesi']
+  parents:
+  - 124755
+173903:
+  aliases: ['Rhinopoma microphyllum']
+  parents:
+  - 124755
+173902:
+  aliases: ['Rhinopoma muscatellum']
+  parents:
+  - 124755
+2094008:
+  aliases: ['Rhogeessa sp. 20130222_359']
+  parents:
+  - 2622910
+249017:
+  aliases: ['Rhynchonycteris naso']
+  parents:
+  - 249016
+1332055:
+  aliases: ['Rhyneptesicus nasutus batinensis']
+  parents:
+  - 568178
+1332056:
+  aliases: ['Rhyneptesicus nasutus matschiei']
+  parents:
+  - 568178
+1332057:
+  aliases: ['Rhyneptesicus nasutus nasutus']
+  parents:
+  - 568178
+9406:
+  aliases: ['Rousettus']
+  parents:
+  - 3136029
+446910:
+  aliases: ['Saccolaimus flaviventris']
+  parents:
+  - 446909
+526813:
+  aliases: ['Saccolaimus saccolaimus']
+  parents:
+  - 446909
+59482:
+  aliases: ['Saccopteryx bilineata']
+  parents:
+  - 59481
+409053:
+  aliases: ['Saccopteryx canescens']
+  parents:
+  - 59481
+409054:
+  aliases: ['Saccopteryx gymnura']
+  parents:
+  - 59481
+249018:
+  aliases: ['Saccopteryx leptura']
+  parents:
+  - 59481
+3077733:
+  aliases: ['Scotoecus sp.']
+  parents:
+  - 2636109
+2448883:
+  aliases: ['Scotoecus sp. DMR-2017']
+  parents:
+  - 2636109
+1002350:
+  aliases: ['Scotoecus sp. IVK-2011']
+  parents:
+  - 2636109
+1001562:
+  aliases: ['Scotonycteris']
+  parents:
+  - 3136029
+3075053:
+  aliases: ['Scotophilus sp.']
+  parents:
+  - 2645158
+1975656:
+  aliases: ['Scotophilus sp. B115']
+  parents:
+  - 2645158
+1975657:
+  aliases: ['Scotophilus sp. B156']
+  parents:
+  - 2645158
+2448884:
+  aliases: ['Scotophilus sp. DMR-2017']
+  parents:
+  - 2645158
+1002351:
+  aliases: ['Scotophilus sp. IVK-2011']
+  parents:
+  - 2645158
+2591333:
+  aliases: ['Scotophilus sp. clade 1 TD-2019']
+  parents:
+  - 2645158
+2591334:
+  aliases: ['Scotophilus sp. clade 2 TD-2019']
+  parents:
+  - 2645158
+2591335:
+  aliases: ['Scotophilus sp. clade 3 TD-2019']
+  parents:
+  - 2645158
+2591336:
+  aliases: ['Scotophilus sp. clade 4 TD-2019']
+  parents:
+  - 2645158
+2591337:
+  aliases: ['Scotophilus sp. clade 5 TD-2019']
+  parents:
+  - 2645158
+2591338:
+  aliases: ['Scotophilus sp. clade 7 TD-2019']
+  parents:
+  - 2645158
+565069:
+  aliases: ['Scotophilus viridis nigritellus']
+  parents:
+  - 312069
+270780:
+  aliases: ['Scotorepens sp. JMW-2004']
+  parents:
+  - 2636263
+662897:
+  aliases: ['Sphaerias']
+  parents:
+  - 3136027
+148038:
+  aliases: ['Sphaeronycteris toxophyllum']
+  parents:
+  - 148029
+148093:
+  aliases: ['Stenoderma rufum']
+  parents:
+  - 148030
+1246967:
+  aliases: ['Stenonycterini']
+  parents:
+  - 3136030
+1983336:
+  aliases: ['Sturnira adrianae']
+  parents:
+  - 27659
+2737875:
+  aliases: ['Sturnira angeli']
+  parents:
+  - 27659
+192400:
+  aliases: ['Sturnira aratathomasi']
+  parents:
+  - 27659
+2019462:
+  aliases: ['Sturnira bakeri']
+  parents:
+  - 27659
+192401:
+  aliases: ['Sturnira bidens']
+  parents:
+  - 27659
+192402:
+  aliases: ['Sturnira bogotensis']
+  parents:
+  - 27659
+1908666:
+  aliases: ['Sturnira burtonlimi']
+  parents:
+  - 27659
+192403:
+  aliases: ['Sturnira erythromos']
+  parents:
+  - 27659
+3242989:
+  aliases: ['Sturnira giannae']
+  parents:
+  - 27659
+192404:
+  aliases: ['Sturnira hondurensis']
+  parents:
+  - 27659
+3370835:
+  aliases: ['Sturnira koopmanhilli']
+  parents:
+  - 27659
+27660:
+  aliases: ['Sturnira lilium']
+  parents:
+  - 27659
+192405:
+  aliases: ['Sturnira ludovici']
+  parents:
+  - 27659
+192406:
+  aliases: ['Sturnira luisi']
+  parents:
+  - 27659
+192407:
+  aliases: ['Sturnira magna']
+  parents:
+  - 27659
+192408:
+  aliases: ['Sturnira mordax']
+  parents:
+  - 27659
+192409:
+  aliases: ['Sturnira nana']
+  parents:
+  - 27659
+192410:
+  aliases: ['Sturnira oporaphilum']
+  parents:
+  - 27659
+196700:
+  aliases: ['Sturnira parvidens']
+  parents:
+  - 27659
+1092446:
+  aliases: ['Sturnira perla']
+  parents:
+  - 27659
+27661:
+  aliases: ['Sturnira tildae']
+  parents:
+  - 27659
+1091511:
+  aliases: ['Styloctenium']
+  parents:
+  - 77225
+2951463:
+  aliases: ['Submyotodon sp. m HF-2022']
+  parents:
+  - 2951462
+58084:
+  aliases: ['Syconycteris']
+  parents:
+  - 77241
+242194:
+  aliases: ['Tadarida brasiliensis brasiliensis']
+  parents:
+  - 9438
+242195:
+  aliases: ['Tadarida brasiliensis cynocephala']
+  parents:
+  - 9438
+242196:
+  aliases: ['Tadarida brasiliensis intermedia']
+  parents:
+  - 9438
+242197:
+  aliases: ['Tadarida brasiliensis mexicana']
+  parents:
+  - 9438
+556300:
+  aliases: ['Tadarida sp. 7070']
+  parents:
+  - 2636308
+446905:
+  aliases: ['Taphozous australis']
+  parents:
+  - 13280
+13281:
+  aliases: ['Taphozous georgianus']
+  parents:
+  - 13280
+1002354:
+  aliases: ['Taphozous hildegardeae']
+  parents:
+  - 13280
+446906:
+  aliases: ['Taphozous hilli']
+  parents:
+  - 13280
+463807:
+  aliases: ['Taphozous longimanus']
+  parents:
+  - 13280
+302395:
+  aliases: ['Taphozous mauritianus']
+  parents:
+  - 13280
+187003:
+  aliases: ['Taphozous melanopogon']
+  parents:
+  - 13280
+249019:
+  aliases: ['Taphozous nudiventris']
+  parents:
+  - 13280
+1381355:
+  aliases: ['Taphozous perforatus']
+  parents:
+  - 13280
+2029311:
+  aliases: ['Taphozous theobaldi']
+  parents:
+  - 13280
+58086:
+  aliases: ['Thoopterus']
+  parents:
+  - 3136027
+3079473:
+  aliases: ['Thyroptera tricolor albiventer']
+  parents:
+  - 124759
+2683044:
+  aliases: ['Tonatia bakeri']
+  parents:
+  - 9425
+9426:
+  aliases: ['Tonatia bidens']
+  parents:
+  - 9425
+2715937:
+  aliases: ['Tonatia maresi']
+  parents:
+  - 9425
+171122:
+  aliases: ['Tonatia saurophila']
+  parents:
+  - 9425
+148073:
+  aliases: ['Trachops cirrhosus']
+  parents:
+  - 148059
+409055:
+  aliases: ['Trachops cirrhosus PS1']
+  parents:
+  - 148059
+409056:
+  aliases: ['Trachops cirrhosus PS2']
+  parents:
+  - 148059
+409057:
+  aliases: ['Trachops cirrhosus PS3']
+  parents:
+  - 148059
+3370920:
+  aliases: ['Trachops coffini']
+  parents:
+  - 148059
+549403:
+  aliases: ['Triaenops afer']
+  parents:
+  - 258842
+1195082:
+  aliases: ['Triaenops menamena']
+  parents:
+  - 258842
+549400:
+  aliases: ['Triaenops parvus']
+  parents:
+  - 258842
+329870:
+  aliases: ['Triaenops persicus']
+  parents:
+  - 258842
+148068:
+  aliases: ['Trinycteris nicefori']
+  parents:
+  - 3477446
+27663:
+  aliases: ['Uroderma bilobatum']
+  parents:
+  - 27662
+2683985:
+  aliases: ['Uroderma convexum']
+  parents:
+  - 27662
+221446:
+  aliases: ['Uroderma magnirostrum']
+  parents:
+  - 27662
+148039:
+  aliases: ['Vampyressa bidens']
+  parents:
+  - 148031
+196701:
+  aliases: ['Vampyressa brocki']
+  parents:
+  - 148031
+2996699:
+  aliases: ['Vampyressa elisabethae']
+  parents:
+  - 148031
+362825:
+  aliases: ['Vampyressa melissa']
+  parents:
+  - 148031
+148040:
+  aliases: ['Vampyressa pusilla']
+  parents:
+  - 148031
+362826:
+  aliases: ['Vampyressa thyone']
+  parents:
+  - 148031
+3156175:
+  aliases: ['Vampyressa villai']
+  parents:
+  - 148031
+3370950:
+  aliases: ['Vampyriscus nymphaeus']
+  parents:
+  - 148031
+148041:
+  aliases: ['Vampyrodes caraccioli']
+  parents:
+  - 148032
+933072:
+  aliases: ['Vampyrodes major']
+  parents:
+  - 148032
+148074:
+  aliases: ['Vampyrum spectrum']
+  parents:
+  - 148060
+1470993:
+  aliases: ['Xeronycteris vieirai']
+  parents:
+  - 1470992
+2623340:
+  aliases: ['unclassified Anoura']
+  parents:
+  - 27641
+2625567:
+  aliases: ['unclassified Artibeus']
+  parents:
+  - 9416
+2645105:
+  aliases: ['unclassified Aselliscus']
+  parents:
+  - 188567
+2646434:
+  aliases: ['unclassified Carollia']
+  parents:
+  - 40232
+2627912:
+  aliases: ['unclassified Choeroniscus']
+  parents:
+  - 148042
+2630904:
+  aliases: ['unclassified Emballonura']
+  parents:
+  - 110939
+2646091:
+  aliases: ['unclassified Hipposideros']
+  parents:
+  - 58068
+3242302:
+  aliases: ['unclassified Megaderma']
+  parents:
+  - 9412
+2624502:
+  aliases: ['unclassified Micronycteris']
+  parents:
+  - 148056
+2640928:
+  aliases: ['unclassified Peropteryx']
+  parents:
+  - 249013
+2628851:
+  aliases: ['unclassified Phyllostomus']
+  parents:
+  - 9422
+2640664:
+  aliases: ['unclassified Platyrrhinus']
+  parents:
+  - 27657
+2633232:
+  aliases: ['unclassified Saccopteryx']
+  parents:
+  - 59481
+2631065:
+  aliases: ['unclassified Sturnira']
+  parents:
+  - 27659
+2622826:
+  aliases: ['unclassified Taphozous']
+  parents:
+  - 13280
+2633921:
+  aliases: ['unclassified Tonatia']
+  parents:
+  - 9425
+58057:
+  aliases: ['Acerodon celebensis']
+  parents:
+  - 58056
+505845:
+  aliases: ['Acerodon jubatus']
+  parents:
+  - 58056
+2933618:
+  aliases: ['Acerodon macklotii']
+  parents:
+  - 58056
+442846:
+  aliases: ['Aethalops aequalis']
+  parents:
+  - 77226
+77227:
+  aliases: ['Aethalops alecto']
+  parents:
+  - 77226
+662937:
+  aliases: ['Alionycteris paucidentata']
+  parents:
+  - 662936
+2563025:
+  aliases: ['Anoura sp. A CCA-2019']
+  parents:
+  - 2623340
+58059:
+  aliases: ['Aproteles bulmerae']
+  parents:
+  - 58058
+362872:
+  aliases: ['Artibeus glaucus rosenbergii']
+  parents:
+  - 40226
+51016:
+  aliases: ['Artibeus glaucus watsoni']
+  parents:
+  - 40226
+406806:
+  aliases: ['Artibeus jamaicensis jamaicensis']
+  parents:
+  - 9417
+406807:
+  aliases: ['Artibeus jamaicensis parvipes']
+  parents:
+  - 9417
+256420:
+  aliases: ['Artibeus jamaicensis paulus']
+  parents:
+  - 9417
+256419:
+  aliases: ['Artibeus jamaicensis richardsoni']
+  parents:
+  - 9417
+211472:
+  aliases: ['Artibeus jamaicensis triomylus']
+  parents:
+  - 9417
+211471:
+  aliases: ['Artibeus jamaicensis yucatanicus']
+  parents:
+  - 9417
+3079475:
+  aliases: ['Artibeus lituratus palmarum']
+  parents:
+  - 27634
+406808:
+  aliases: ['Artibeus planirostris fallax']
+  parents:
+  - 40230
+406809:
+  aliases: ['Artibeus planirostris grenadensis']
+  parents:
+  - 40230
+406810:
+  aliases: ['Artibeus planirostris hercules']
+  parents:
+  - 40230
+406811:
+  aliases: ['Artibeus planirostris planirostris']
+  parents:
+  - 40230
+406812:
+  aliases: ['Artibeus planirostris trinitatis']
+  parents:
+  - 40230
+1002695:
+  aliases: ['Artibeus sp. AVB-2011']
+  parents:
+  - 2625567
+1105487:
+  aliases: ['Artibeus sp. BOLD:AAA2159']
+  parents:
+  - 2625567
+1105488:
+  aliases: ['Artibeus sp. BOLD:AAA2160']
+  parents:
+  - 2625567
+1105489:
+  aliases: ['Artibeus sp. BOLD:AAA2332']
+  parents:
+  - 2625567
+416810:
+  aliases: ['Artibeus sp. FURB']
+  parents:
+  - 2625567
+887799:
+  aliases: ['Artibeus sp. JRA-2010']
+  parents:
+  - 2625567
+1882412:
+  aliases: ['Aselliscus sp. Zz-2016a']
+  parents:
+  - 2645105
+77229:
+  aliases: ['Balionycteris maculata']
+  parents:
+  - 77228
+270782:
+  aliases: ['Boneia bidens']
+  parents:
+  - 270781
+290571:
+  aliases: ['Brachyphylla nana pumila']
+  parents:
+  - 290570
+3114349:
+  aliases: ['Carollia sp.']
+  parents:
+  - 2646434
+1380313:
+  aliases: ['Carollia sp. 1 PMV-2013']
+  parents:
+  - 2646434
+1091509:
+  aliases: ['Casinycteris argynnis']
+  parents:
+  - 1091508
+1497437:
+  aliases: ['Casinycteris campomaanensis']
+  parents:
+  - 1091508
+1497438:
+  aliases: ['Casinycteris ophiodon']
+  parents:
+  - 1091508
+280973:
+  aliases: ['Centurio senex greenhalli']
+  parents:
+  - 27644
+2773073:
+  aliases: ['Chiroderma doriae vizottoi']
+  parents:
+  - 33544
+170236:
+  aliases: ['Chironax melanocephalus']
+  parents:
+  - 170235
+999943:
+  aliases: ['Choeroniscus sp. BOLD:AAC3416']
+  parents:
+  - 2627912
+58060:
+  aliases: ['Cynopterus brachyotis']
+  parents:
+  - 9399
+867815:
+  aliases: ['Cynopterus cf. brachyotis CMF-2010']
+  parents:
+  - 9399
+298109:
+  aliases: ['Cynopterus horsfieldii']
+  parents:
+  - 9399
+378216:
+  aliases: ['Cynopterus nusatenggara']
+  parents:
+  - 9399
+9400:
+  aliases: ['Cynopterus sphinx']
+  parents:
+  - 9399
+867816:
+  aliases: ['Cynopterus titthaecheilus']
+  parents:
+  - 9399
+505943:
+  aliases: ['Desmalopex leucoptera']
+  parents:
+  - 515994
+515995:
+  aliases: ['Desmalopex microleucoptera']
+  parents:
+  - 515994
+170213:
+  aliases: ['Dobsonia andersoni']
+  parents:
+  - 42146
+170214:
+  aliases: ['Dobsonia inermis']
+  parents:
+  - 42146
+522445:
+  aliases: ['Dobsonia magna']
+  parents:
+  - 42146
+170215:
+  aliases: ['Dobsonia minor']
+  parents:
+  - 42146
+42147:
+  aliases: ['Dobsonia moluccensis']
+  parents:
+  - 42146
+170216:
+  aliases: ['Dobsonia pannietensis']
+  parents:
+  - 42146
+170217:
+  aliases: ['Dobsonia praedatrix']
+  parents:
+  - 42146
+170218:
+  aliases: ['Dobsonia viridis']
+  parents:
+  - 42146
+2703642:
+  aliases: ['Dyacopterus rickarti']
+  parents:
+  - 326080
+326081:
+  aliases: ['Dyacopterus spadiceus']
+  parents:
+  - 326080
+58063:
+  aliases: ['Eidolon dupreanum']
+  parents:
+  - 58062
+77214:
+  aliases: ['Eidolon helvum']
+  parents:
+  - 58062
+1368311:
+  aliases: ['Emballonura semicaudata rotensis']
+  parents:
+  - 170234
+271461:
+  aliases: ['Emballonura sp. JMW-2004']
+  parents:
+  - 2630904
+1244809:
+  aliases: ['Emballonura sp. SJP-2012']
+  parents:
+  - 2630904
+526811:
+  aliases: ['Eonycteris major']
+  parents:
+  - 58064
+1091510:
+  aliases: ['Eonycteris robusta']
+  parents:
+  - 58064
+58065:
+  aliases: ['Eonycteris spelaea']
+  parents:
+  - 58064
+58066:
+  aliases: ['Epomophorus']
+  parents:
+  - 1246964
+77230:
+  aliases: ['Epomops']
+  parents:
+  - 1246964
+301158:
+  aliases: ['Haplonycteris fischeri']
+  parents:
+  - 301157
+584770:
+  aliases: ['Harpyionycteris celebensis']
+  parents:
+  - 378749
+378750:
+  aliases: ['Harpyionycteris whiteheadi']
+  parents:
+  - 378749
+1197850:
+  aliases: ['Hipposideros alongensis alongensis']
+  parents:
+  - 1197849
+1197851:
+  aliases: ['Hipposideros alongensis sungi']
+  parents:
+  - 1197849
+186991:
+  aliases: ['Hipposideros armiger terasensis']
+  parents:
+  - 186990
+343907:
+  aliases: ['Hipposideros ater gilberti']
+  parents:
+  - 279184
+635127:
+  aliases: ['Hipposideros caffer tephrus']
+  parents:
+  - 302402
+867826:
+  aliases: ['Hipposideros cf. larvatus CMF-2010']
+  parents:
+  - 354741
+2291615:
+  aliases: ['Hipposideros diadema masoni']
+  parents:
+  - 59453
+354743:
+  aliases: ['Hipposideros grandis']
+  parents:
+  - 354741
+354742:
+  aliases: ['Hipposideros khasiana']
+  parents:
+  - 354741
+175524:
+  aliases: ['Hipposideros larvatus']
+  parents:
+  - 354741
+1197856:
+  aliases: ['Hipposideros larvatus s.l. SJP-2012']
+  parents:
+  - 354741
+3457474:
+  aliases: ['Hipposideros larvatus sensu lato KP-2025']
+  parents:
+  - 354741
+3374061:
+  aliases: ['Hipposideros sp.']
+  parents:
+  - 2646091
+586238:
+  aliases: ['Hipposideros sp. 1 KS-2008']
+  parents:
+  - 2646091
+1391745:
+  aliases: ['Hipposideros sp. 1 LEP-2013']
+  parents:
+  - 2646091
+1116469:
+  aliases: ['Hipposideros sp. A SWM-2011']
+  parents:
+  - 2646091
+1699535:
+  aliases: ['Hipposideros sp. ARR-2015']
+  parents:
+  - 2646091
+1116468:
+  aliases: ['Hipposideros sp. B SWM-2011']
+  parents:
+  - 2646091
+867830:
+  aliases: ['Hipposideros sp. C CMF-2010']
+  parents:
+  - 2646091
+415934:
+  aliases: ['Hipposideros sp. GZNU200307']
+  parents:
+  - 2646091
+1002344:
+  aliases: ['Hipposideros sp. IVK-2011']
+  parents:
+  - 2646091
+1207991:
+  aliases: ['Hipposideros sp. JAE-2012']
+  parents:
+  - 2646091
+271462:
+  aliases: ['Hipposideros sp. JMW-2004a']
+  parents:
+  - 2646091
+271463:
+  aliases: ['Hipposideros sp. JMW-2004b']
+  parents:
+  - 2646091
+2448872:
+  aliases: ['Hipposideros sp. caffer-ruber DMR-2017']
+  parents:
+  - 2646091
+3384837:
+  aliases: ['Hipposideros sp. n. TK-2024']
+  parents:
+  - 2646091
+1197766:
+  aliases: ['Hipposideros turpis turpis']
+  parents:
+  - 185215
+448083:
+  aliases: ['Hypsignathus']
+  parents:
+  - 1246964
+556919:
+  aliases: ['Latidens salimalii']
+  parents:
+  - 556918
+29076:
+  aliases: ['Macroglossus minimus']
+  parents:
+  - 29075
+326083:
+  aliases: ['Macroglossus sobrinus']
+  parents:
+  - 29075
+3242303:
+  aliases: ['Megaderma sp.']
+  parents:
+  - 3242302
+298110:
+  aliases: ['Megaerops ecaudatus']
+  parents:
+  - 77232
+374419:
+  aliases: ['Megaerops kusnotoi']
+  parents:
+  - 77232
+77233:
+  aliases: ['Megaerops niphanae']
+  parents:
+  - 77232
+58072:
+  aliases: ['Megaloglossus']
+  parents:
+  - 1246961
+77215:
+  aliases: ['Melonycteris melanops']
+  parents:
+  - 58074
+319527:
+  aliases: ['Melonycteris woodfordi']
+  parents:
+  - 58074
+338420:
+  aliases: ['Micronycteris sp. TK136752']
+  parents:
+  - 2624502
+1496138:
+  aliases: ['Mirimiri acrodonta']
+  parents:
+  - 1496136
+77236:
+  aliases: ['Myonycteris']
+  parents:
+  - 1246961
+498219:
+  aliases: ['Nanonycteris']
+  parents:
+  - 1246964
+2747556:
+  aliases: ['Neopteryx frosti']
+  parents:
+  - 2747555
+3387232:
+  aliases: ['Nesonycteris ardoulisi schouteni']
+  parents:
+  - 3387231
+3387230:
+  aliases: ['Nesonycteris fardoulisi fardoulisi']
+  parents:
+  - 3371130
+58078:
+  aliases: ['Notopteris macdonaldii']
+  parents:
+  - 58077
+270783:
+  aliases: ['Nyctimene aello']
+  parents:
+  - 48987
+48988:
+  aliases: ['Nyctimene albiventer']
+  parents:
+  - 48987
+170209:
+  aliases: ['Nyctimene cephalotes']
+  parents:
+  - 48987
+170210:
+  aliases: ['Nyctimene certans']
+  parents:
+  - 48987
+77240:
+  aliases: ['Nyctimene major']
+  parents:
+  - 48987
+2703643:
+  aliases: ['Nyctimene rabori']
+  parents:
+  - 48987
+58079:
+  aliases: ['Nyctimene robinsoni']
+  parents:
+  - 48987
+170211:
+  aliases: ['Nyctimene vizcaccia']
+  parents:
+  - 48987
+328968:
+  aliases: ['Otopteropus cartilagonodus']
+  parents:
+  - 328967
+270785:
+  aliases: ['Paranyctimene raptor']
+  parents:
+  - 270784
+326151:
+  aliases: ['Penthetor lucasii']
+  parents:
+  - 326150
+1158974:
+  aliases: ['Peropteryx sp. BOLD:AAI2457']
+  parents:
+  - 2640928
+463810:
+  aliases: ['Peropteryx sp. ROM 104396']
+  parents:
+  - 2640928
+463811:
+  aliases: ['Peropteryx sp. RSV 2330']
+  parents:
+  - 2640928
+2737247:
+  aliases: ['Phyllostomus sp. PHH3']
+  parents:
+  - 2628851
+3076788:
+  aliases: ['Platyrrhinus incarum incarum']
+  parents:
+  - 574072
+574066:
+  aliases: ['Platyrrhinus lineatus nigellus']
+  parents:
+  - 410852
+1684764:
+  aliases: ['Platyrrhinus sp. MH-2015']
+  parents:
+  - 2640664
+1812310:
+  aliases: ['Plerotes anchietae']
+  parents:
+  - 1812309
+2933645:
+  aliases: ['Ptenochirus jagorii']
+  parents:
+  - 132906
+328961:
+  aliases: ['Ptenochirus minor']
+  parents:
+  - 132906
+414524:
+  aliases: ['Ptenochirus wetmorei']
+  parents:
+  - 132906
+58081:
+  aliases: ['Pteralopex atrata']
+  parents:
+  - 58080
+1496134:
+  aliases: ['Pteralopex taki']
+  parents:
+  - 58080
+58082:
+  aliases: ['Pteropus admiralitatum']
+  parents:
+  - 9401
+589507:
+  aliases: ['Pteropus aldabrensis']
+  parents:
+  - 9401
+9402:
+  aliases: ['Pteropus alecto']
+  parents:
+  - 9401
+170220:
+  aliases: ['Pteropus anetianus']
+  parents:
+  - 9401
+2721786:
+  aliases: ['Pteropus caniceps']
+  parents:
+  - 9401
+1291037:
+  aliases: ['Pteropus capistratus']
+  parents:
+  - 9401
+2721787:
+  aliases: ['Pteropus chrysoproctus']
+  parents:
+  - 9401
+170222:
+  aliases: ['Pteropus cognatus']
+  parents:
+  - 9401
+328804:
+  aliases: ['Pteropus conspicillatus']
+  parents:
+  - 9401
+126282:
+  aliases: ['Pteropus dasymallus']
+  parents:
+  - 9401
+1288886:
+  aliases: ['Pteropus faunulus']
+  parents:
+  - 9401
+170223:
+  aliases: ['Pteropus fundatus']
+  parents:
+  - 9401
+3370656:
+  aliases: ['Pteropus gilliardi']
+  parents:
+  - 9401
+1495907:
+  aliases: ['Pteropus griseus']
+  parents:
+  - 9401
+9405:
+  aliases: ['Pteropus hypomelanus']
+  parents:
+  - 9401
+589508:
+  aliases: ['Pteropus livingstonii']
+  parents:
+  - 9401
+1495904:
+  aliases: ['Pteropus lombocensis']
+  parents:
+  - 9401
+166054:
+  aliases: ['Pteropus lylei']
+  parents:
+  - 9401
+448077:
+  aliases: ['Pteropus macrotis']
+  parents:
+  - 9401
+1496129:
+  aliases: ['Pteropus mahaganus']
+  parents:
+  - 9401
+522447:
+  aliases: ['Pteropus mariannus']
+  parents:
+  - 9401
+143291:
+  aliases: ['Pteropus medius']
+  parents:
+  - 9401
+2721788:
+  aliases: ['Pteropus melanopogon']
+  parents:
+  - 9401
+1562755:
+  aliases: ['Pteropus melanotus']
+  parents:
+  - 9401
+522446:
+  aliases: ['Pteropus molossinus']
+  parents:
+  - 9401
+170224:
+  aliases: ['Pteropus neohibernicus']
+  parents:
+  - 9401
+170225:
+  aliases: ['Pteropus niger']
+  parents:
+  - 9401
+1496128:
+  aliases: ['Pteropus nitendiensis']
+  parents:
+  - 9401
+170226:
+  aliases: ['Pteropus ocularis']
+  parents:
+  - 9401
+170227:
+  aliases: ['Pteropus ornatus']
+  parents:
+  - 9401
+1495906:
+  aliases: ['Pteropus pelagicus']
+  parents:
+  - 9401
+1495877:
+  aliases: ['Pteropus pelewensis']
+  parents:
+  - 9401
+170228:
+  aliases: ['Pteropus personatus']
+  parents:
+  - 9401
+170229:
+  aliases: ['Pteropus pohlei']
+  parents:
+  - 9401
+9403:
+  aliases: ['Pteropus poliocephalus']
+  parents:
+  - 9401
+1496133:
+  aliases: ['Pteropus pselaphon']
+  parents:
+  - 9401
+161598:
+  aliases: ['Pteropus pumilus']
+  parents:
+  - 9401
+110942:
+  aliases: ['Pteropus rayneri']
+  parents:
+  - 9401
+2747553:
+  aliases: ['Pteropus rennelli']
+  parents:
+  - 9401
+77216:
+  aliases: ['Pteropus rodricensis']
+  parents:
+  - 9401
+196297:
+  aliases: ['Pteropus rufus']
+  parents:
+  - 9401
+170230:
+  aliases: ['Pteropus samoensis']
+  parents:
+  - 9401
+94117:
+  aliases: ['Pteropus scapulatus']
+  parents:
+  - 9401
+589506:
+  aliases: ['Pteropus seychellensis']
+  parents:
+  - 9401
+161599:
+  aliases: ['Pteropus speciosus']
+  parents:
+  - 9401
+9404:
+  aliases: ['Pteropus temminckii']
+  parents:
+  - 9401
+1496132:
+  aliases: ['Pteropus tokudae']
+  parents:
+  - 9401
+77217:
+  aliases: ['Pteropus tonganus']
+  parents:
+  - 9401
+1496131:
+  aliases: ['Pteropus tuberculatus']
+  parents:
+  - 9401
+1495879:
+  aliases: ['Pteropus ualanus']
+  parents:
+  - 9401
+132908:
+  aliases: ['Pteropus vampyrus']
+  parents:
+  - 9401
+170231:
+  aliases: ['Pteropus vetulus']
+  parents:
+  - 9401
+589509:
+  aliases: ['Pteropus voeltzkowi']
+  parents:
+  - 9401
+170232:
+  aliases: ['Pteropus woodfordi']
+  parents:
+  - 9401
+320431:
+  aliases: ['Rhinolophus acuminatus']
+  parents:
+  - 49442
+59477:
+  aliases: ['Rhinolophus affinis']
+  parents:
+  - 49442
+249024:
+  aliases: ['Rhinolophus alcyone']
+  parents:
+  - 49442
+2291617:
+  aliases: ['Rhinolophus andamanensis']
+  parents:
+  - 49442
+76834:
+  aliases: ['Rhinolophus arcuatus']
+  parents:
+  - 49442
+556920:
+  aliases: ['Rhinolophus beddomei']
+  parents:
+  - 49442
+519037:
+  aliases: ['Rhinolophus blasii']
+  parents:
+  - 49442
+2603870:
+  aliases: ['Rhinolophus blasii complex sp. 1 TD-2019']
+  parents:
+  - 49442
+3068536:
+  aliases: ['Rhinolophus bocharicus']
+  parents:
+  - 49442
+337452:
+  aliases: ['Rhinolophus borneensis']
+  parents:
+  - 49442
+302408:
+  aliases: ['Rhinolophus capensis']
+  parents:
+  - 49442
+1078801:
+  aliases: ['Rhinolophus celebensis']
+  parents:
+  - 49442
+1007694:
+  aliases: ['Rhinolophus cf. chaseni BOLD:AAB4878']
+  parents:
+  - 49442
+1154687:
+  aliases: ['Rhinolophus cf. chaseni SVK-2012']
+  parents:
+  - 49442
+2603859:
+  aliases: ['Rhinolophus cf. denti TD-2019']
+  parents:
+  - 49442
+2603860:
+  aliases: ['Rhinolophus cf. denti/simulator TD-2019']
+  parents:
+  - 49442
+2448881:
+  aliases: ['Rhinolophus cf. eloquens DMR-2017']
+  parents:
+  - 49442
+867886:
+  aliases: ['Rhinolophus cf. ferrumequinum CMF-2010']
+  parents:
+  - 49442
+1232899:
+  aliases: ['Rhinolophus cf. hildebrandti']
+  parents:
+  - 49442
+2528448:
+  aliases: ['Rhinolophus cf. inops MRMD1747']
+  parents:
+  - 49442
+2528452:
+  aliases: ['Rhinolophus cf. inops MRMD1818']
+  parents:
+  - 49442
+3449228:
+  aliases: ['Rhinolophus cf. landeri']
+  parents:
+  - 49442
+2603861:
+  aliases: ['Rhinolophus cf. landeri TD-2019']
+  parents:
+  - 49442
+1001579:
+  aliases: ['Rhinolophus cf. lepidus']
+  parents:
+  - 49442
+867887:
+  aliases: ['Rhinolophus cf. lepidus CMF-2010']
+  parents:
+  - 49442
+2304489:
+  aliases: ['Rhinolophus cf. macrotis LZ-2018']
+  parents:
+  - 49442
+1964314:
+  aliases: ['Rhinolophus cf. macrotis Phia Oac VTT-2017']
+  parents:
+  - 49442
+2590849:
+  aliases: ['Rhinolophus cf. macrotis TL-2019']
+  parents:
+  - 49442
+1964313:
+  aliases: ['Rhinolophus cf. macrotis VTT-2017']
+  parents:
+  - 49442
+2916559:
+  aliases: ['Rhinolophus cf. macrotis sensu Tu et al. 2017']
+  parents:
+  - 49442
+2528453:
+  aliases: ['Rhinolophus cf. philippinensis AMF0074']
+  parents:
+  - 49442
+2528449:
+  aliases: ['Rhinolophus cf. philippinensis AMF0075']
+  parents:
+  - 49442
+2528447:
+  aliases: ['Rhinolophus cf. philippinensis AMF0076']
+  parents:
+  - 49442
+1007695:
+  aliases: ['Rhinolophus cf. pusillus BOLD:AAB9127']
+  parents:
+  - 49442
+867888:
+  aliases: ['Rhinolophus cf. pusillus CMF-2010']
+  parents:
+  - 49442
+2304488:
+  aliases: ['Rhinolophus cf. siamensis LZ-2018']
+  parents:
+  - 49442
+1964315:
+  aliases: ['Rhinolophus cf. siamensis VTT-2017']
+  parents:
+  - 49442
+2916560:
+  aliases: ['Rhinolophus cf. siamensis sensu Tu et al. 2017']
+  parents:
+  - 49442
+1939661:
+  aliases: ['Rhinolophus cf. simulator SJP-2016']
+  parents:
+  - 49442
+2528451:
+  aliases: ['Rhinolophus cf. subrufus AMF0068']
+  parents:
+  - 49442
+2528446:
+  aliases: ['Rhinolophus cf. subrufus AMF0069']
+  parents:
+  - 49442
+2528450:
+  aliases: ['Rhinolophus cf. subrufus DMP124']
+  parents:
+  - 49442
+2528454:
+  aliases: ['Rhinolophus cf. subrufus MGP0605']
+  parents:
+  - 49442
+867889:
+  aliases: ['Rhinolophus cf. thomasi CMF-2010']
+  parents:
+  - 49442
+867890:
+  aliases: ['Rhinolophus chaseni']
+  parents:
+  - 49442
+2510767:
+  aliases: ['Rhinolophus chiewkweeae']
+  parents:
+  - 49442
+59478:
+  aliases: ['Rhinolophus clivosus']
+  parents:
+  - 49442
+2603871:
+  aliases: ['Rhinolophus clivosus complex sp. 1 TD-2019']
+  parents:
+  - 49442
+2603872:
+  aliases: ['Rhinolophus clivosus complex sp. 2 TD-2019']
+  parents:
+  - 49442
+2603873:
+  aliases: ['Rhinolophus clivosus complex sp. 3 TD-2019']
+  parents:
+  - 49442
+2603875:
+  aliases: ['Rhinolophus clivosus complex sp. 6 TD-2019']
+  parents:
+  - 49442
+867891:
+  aliases: ['Rhinolophus coelophyllus']
+  parents:
+  - 49442
+1548709:
+  aliases: ['Rhinolophus cognatus']
+  parents:
+  - 49442
+196296:
+  aliases: ['Rhinolophus cornutus']
+  parents:
+  - 49442
+178895:
+  aliases: ['Rhinolophus creaghi']
+  parents:
+  - 49442
+1434703:
+  aliases: ['Rhinolophus damarensis']
+  parents:
+  - 49442
+49443:
+  aliases: ['Rhinolophus darlingi']
+  parents:
+  - 49442
+2603862:
+  aliases: ['Rhinolophus deckenii']
+  parents:
+  - 49442
+608656:
+  aliases: ['Rhinolophus denti']
+  parents:
+  - 49442
+3449238:
+  aliases: ['Rhinolophus dobsoni']
+  parents:
+  - 49442
+519038:
+  aliases: ['Rhinolophus eloquens']
+  parents:
+  - 49442
+109476:
+  aliases: ['Rhinolophus euryale']
+  parents:
+  - 49442
+76835:
+  aliases: ['Rhinolophus euryotis']
+  parents:
+  - 49442
+59479:
+  aliases: ['Rhinolophus ferrumequinum']
+  parents:
+  - 49442
+2933649:
+  aliases: ['Rhinolophus foetidus']
+  parents:
+  - 49442
+472238:
+  aliases: ['Rhinolophus formosae']
+  parents:
+  - 49442
+3007093:
+  aliases: ['Rhinolophus francisi']
+  parents:
+  - 49442
+302410:
+  aliases: ['Rhinolophus fumigatus']
+  parents:
+  - 49442
+2603876:
+  aliases: ['Rhinolophus fumigatus/eloquens complex sp. 1 TD-2019']
+  parents:
+  - 49442
+2603877:
+  aliases: ['Rhinolophus fumigatus/eloquens complex sp. 2 TD-2019']
+  parents:
+  - 49442
+2603878:
+  aliases: ['Rhinolophus fumigatus/eloquens complex sp. 3 TD-2019']
+  parents:
+  - 49442
+2603874:
+  aliases: ['Rhinolophus fumigatus/eloquens complex sp. 4 TD-2019']
+  parents:
+  - 49442
+2603879:
+  aliases: ['Rhinolophus fumigatus/eloquens complex sp. 7 TD-2019']
+  parents:
+  - 49442
+2603880:
+  aliases: ['Rhinolophus fumigatus/eloquens complex sp. 8 TD-2019']
+  parents:
+  - 49442
+2603863:
+  aliases: ['Rhinolophus gorongosae']
+  parents:
+  - 49442
+302411:
+  aliases: ['Rhinolophus hildebrandti']
+  parents:
+  - 49442
+2603881:
+  aliases: ['Rhinolophus hildebrandtii complex sp. 1 TD-2019']
+  parents:
+  - 49442
+2603882:
+  aliases: ['Rhinolophus hildebrandtii complex sp. 2 TD-2019']
+  parents:
+  - 49442
+2957227:
+  aliases: ['Rhinolophus hilli']
+  parents:
+  - 49442
+77218:
+  aliases: ['Rhinolophus hipposideros']
+  parents:
+  - 49442
+2291618:
+  aliases: ['Rhinolophus indorouxii']
+  parents:
+  - 49442
+1078804:
+  aliases: ['Rhinolophus inops']
+  parents:
+  - 49442
+1078820:
+  aliases: ['Rhinolophus inops/arcuatus']
+  parents:
+  - 49442
+1078825:
+  aliases: ['Rhinolophus inops/subrufus']
+  parents:
+  - 49442
+2603864:
+  aliases: ['Rhinolophus kahuzi']
+  parents:
+  - 49442
+519039:
+  aliases: ['Rhinolophus landeri']
+  parents:
+  - 49442
+188570:
+  aliases: ['Rhinolophus lepidus']
+  parents:
+  - 49442
+2603865:
+  aliases: ['Rhinolophus lobatus']
+  parents:
+  - 49442
+1704495:
+  aliases: ['Rhinolophus luctoides']
+  parents:
+  - 49442
+337453:
+  aliases: ['Rhinolophus luctus']
+  parents:
+  - 49442
+2972396:
+  aliases: ['Rhinolophus mabuensis']
+  parents:
+  - 49442
+608657:
+  aliases: ['Rhinolophus maclaudi']
+  parents:
+  - 49442
+196889:
+  aliases: ['Rhinolophus macrotis']
+  parents:
+  - 49442
+608659:
+  aliases: ['Rhinolophus malayanus']
+  parents:
+  - 49442
+476588:
+  aliases: ['Rhinolophus marshalli']
+  parents:
+  - 49442
+76836:
+  aliases: ['Rhinolophus megaphyllus']
+  parents:
+  - 49442
+342862:
+  aliases: ['Rhinolophus mehelyi']
+  parents:
+  - 49442
+3344654:
+  aliases: ['Rhinolophus microglobosus']
+  parents:
+  - 49442
+169756:
+  aliases: ['Rhinolophus monoceros']
+  parents:
+  - 49442
+1871414:
+  aliases: ['Rhinolophus monticolus']
+  parents:
+  - 49442
+1704492:
+  aliases: ['Rhinolophus morio']
+  parents:
+  - 49442
+3052836:
+  aliases: ['Rhinolophus mossambicus']
+  parents:
+  - 49442
+3370727:
+  aliases: ['Rhinolophus nippon']
+  parents:
+  - 49442
+479722:
+  aliases: ['Rhinolophus osgoodi']
+  parents:
+  - 49442
+188571:
+  aliases: ['Rhinolophus pearsonii']
+  parents:
+  - 49442
+186998:
+  aliases: ['Rhinolophus perditus']
+  parents:
+  - 49442
+3030660:
+  aliases: ['Rhinolophus perniger']
+  parents:
+  - 49442
+76837:
+  aliases: ['Rhinolophus philippinensis']
+  parents:
+  - 49442
+159859:
+  aliases: ['Rhinolophus pumilus']
+  parents:
+  - 49442
+159858:
+  aliases: ['Rhinolophus pusillus']
+  parents:
+  - 49442
+188572:
+  aliases: ['Rhinolophus rex']
+  parents:
+  - 49442
+2603866:
+  aliases: ['Rhinolophus rhodesiae']
+  parents:
+  - 49442
+526812:
+  aliases: ['Rhinolophus robinsoni']
+  parents:
+  - 49442
+89398:
+  aliases: ['Rhinolophus rouxii']
+  parents:
+  - 49442
+545504:
+  aliases: ['Rhinolophus rufus']
+  parents:
+  - 49442
+519040:
+  aliases: ['Rhinolophus ruwenzorii']
+  parents:
+  - 49442
+3052837:
+  aliases: ['Rhinolophus sakejiensis']
+  parents:
+  - 49442
+59480:
+  aliases: ['Rhinolophus sedulus']
+  parents:
+  - 49442
+608708:
+  aliases: ['Rhinolophus shameli']
+  parents:
+  - 49442
+1871418:
+  aliases: ['Rhinolophus shortridgei']
+  parents:
+  - 49442
+867892:
+  aliases: ['Rhinolophus siamensis']
+  parents:
+  - 49442
+519041:
+  aliases: ['Rhinolophus simulator']
+  parents:
+  - 49442
+2603883:
+  aliases: ['Rhinolophus simulator complex sp. 1 TD-2019']
+  parents:
+  - 49442
+2603884:
+  aliases: ['Rhinolophus simulator complex sp. 2 TD-2019']
+  parents:
+  - 49442
+89399:
+  aliases: ['Rhinolophus sinicus']
+  parents:
+  - 49442
+430491:
+  aliases: ['Rhinolophus stheno']
+  parents:
+  - 49442
+545503:
+  aliases: ['Rhinolophus subrufus']
+  parents:
+  - 49442
+1078826:
+  aliases: ['Rhinolophus subrufus/arcuatus']
+  parents:
+  - 49442
+608709:
+  aliases: ['Rhinolophus swinnyi']
+  parents:
+  - 49442
+2998138:
+  aliases: ['Rhinolophus thailandensis']
+  parents:
+  - 49442
+476589:
+  aliases: ['Rhinolophus thomasi']
+  parents:
+  - 49442
+430492:
+  aliases: ['Rhinolophus trifoliatus']
+  parents:
+  - 49442
+1078802:
+  aliases: ['Rhinolophus virgo']
+  parents:
+  - 49442
+3449239:
+  aliases: ['Rhinolophus webalai']
+  parents:
+  - 49442
+2603867:
+  aliases: ['Rhinolophus willardi']
+  parents:
+  - 49442
+563833:
+  aliases: ['Rhinolophus xinanzhongguoensis']
+  parents:
+  - 49442
+2952509:
+  aliases: ['Rhinolophus yonghoiseni']
+  parents:
+  - 49442
+3370733:
+  aliases: ['Rhinolophus yunanensis']
+  parents:
+  - 49442
+471461:
+  aliases: ['Rhinopoma microphyllum harrisoni']
+  parents:
+  - 173903
+471460:
+  aliases: ['Rhinopoma microphyllum kinneari']
+  parents:
+  - 173903
+471462:
+  aliases: ['Rhinopoma microphyllum microphyllum']
+  parents:
+  - 173903
+9407:
+  aliases: ['Rousettus aegyptiacus']
+  parents:
+  - 9406
+58083:
+  aliases: ['Rousettus amplexicaudatus']
+  parents:
+  - 9406
+1129002:
+  aliases: ['Rousettus celebensis']
+  parents:
+  - 9406
+9408:
+  aliases: ['Rousettus leschenaultii']
+  parents:
+  - 9406
+2721789:
+  aliases: ['Rousettus linduensis']
+  parents:
+  - 9406
+77223:
+  aliases: ['Rousettus madagascariensis']
+  parents:
+  - 9406
+705079:
+  aliases: ['Rousettus obliviosus']
+  parents:
+  - 9406
+414523:
+  aliases: ['Rousettus spinalatus']
+  parents:
+  - 9406
+245071:
+  aliases: ['Saccopteryx sp. CRB2490']
+  parents:
+  - 2633232
+1609901:
+  aliases: ['Scotonycteris bergmansi']
+  parents:
+  - 1001562
+1609904:
+  aliases: ['Scotonycteris occidentalis']
+  parents:
+  - 1001562
+1001563:
+  aliases: ['Scotonycteris zenkeri']
+  parents:
+  - 1001562
+662898:
+  aliases: ['Sphaerias blanfordi']
+  parents:
+  - 662897
+1246966:
+  aliases: ['Stenonycteris']
+  parents:
+  - 1246967
+1983337:
+  aliases: ['Sturnira adrianae adrianae']
+  parents:
+  - 1983336
+1983338:
+  aliases: ['Sturnira adrianae caripana']
+  parents:
+  - 1983336
+1331069:
+  aliases: ['Sturnira lilium paulsoni']
+  parents:
+  - 27660
+192866:
+  aliases: ['Sturnira luisi serotinus']
+  parents:
+  - 192406
+192867:
+  aliases: ['Sturnira luisi thomasi']
+  parents:
+  - 192406
+192868:
+  aliases: ['Sturnira luisi vulcanensis']
+  parents:
+  - 192406
+192869:
+  aliases: ['Sturnira luisi zygomaticus']
+  parents:
+  - 192406
+1932380:
+  aliases: ['Sturnira sp. 3 AK-2017']
+  parents:
+  - 2631065
+244174:
+  aliases: ['Sturnira sp. CAI-2003A']
+  parents:
+  - 2631065
+244175:
+  aliases: ['Sturnira sp. CAI-2003B']
+  parents:
+  - 2631065
+3098844:
+  aliases: ['Sturnira sp. b NT-2023']
+  parents:
+  - 2631065
+2019461:
+  aliases: ['Sturnira sp. n. 3 GHC-2017']
+  parents:
+  - 2631065
+1091512:
+  aliases: ['Styloctenium mindorense']
+  parents:
+  - 1091511
+1442611:
+  aliases: ['Styloctenium wallacei']
+  parents:
+  - 1091511
+58085:
+  aliases: ['Syconycteris australis']
+  parents:
+  - 58084
+110943:
+  aliases: ['Taphozous sp.']
+  parents:
+  - 2622826
+1548710:
+  aliases: ['Taphozous sp. CS-2014']
+  parents:
+  - 2622826
+1002352:
+  aliases: ['Taphozous sp. IVK-2011']
+  parents:
+  - 2622826
+58087:
+  aliases: ['Thoopterus nigrescens']
+  parents:
+  - 58086
+318598:
+  aliases: ['Tonatia sp. ECT-2005']
+  parents:
+  - 2633921
+2996700:
+  aliases: ['Vampyressa melissa sinchi']
+  parents:
+  - 362825
+1158975:
+  aliases: ['unclassified Cynopterus']
+  parents:
+  - 9399
+2719124:
+  aliases: ['unclassified Dobsonia']
+  parents:
+  - 42146
+2620160:
+  aliases: ['unclassified Macroglossus']
+  parents:
+  - 29075
+2944748:
+  aliases: ['unclassified Megaerops']
+  parents:
+  - 77232
+2721790:
+  aliases: ['unclassified Nyctimene']
+  parents:
+  - 48987
+2647550:
+  aliases: ['unclassified Pteropus']
+  parents:
+  - 9401
+2629890:
+  aliases: ['unclassified Rhinolophus']
+  parents:
+  - 49442
+2640345:
+  aliases: ['unclassified Rousettus']
+  parents:
+  - 9406
+2634128:
+  aliases: ['unclassified Syconycteris']
+  parents:
+  - 58084
+1898386:
+  aliases: ['Cynopterus sp.']
+  parents:
+  - 1158975
+1158921:
+  aliases: ['Cynopterus sp. A JLE-2012']
+  parents:
+  - 1158975
+1477526:
+  aliases: ['Cynopterus sp. BC-2014']
+  parents:
+  - 1158975
+2944750:
+  aliases: ['Cynopterus sp. USNM MAMM 619523']
+  parents:
+  - 1158975
+2719125:
+  aliases: ['Dobsonia sp. 050810x2F']
+  parents:
+  - 2719124
+1898387:
+  aliases: ['Epomophorus anselli']
+  parents:
+  - 58066
+2448868:
+  aliases: ['Epomophorus cf. labiatus DMR-2017']
+  parents:
+  - 58066
+59450:
+  aliases: ['Epomophorus crypturus']
+  parents:
+  - 58066
+3369967:
+  aliases: ['Epomophorus dobsonii']
+  parents:
+  - 58066
+372077:
+  aliases: ['Epomophorus gambianus']
+  parents:
+  - 58066
+903567:
+  aliases: ['Epomophorus labiatus']
+  parents:
+  - 58066
+302407:
+  aliases: ['Epomophorus minor']
+  parents:
+  - 58066
+2853157:
+  aliases: ['Epomophorus pusillus']
+  parents:
+  - 58066
+58067:
+  aliases: ['Epomophorus wahlbergi']
+  parents:
+  - 58066
+1410044:
+  aliases: ['Epomops buettikoferi']
+  parents:
+  - 77230
+77231:
+  aliases: ['Epomops franqueti']
+  parents:
+  - 77230
+3025999:
+  aliases: ['Hipposideros grandis consonensis']
+  parents:
+  - 354743
+448084:
+  aliases: ['Hypsignathus monstrosus']
+  parents:
+  - 448083
+358130:
+  aliases: ['Macroglossus sp. TK 20305']
+  parents:
+  - 2620160
+448085:
+  aliases: ['Macroglossus sp. TK20306']
+  parents:
+  - 2620160
+2944749:
+  aliases: ['Megaerops sp. USNM MAMM 583818']
+  parents:
+  - 2944748
+1245032:
+  aliases: ['Megaloglossus azagnyi']
+  parents:
+  - 58072
+58073:
+  aliases: ['Megaloglossus woermanni']
+  parents:
+  - 58072
+319529:
+  aliases: ['Melonycteris woodfordi woodfordi']
+  parents:
+  - 319527
+58071:
+  aliases: ['Myonycteris angolensis']
+  parents:
+  - 77236
+77237:
+  aliases: ['Myonycteris brachycephala']
+  parents:
+  - 77236
+1245035:
+  aliases: ['Myonycteris leptodon']
+  parents:
+  - 77236
+77242:
+  aliases: ['Myonycteris relicta']
+  parents:
+  - 77236
+77243:
+  aliases: ['Myonycteris torquata']
+  parents:
+  - 77236
+498220:
+  aliases: ['Nanonycteris veldkampii']
+  parents:
+  - 498219
+1538293:
+  aliases: ['Nyctimene albiventer papuanus']
+  parents:
+  - 48988
+2721791:
+  aliases: ['Nyctimene sp. MZB-32262']
+  parents:
+  - 2721790
+1496130:
+  aliases: ['Pteropus admiralitatum colonus']
+  parents:
+  - 58082
+3439936:
+  aliases: ['Pteropus alecto alecto']
+  parents:
+  - 9402
+1495874:
+  aliases: ['Pteropus anetianus eotinus']
+  parents:
+  - 170220
+170221:
+  aliases: ['Pteropus capistratus ennisae']
+  parents:
+  - 1291037
+385575:
+  aliases: ['Pteropus dasymallus formosus']
+  parents:
+  - 126282
+2517870:
+  aliases: ['Pteropus dasymallus yayeyamae']
+  parents:
+  - 126282
+1562761:
+  aliases: ['Pteropus melanotus natalis']
+  parents:
+  - 1562755
+1495878:
+  aliases: ['Pteropus pelewensis pelewensis']
+  parents:
+  - 1495877
+1495872:
+  aliases: ['Pteropus pelewensis yapensis']
+  parents:
+  - 1495877
+1496126:
+  aliases: ['Pteropus rayneri grandis']
+  parents:
+  - 110942
+1495876:
+  aliases: ['Pteropus samoensis nawaiensis']
+  parents:
+  - 170230
+589510:
+  aliases: ['Pteropus seychellensis comorensis']
+  parents:
+  - 589506
+589511:
+  aliases: ['Pteropus seychellensis seychellensis']
+  parents:
+  - 589506
+1562770:
+  aliases: ['Pteropus sp.']
+  parents:
+  - 2647550
+638936:
+  aliases: ['Pteropus sp. CCS-2009a']
+  parents:
+  - 2647550
+1129003:
+  aliases: ['Pteropus sp. KTJD-2011']
+  parents:
+  - 2647550
+2170357:
+  aliases: ['Pteropus sp. M.47692.003']
+  parents:
+  - 2647550
+2170358:
+  aliases: ['Pteropus sp. M.47692.004']
+  parents:
+  - 2647550
+3044306:
+  aliases: ['Rhinolophus beddomei beddomei']
+  parents:
+  - 556920
+3044305:
+  aliases: ['Rhinolophus beddomei sobrinus']
+  parents:
+  - 556920
+1434704:
+  aliases: ['Rhinolophus darlingi barbetonensis']
+  parents:
+  - 49443
+1434706:
+  aliases: ['Rhinolophus darlingi darlingi']
+  parents:
+  - 49443
+1077283:
+  aliases: ['Rhinolophus ferrumequinum korai']
+  parents:
+  - 59479
+608660:
+  aliases: ['Rhinolophus ferrumequinum nippon']
+  parents:
+  - 59479
+1203030:
+  aliases: ['Rhinolophus ferrumequinum quelpartis']
+  parents:
+  - 59479
+1774222:
+  aliases: ['Rhinolophus ferrumequinum tragatus']
+  parents:
+  - 59479
+512570:
+  aliases: ['Rhinolophus lepidus cuneatus']
+  parents:
+  - 188570
+3387499:
+  aliases: ['Rhinolophus lepidus monticola']
+  parents:
+  - 188570
+2590040:
+  aliases: ['Rhinolophus macrotis caldwelli']
+  parents:
+  - 196889
+2590039:
+  aliases: ['Rhinolophus macrotis episcopus']
+  parents:
+  - 196889
+3030661:
+  aliases: ['Rhinolophus perniger lanosus']
+  parents:
+  - 3030660
+376555:
+  aliases: ['Rhinolophus pusillus blythi']
+  parents:
+  - 159858
+479477:
+  aliases: ['Rhinolophus rex paradoxolophus']
+  parents:
+  - 188572
+89808:
+  aliases: ['Rhinolophus rouxii rouxii']
+  parents:
+  - 89398
+1585245:
+  aliases: ['Rhinolophus sinicus sinicus']
+  parents:
+  - 89399
+3075052:
+  aliases: ['Rhinolophus sp.']
+  parents:
+  - 2629890
+3242299:
+  aliases: ['Rhinolophus sp. 1 HW-2024']
+  parents:
+  - 2629890
+519447:
+  aliases: ['Rhinolophus sp. 1 KS-2008']
+  parents:
+  - 2629890
+3115446:
+  aliases: ['Rhinolophus sp. 1 MU-2024a']
+  parents:
+  - 2629890
+1332270:
+  aliases: ['Rhinolophus sp. 1 PV-2013']
+  parents:
+  - 2629890
+1133290:
+  aliases: ['Rhinolophus sp. 1 XY-2012']
+  parents:
+  - 2629890
+393600:
+  aliases: ['Rhinolophus sp. 1234']
+  parents:
+  - 2629890
+3242300:
+  aliases: ['Rhinolophus sp. 2 HW-2024']
+  parents:
+  - 2629890
+519449:
+  aliases: ['Rhinolophus sp. 2 KS-2008']
+  parents:
+  - 2629890
+1133291:
+  aliases: ['Rhinolophus sp. 2 XY-2012']
+  parents:
+  - 2629890
+3242301:
+  aliases: ['Rhinolophus sp. 3 HW-2024']
+  parents:
+  - 2629890
+1001581:
+  aliases: ['Rhinolophus sp. AVB-2011']
+  parents:
+  - 2629890
+867885:
+  aliases: ['Rhinolophus sp. B JLE-2010']
+  parents:
+  - 2629890
+2942956:
+  aliases: ['Rhinolophus sp. B42']
+  parents:
+  - 2629890
+2942957:
+  aliases: ['Rhinolophus sp. B73']
+  parents:
+  - 2629890
+1158970:
+  aliases: ['Rhinolophus sp. BOLD:AAB4878']
+  parents:
+  - 2629890
+2448836:
+  aliases: ['Rhinolophus sp. CN 2016']
+  parents:
+  - 2629890
+2448882:
+  aliases: ['Rhinolophus sp. DMR-2017']
+  parents:
+  - 2629890
+415936:
+  aliases: ['Rhinolophus sp. GZNU200303']
+  parents:
+  - 2629890
+692277:
+  aliases: ['Rhinolophus sp. HHS-2009a']
+  parents:
+  - 2629890
+2810476:
+  aliases: ['Rhinolophus sp. HW-2021']
+  parents:
+  - 2629890
+1002349:
+  aliases: ['Rhinolophus sp. IVK-2011']
+  parents:
+  - 2629890
+271464:
+  aliases: ['Rhinolophus sp. JMW-2004a']
+  parents:
+  - 2629890
+271465:
+  aliases: ['Rhinolophus sp. JMW-2004b']
+  parents:
+  - 2629890
+1078817:
+  aliases: ['Rhinolophus sp. LEP-2011']
+  parents:
+  - 2629890
+2661589:
+  aliases: ['Rhinolophus sp. LIK17']
+  parents:
+  - 2629890
+2853601:
+  aliases: ['Rhinolophus sp. Nditam11']
+  parents:
+  - 2629890
+2750743:
+  aliases: ['Rhinolophus sp. PREDICT/PDF-2370']
+  parents:
+  - 2629890
+2750742:
+  aliases: ['Rhinolophus sp. PREDICT/PDF-2386']
+  parents:
+  - 2629890
+2750744:
+  aliases: ['Rhinolophus sp. PREDICT/PRD-0038']
+  parents:
+  - 2629890
+3040050:
+  aliases: ['Rhinolophus sp. Yunnan 1038']
+  parents:
+  - 2629890
+3040051:
+  aliases: ['Rhinolophus sp. Yunnan 329']
+  parents:
+  - 2629890
+2908703:
+  aliases: ['Rhinolophus sp. i KPD-2022']
+  parents:
+  - 2629890
+2972397:
+  aliases: ['Rhinolophus sp. n. MR-2022']
+  parents:
+  - 2629890
+2489498:
+  aliases: ['Rhinolophus sp. n. TK-2018']
+  parents:
+  - 2629890
+3418546:
+  aliases: ['Rhinolophus sp. y RL-2025']
+  parents:
+  - 2629890
+77220:
+  aliases: ['Rousettus aegyptiacus aegyptiacus']
+  parents:
+  - 9407
+77221:
+  aliases: ['Rousettus aegyptiacus princeps']
+  parents:
+  - 9407
+1898393:
+  aliases: ['Rousettus sp.']
+  parents:
+  - 2640345
+1812332:
+  aliases: ['Rousettus sp. FCA-2016a']
+  parents:
+  - 2640345
+1158137:
+  aliases: ['Rousettus sp. YPZ-2012']
+  parents:
+  - 2640345
+3370833:
+  aliases: ['Stenonycteris lanosa']
+  parents:
+  - 1246966
+77224:
+  aliases: ['Syconycteris sp.']
+  parents:
+  - 2634128
+2625338:
+  aliases: ['unclassified Epomophorus']
+  parents:
+  - 58066
+2621561:
+  aliases: ['unclassified Epomops']
+  parents:
+  - 77230
+2677420:
+  aliases: ['unclassified Hypsignathus']
+  parents:
+  - 448083
+2624632:
+  aliases: ['unclassified Myonycteris']
+  parents:
+  - 77236
+2719126:
+  aliases: ['Epomophorus sp. MNHN ZM 2011-726']
+  parents:
+  - 2625338
+2719127:
+  aliases: ['Epomophorus sp. MNHN ZM 2011-760']
+  parents:
+  - 2625338
+1898389:
+  aliases: ['Epomops sp.']
+  parents:
+  - 2621561
+1091513:
+  aliases: ['Hypsignathus sp. FCA-2011']
+  parents:
+  - 2677420
+1245033:
+  aliases: ['Myonycteris angolensis ruwenzorii']
+  parents:
+  - 58071
+1245034:
+  aliases: ['Myonycteris angolensis smithii']
+  parents:
+  - 58071
+2014926:
+  aliases: ['Myonycteris sp. TLG-2017']
+  parents:
+  - 2624632
+9443:
+  aliases: ['Primates']
+  parents: []
+376913:
+  aliases: ['Haplorrhini']
+  parents:
+  - 9443
+376911:
+  aliases: ['Strepsirrhini']
+  parents:
+  - 9443
+57118:
+  aliases: ['unclassified Primates']
+  parents:
+  - 9443
+376916:
+  aliases: ['Chiromyiformes']
+  parents:
+  - 376911
+376915:
+  aliases: ['Lemuriformes']
+  parents:
+  - 376911
+376917:
+  aliases: ['Lorisiformes']
+  parents:
+  - 376911
+976298:
+  aliases: ['Primates sp. BOLD:AAA0001']
+  parents:
+  - 57118
+1068292:
+  aliases: ['Primates sp. BOLD:AAC7735']
+  parents:
+  - 57118
+976299:
+  aliases: ['Primates sp. BOLD:AAC9009']
+  parents:
+  - 57118
+1068293:
+  aliases: ['Primates sp. BOLD:AAD0215']
+  parents:
+  - 57118
+976300:
+  aliases: ['Primates sp. BOLD:AAE4744']
+  parents:
+  - 57118
+1068294:
+  aliases: ['Primates sp. BOLD:AAF0367']
+  parents:
+  - 57118
+976301:
+  aliases: ['Primates sp. BOLD:AAJ7304']
+  parents:
+  - 57118
+976302:
+  aliases: ['Primates sp. BOLD:AAO0053']
+  parents:
+  - 57118
+314293:
+  aliases: ['Simiiformes']
+  parents:
+  - 376913
+376912:
+  aliases: ['Tarsiiformes']
+  parents:
+  - 376913
+9526:
+  aliases: ['Catarrhini']
+  parents:
+  - 314293
+30615:
+  aliases: ['Cheirogaleidae']
+  parents:
+  - 376915
+30613:
+  aliases: ['Daubentoniidae']
+  parents:
+  - 376916
+40297:
+  aliases: ['Galagidae']
+  parents:
+  - 376917
+30599:
+  aliases: ['Indriidae']
+  parents:
+  - 376915
+9445:
+  aliases: ['Lemuridae']
+  parents:
+  - 376915
+30614:
+  aliases: ['Lepilemuridae']
+  parents:
+  - 376915
+9461:
+  aliases: ['Lorisidae']
+  parents:
+  - 376917
+1513476:
+  aliases: ['Palaeopropithecidae']
+  parents:
+  - 376915
+9479:
+  aliases: ['Platyrrhini']
+  parents:
+  - 314293
+9475:
+  aliases: ['Tarsiidae']
+  parents:
+  - 376912
+3085341:
+  aliases: ['unclassified Simiiformes']
+  parents:
+  - 314293
+122247:
+  aliases: ['Allocebus']
+  parents:
+  - 30615
+376918:
+  aliases: ['Aotidae']
+  parents:
+  - 9479
+523820:
+  aliases: ['Archaeolemur']
+  parents:
+  - 30599
+261738:
+  aliases: ['Arctocebus']
+  parents:
+  - 9461
+378855:
+  aliases: ['Atelidae']
+  parents:
+  - 9479
+122245:
+  aliases: ['Avahi']
+  parents:
+  - 30599
+1868481:
+  aliases: ['Carlito']
+  parents:
+  - 9475
+9498:
+  aliases: ['Cebidae']
+  parents:
+  - 9479
+1971489:
+  aliases: ['Cephalopachus']
+  parents:
+  - 9475
+314294:
+  aliases: ['Cercopithecoidea']
+  parents:
+  - 9526
+9459:
+  aliases: ['Cheirogaleus']
+  parents:
+  - 30615
+13038:
+  aliases: ['Daubentonia']
+  parents:
+  - 30613
+13513:
+  aliases: ['Eulemur']
+  parents:
+  - 9445
+261735:
+  aliases: ['Euoticus']
+  parents:
+  - 40297
+9462:
+  aliases: ['Galago']
+  parents:
+  - 40297
+89671:
+  aliases: ['Galagoides']
+  parents:
+  - 40297
+523824:
+  aliases: ['Hadropithecus']
+  parents:
+  - 30599
+13556:
+  aliases: ['Hapalemur']
+  parents:
+  - 9445
+314295:
+  aliases: ['Hominoidea']
+  parents:
+  - 9526
+34826:
+  aliases: ['Indri']
+  parents:
+  - 30599
+9446:
+  aliases: ['Lemur']
+  parents:
+  - 9445
+9452:
+  aliases: ['Lepilemur']
+  parents:
+  - 30614
+9467:
+  aliases: ['Loris']
+  parents:
+  - 9461
+126593:
+  aliases: ['Megaladapis']
+  parents:
+  - 30614
+13149:
+  aliases: ['Microcebus']
+  parents:
+  - 30615
+83691:
+  aliases: ['Mirza']
+  parents:
+  - 30615
+9469:
+  aliases: ['Nycticebus']
+  parents:
+  - 9461
+30610:
+  aliases: ['Otolemur']
+  parents:
+  - 40297
+1513474:
+  aliases: ['Pachylemur']
+  parents:
+  - 9445
+322024:
+  aliases: ['Palaeopropithecus']
+  parents:
+  - 1513476
+2604441:
+  aliases: ['Paragalago']
+  parents:
+  - 40297
+9471:
+  aliases: ['Perodicticus']
+  parents:
+  - 9461
+261733:
+  aliases: ['Phaner']
+  parents:
+  - 30615
+376919:
+  aliases: ['Pitheciidae']
+  parents:
+  - 9479
+1328069:
+  aliases: ['Prolemur']
+  parents:
+  - 9445
+30600:
+  aliases: ['Propithecus']
+  parents:
+  - 30599
+70699:
+  aliases: ['Simiiformes sp.']
+  parents:
+  - 3085341
+9476:
+  aliases: ['Tarsius']
+  parents:
+  - 9475
+9454:
+  aliases: ['Varecia']
+  parents:
+  - 9445
+3030685:
+  aliases: ['Xanthonycticebus']
+  parents:
+  - 9461
+3413538:
+  aliases: ['unclassified Lorisidae']
+  parents:
+  - 9461
+3043103:
+  aliases: ['Allocebus trichotus']
+  parents:
+  - 122247
+38066:
+  aliases: ['Alouattinae']
+  parents:
+  - 378855
+9504:
+  aliases: ['Aotus']
+  parents:
+  - 376918
+523822:
+  aliases: ['Archaeolemur edwardsi']
+  parents:
+  - 523820
+523821:
+  aliases: ['Archaeolemur majori']
+  parents:
+  - 523820
+300161:
+  aliases: ['Arctocebus aureus']
+  parents:
+  - 261738
+261739:
+  aliases: ['Arctocebus calabarensis']
+  parents:
+  - 261738
+38068:
+  aliases: ['Atelinae']
+  parents:
+  - 378855
+3043105:
+  aliases: ['Avahi betsileo']
+  parents:
+  - 122245
+402244:
+  aliases: ['Avahi cleesei']
+  parents:
+  - 122245
+122246:
+  aliases: ['Avahi laniger']
+  parents:
+  - 122245
+3061928:
+  aliases: ['Avahi meridionalis']
+  parents:
+  - 122245
+3369724:
+  aliases: ['Avahi mooreorum']
+  parents:
+  - 122245
+132108:
+  aliases: ['Avahi occidentalis']
+  parents:
+  - 122245
+1313323:
+  aliases: ['Avahi peyrierasi']
+  parents:
+  - 122245
+402239:
+  aliases: ['Avahi unicolor']
+  parents:
+  - 122245
+38069:
+  aliases: ['Callicebinae']
+  parents:
+  - 376919
+9480:
+  aliases: ['Callitrichinae']
+  parents:
+  - 9498
+1868482:
+  aliases: ['Carlito syrichta']
+  parents:
+  - 1868481
+38070:
+  aliases: ['Cebinae']
+  parents:
+  - 9498
+9477:
+  aliases: ['Cephalopachus bancanus']
+  parents:
+  - 1971489
+9527:
+  aliases: ['Cercopithecidae']
+  parents:
+  - 314294
+3043109:
+  aliases: ['Cheirogaleus andysabini']
+  parents:
+  - 9459
+2563322:
+  aliases: ['Cheirogaleus cf. medius RW-2019']
+  parents:
+  - 9459
+291259:
+  aliases: ['Cheirogaleus crossleyi']
+  parents:
+  - 9459
+3043111:
+  aliases: ['Cheirogaleus grovesi']
+  parents:
+  - 9459
+1569974:
+  aliases: ['Cheirogaleus lavasoensis']
+  parents:
+  - 9459
+47177:
+  aliases: ['Cheirogaleus major']
+  parents:
+  - 9459
+9460:
+  aliases: ['Cheirogaleus medius']
+  parents:
+  - 9459
+867375:
+  aliases: ['Cheirogaleus minusculus']
+  parents:
+  - 9459
+3043106:
+  aliases: ['Cheirogaleus shethi']
+  parents:
+  - 9459
+752538:
+  aliases: ['Cheirogaleus sibreei']
+  parents:
+  - 9459
+31869:
+  aliases: ['Daubentonia madagascariensis']
+  parents:
+  - 13038
+1215604:
+  aliases: ['Eulemur albifrons']
+  parents:
+  - 13513
+1417236:
+  aliases: ['Eulemur albifrons x cinereiceps']
+  parents:
+  - 13513
+1417231:
+  aliases: ['Eulemur albifrons x rufifrons']
+  parents:
+  - 13513
+639525:
+  aliases: ['Eulemur cinereiceps']
+  parents:
+  - 13513
+13514:
+  aliases: ['Eulemur coronatus']
+  parents:
+  - 13513
+87288:
+  aliases: ['Eulemur flavifrons']
+  parents:
+  - 13513
+13515:
+  aliases: ['Eulemur fulvus']
+  parents:
+  - 13513
+30602:
+  aliases: ['Eulemur macaco']
+  parents:
+  - 13513
+34828:
+  aliases: ['Eulemur mongoz']
+  parents:
+  - 13513
+34829:
+  aliases: ['Eulemur rubriventer']
+  parents:
+  - 13513
+859984:
+  aliases: ['Eulemur rufifrons']
+  parents:
+  - 13513
+3697755:
+  aliases: ['Eulemur rufifrons x Eulemur cinereiceps']
+  parents:
+  - 13513
+859983:
+  aliases: ['Eulemur rufus']
+  parents:
+  - 13513
+122225:
+  aliases: ['Eulemur sanfordi']
+  parents:
+  - 13513
+261736:
+  aliases: ['Euoticus elegantulus']
+  parents:
+  - 261735
+34830:
+  aliases: ['Galago alleni']
+  parents:
+  - 9462
+261731:
+  aliases: ['Galago gabonensis']
+  parents:
+  - 9462
+111173:
+  aliases: ['Galago gallarum']
+  parents:
+  - 9462
+135486:
+  aliases: ['Galago matschiei']
+  parents:
+  - 9462
+30609:
+  aliases: ['Galago moholi']
+  parents:
+  - 9462
+9465:
+  aliases: ['Galago senegalensis']
+  parents:
+  - 9462
+1487601:
+  aliases: ['Galagoides cocos']
+  parents:
+  - 89671
+89672:
+  aliases: ['Galagoides demidoff']
+  parents:
+  - 89671
+337210:
+  aliases: ['Galagoides orinus']
+  parents:
+  - 89671
+1738047:
+  aliases: ['Galagoides rondoensis']
+  parents:
+  - 89671
+867376:
+  aliases: ['Galagoides thomasi']
+  parents:
+  - 89671
+523825:
+  aliases: ['Hadropithecus stenognathus']
+  parents:
+  - 523824
+3370048:
+  aliases: ['Hapalemur alaotrensis']
+  parents:
+  - 13556
+122222:
+  aliases: ['Hapalemur aureus']
+  parents:
+  - 13556
+3043110:
+  aliases: ['Hapalemur gilberti']
+  parents:
+  - 13556
+13557:
+  aliases: ['Hapalemur griseus']
+  parents:
+  - 13556
+3043112:
+  aliases: ['Hapalemur meridionalis']
+  parents:
+  - 13556
+867377:
+  aliases: ['Hapalemur occidentalis']
+  parents:
+  - 13556
+9604:
+  aliases: ['Hominidae']
+  parents:
+  - 314295
+9577:
+  aliases: ['Hylobatidae']
+  parents:
+  - 314295
+34827:
+  aliases: ['Indri indri']
+  parents:
+  - 34826
+9447:
+  aliases: ['Lemur catta']
+  parents:
+  - 9446
+342399:
+  aliases: ['Lepilemur aeeclis']
+  parents:
+  - 9452
+886957:
+  aliases: ['Lepilemur ahmansoni']
+  parents:
+  - 9452
+342401:
+  aliases: ['Lepilemur ankaranensis']
+  parents:
+  - 9452
+886958:
+  aliases: ['Lepilemur betsileo']
+  parents:
+  - 9452
+78583:
+  aliases: ['Lepilemur dorsalis']
+  parents:
+  - 9452
+122230:
+  aliases: ['Lepilemur edwardsi']
+  parents:
+  - 9452
+886959:
+  aliases: ['Lepilemur fleuretae']
+  parents:
+  - 9452
+886960:
+  aliases: ['Lepilemur grewcocki']
+  parents:
+  - 9452
+886961:
+  aliases: ['Lepilemur hollandorum']
+  parents:
+  - 9452
+756882:
+  aliases: ['Lepilemur hubbardi']
+  parents:
+  - 9452
+486960:
+  aliases: ['Lepilemur jamesi']
+  parents:
+  - 9452
+100475:
+  aliases: ['Lepilemur leucopus']
+  parents:
+  - 9452
+185457:
+  aliases: ['Lepilemur microdon']
+  parents:
+  - 9452
+886963:
+  aliases: ['Lepilemur milanoii']
+  parents:
+  - 9452
+9453:
+  aliases: ['Lepilemur mustelinus']
+  parents:
+  - 9452
+458173:
+  aliases: ['Lepilemur otto']
+  parents:
+  - 9452
+886964:
+  aliases: ['Lepilemur petteri']
+  parents:
+  - 9452
+886965:
+  aliases: ['Lepilemur randrianasoloi']
+  parents:
+  - 9452
+78866:
+  aliases: ['Lepilemur ruficaudatus']
+  parents:
+  - 9452
+3370157:
+  aliases: ['Lepilemur sahamalaza']
+  parents:
+  - 9452
+886966:
+  aliases: ['Lepilemur scottorum']
+  parents:
+  - 9452
+236288:
+  aliases: ['Lepilemur seali']
+  parents:
+  - 9452
+78584:
+  aliases: ['Lepilemur septentrionalis']
+  parents:
+  - 9452
+886967:
+  aliases: ['Lepilemur tymerlachsoni']
+  parents:
+  - 9452
+886968:
+  aliases: ['Lepilemur wrighti']
+  parents:
+  - 9452
+300163:
+  aliases: ['Loris lydekkerianus']
+  parents:
+  - 9467
+9468:
+  aliases: ['Loris tardigradus']
+  parents:
+  - 9467
+185953:
+  aliases: ['Megaladapis edwardsi']
+  parents:
+  - 126593
+864580:
+  aliases: ['Microcebus arnholdi']
+  parents:
+  - 13149
+143352:
+  aliases: ['Microcebus berthae']
+  parents:
+  - 13149
+412750:
+  aliases: ['Microcebus bongolavensis']
+  parents:
+  - 13149
+3043107:
+  aliases: ['Microcebus boraha']
+  parents:
+  - 13149
+412751:
+  aliases: ['Microcebus danfossi']
+  parents:
+  - 13149
+2483760:
+  aliases: ['Microcebus ganzhorni']
+  parents:
+  - 13149
+1131379:
+  aliases: ['Microcebus gerpi']
+  parents:
+  - 13149
+143354:
+  aliases: ['Microcebus griseorufus']
+  parents:
+  - 13149
+236275:
+  aliases: ['Microcebus jollyae']
+  parents:
+  - 13149
+2508170:
+  aliases: ['Microcebus jonahi']
+  parents:
+  - 13149
+343908:
+  aliases: ['Microcebus lehilahytsara']
+  parents:
+  - 13149
+412752:
+  aliases: ['Microcebus lokobensis']
+  parents:
+  - 13149
+548481:
+  aliases: ['Microcebus macarthurii']
+  parents:
+  - 13149
+415757:
+  aliases: ['Microcebus mamiratra']
+  parents:
+  - 13149
+3043108:
+  aliases: ['Microcebus manitatra']
+  parents:
+  - 13149
+864581:
+  aliases: ['Microcebus margotmarshae']
+  parents:
+  - 13149
+1310124:
+  aliases: ['Microcebus marohita']
+  parents:
+  - 13149
+30608:
+  aliases: ['Microcebus murinus']
+  parents:
+  - 13149
+143283:
+  aliases: ['Microcebus myoxinus']
+  parents:
+  - 13149
+122231:
+  aliases: ['Microcebus ravelobensis']
+  parents:
+  - 13149
+122232:
+  aliases: ['Microcebus rufus']
+  parents:
+  - 13149
+143353:
+  aliases: ['Microcebus sambiranensis']
+  parents:
+  - 13149
+236272:
+  aliases: ['Microcebus simmonsi']
+  parents:
+  - 13149
+1310123:
+  aliases: ['Microcebus tanosi']
+  parents:
+  - 13149
+143351:
+  aliases: ['Microcebus tavaratra']
+  parents:
+  - 13149
+47180:
+  aliases: ['Mirza coquereli']
+  parents:
+  - 83691
+339999:
+  aliases: ['Mirza zaza']
+  parents:
+  - 83691
+261741:
+  aliases: ['Nycticebus bengalensis']
+  parents:
+  - 9469
+3030686:
+  aliases: ['Nycticebus borneanus']
+  parents:
+  - 9469
+9470:
+  aliases: ['Nycticebus coucang']
+  parents:
+  - 9469
+2933639:
+  aliases: ['Nycticebus hilleri']
+  parents:
+  - 9469
+310934:
+  aliases: ['Nycticebus javanicus']
+  parents:
+  - 9469
+3030687:
+  aliases: ['Nycticebus kayan']
+  parents:
+  - 9469
+310932:
+  aliases: ['Nycticebus menagensis']
+  parents:
+  - 9469
+9463:
+  aliases: ['Otolemur crassicaudatus']
+  parents:
+  - 30610
+30611:
+  aliases: ['Otolemur garnettii']
+  parents:
+  - 30610
+337212:
+  aliases: ['Otolemur monteiri']
+  parents:
+  - 30610
+1513475:
+  aliases: ['Pachylemur jullyi']
+  parents:
+  - 1513474
+1513477:
+  aliases: ['Palaeopropithecus ingens']
+  parents:
+  - 322024
+1597978:
+  aliases: ['Palaeopropithecus maximus']
+  parents:
+  - 322024
+2604442:
+  aliases: ['Paragalago cocos']
+  parents:
+  - 2604441
+3043104:
+  aliases: ['Paragalago granti']
+  parents:
+  - 2604441
+2604443:
+  aliases: ['Paragalago zanzibaricus']
+  parents:
+  - 2604441
+3413539:
+  aliases: ['Perodicticinae sp.']
+  parents:
+  - 3413538
+9472:
+  aliases: ['Perodicticus potto']
+  parents:
+  - 9471
+1313324:
+  aliases: ['Phaner electromontis']
+  parents:
+  - 261733
+261734:
+  aliases: ['Phaner furcifer']
+  parents:
+  - 261733
+568393:
+  aliases: ['Phaner pallescens']
+  parents:
+  - 261733
+1313325:
+  aliases: ['Phaner parienti']
+  parents:
+  - 261733
+38039:
+  aliases: ['Pitheciinae']
+  parents:
+  - 376919
+1328070:
+  aliases: ['Prolemur simus']
+  parents:
+  - 1328069
+543560:
+  aliases: ['Propithecus candidus']
+  parents:
+  - 30600
+379532:
+  aliases: ['Propithecus coquereli']
+  parents:
+  - 30600
+475618:
+  aliases: ['Propithecus deckenii']
+  parents:
+  - 30600
+83281:
+  aliases: ['Propithecus diadema']
+  parents:
+  - 30600
+543559:
+  aliases: ['Propithecus edwardsi']
+  parents:
+  - 30600
+989338:
+  aliases: ['Propithecus perrieri']
+  parents:
+  - 30600
+30601:
+  aliases: ['Propithecus tattersalli']
+  parents:
+  - 30600
+34825:
+  aliases: ['Propithecus verreauxi']
+  parents:
+  - 30600
+378850:
+  aliases: ['Saimiriinae']
+  parents:
+  - 9498
+449501:
+  aliases: ['Tarsius dentatus']
+  parents:
+  - 9476
+642591:
+  aliases: ['Tarsius dentatus x lariang']
+  parents:
+  - 9476
+1748400:
+  aliases: ['Tarsius fuscus']
+  parents:
+  - 9476
+630277:
+  aliases: ['Tarsius lariang']
+  parents:
+  - 9476
+2925011:
+  aliases: ['Tarsius pumilus']
+  parents:
+  - 9476
+905053:
+  aliases: ['Tarsius sangirensis']
+  parents:
+  - 9476
+662464:
+  aliases: ['Tarsius tarsier']
+  parents:
+  - 9476
+981131:
+  aliases: ['Tarsius wallacei']
+  parents:
+  - 9476
+554167:
+  aliases: ['Varecia rubra']
+  parents:
+  - 9454
+9455:
+  aliases: ['Varecia variegata']
+  parents:
+  - 9454
+101278:
+  aliases: ['Xanthonycticebus pygmaeus']
+  parents:
+  - 3030685
+2490929:
+  aliases: ['Xenothricinae']
+  parents:
+  - 376919
+3471685:
+  aliases: ['unclassified Avahi']
+  parents:
+  - 122245
+38071:
+  aliases: ['unclassified Cebidae']
+  parents:
+  - 9498
+2628747:
+  aliases: ['unclassified Galago']
+  parents:
+  - 9462
+2641939:
+  aliases: ['unclassified Lemur']
+  parents:
+  - 9446
+2645584:
+  aliases: ['unclassified Lepilemur']
+  parents:
+  - 9452
+2620125:
+  aliases: ['unclassified Megaladapis']
+  parents:
+  - 126593
+2630091:
+  aliases: ['unclassified Microcebus']
+  parents:
+  - 13149
+2628182:
+  aliases: ['unclassified Mirza']
+  parents:
+  - 83691
+2646861:
+  aliases: ['unclassified Nycticebus']
+  parents:
+  - 9469
+2619300:
+  aliases: ['unclassified Palaeopropithecus']
+  parents:
+  - 322024
+2677806:
+  aliases: ['unclassified Propithecus']
+  parents:
+  - 30600
+2624233:
+  aliases: ['unclassified Tarsius']
+  parents:
+  - 9476
+3030688:
+  aliases: ['unclassified Xanthonycticebus']
+  parents:
+  - 3030685
+9499:
+  aliases: ['Alouatta']
+  parents:
+  - 38066
+168015:
+  aliases: ['Aotinae gen. sp.']
+  parents:
+  - 38071
+30591:
+  aliases: ['Aotus azarai']
+  parents:
+  - 9504
+361674:
+  aliases: ['Aotus brumbacki']
+  parents:
+  - 9504
+292213:
+  aliases: ['Aotus griseimembra']
+  parents:
+  - 9504
+43147:
+  aliases: ['Aotus lemurinus']
+  parents:
+  - 9504
+37293:
+  aliases: ['Aotus nancymaae']
+  parents:
+  - 9504
+57175:
+  aliases: ['Aotus nigriceps']
+  parents:
+  - 9504
+9505:
+  aliases: ['Aotus trivirgatus']
+  parents:
+  - 9504
+57176:
+  aliases: ['Aotus vociferans']
+  parents:
+  - 9504
+1263727:
+  aliases: ['Aotus zonalis']
+  parents:
+  - 9504
+9506:
+  aliases: ['Ateles']
+  parents:
+  - 38068
+3471686:
+  aliases: ['Avahi sp.']
+  parents:
+  - 3471685
+30593:
+  aliases: ['Brachyteles']
+  parents:
+  - 38068
+30595:
+  aliases: ['Cacajao']
+  parents:
+  - 38039
+9522:
+  aliases: ['Callicebus']
+  parents:
+  - 38069
+9494:
+  aliases: ['Callimico']
+  parents:
+  - 9480
+9481:
+  aliases: ['Callithrix']
+  parents:
+  - 9480
+1965109:
+  aliases: ['Cebuella']
+  parents:
+  - 9480
+9513:
+  aliases: ['Cebus']
+  parents:
+  - 38070
+1971490:
+  aliases: ['Cephalopachus bancanus bancanus']
+  parents:
+  - 9477
+2567999:
+  aliases: ['Cephalopachus bancanus borneanus']
+  parents:
+  - 9477
+9576:
+  aliases: ['Cercopithecidae gen. sp.']
+  parents:
+  - 9527
+9528:
+  aliases: ['Cercopithecinae']
+  parents:
+  - 9527
+1812102:
+  aliases: ['Cheracebus']
+  parents:
+  - 38069
+9524:
+  aliases: ['Chiropotes']
+  parents:
+  - 38039
+9569:
+  aliases: ['Colobinae']
+  parents:
+  - 9527
+122224:
+  aliases: ['Eulemur fulvus albocollaris']
+  parents:
+  - 13515
+47178:
+  aliases: ['Eulemur fulvus collaris']
+  parents:
+  - 13515
+40322:
+  aliases: ['Eulemur fulvus fulvus']
+  parents:
+  - 13515
+27680:
+  aliases: ['Eulemur fulvus mayottensis']
+  parents:
+  - 13515
+30603:
+  aliases: ['Eulemur macaco macaco']
+  parents:
+  - 30602
+1738052:
+  aliases: ['Galago senegalensis braccatus']
+  parents:
+  - 9465
+1738048:
+  aliases: ['Galago senegalensis senegalensis']
+  parents:
+  - 9465
+9464:
+  aliases: ['Galago sp.']
+  parents:
+  - 2628747
+1738051:
+  aliases: ['Galagoides demidoff murinus']
+  parents:
+  - 89672
+1738046:
+  aliases: ['Galagoides zanzibaricus udzungwensis']
+  parents:
+  - 2604443
+1738053:
+  aliases: ['Galagoides zanzibaricus zanzibaricus']
+  parents:
+  - 2604443
+185596:
+  aliases: ['Hapalemur griseus JF2002']
+  parents:
+  - 13557
+122219:
+  aliases: ['Hapalemur griseus griseus']
+  parents:
+  - 13557
+2883640:
+  aliases: ['Hominidae intergeneric hybrids']
+  parents:
+  - 9604
+207598:
+  aliases: ['Homininae']
+  parents:
+  - 9604
+325167:
+  aliases: ['Hoolock']
+  parents:
+  - 9577
+9578:
+  aliases: ['Hylobates']
+  parents:
+  - 9577
+9518:
+  aliases: ['Lagothrix']
+  parents:
+  - 38068
+69491:
+  aliases: ['Lemur sp.']
+  parents:
+  - 2641939
+2681187:
+  aliases: ['Leontocebus']
+  parents:
+  - 9480
+30587:
+  aliases: ['Leontopithecus']
+  parents:
+  - 9480
+185590:
+  aliases: ['Lepilemur sp. RANO234']
+  parents:
+  - 2645584
+185591:
+  aliases: ['Lepilemur sp. RANO235']
+  parents:
+  - 2645584
+185458:
+  aliases: ['Lepilemur sp. RANO236']
+  parents:
+  - 2645584
+400023:
+  aliases: ['Lepilemur sp. hubbardi']
+  parents:
+  - 2645584
+1738050:
+  aliases: ['Loris lydekkerianus lydekkerianus']
+  parents:
+  - 300163
+300166:
+  aliases: ['Loris lydekkerianus malabaricus']
+  parents:
+  - 300163
+261740:
+  aliases: ['Loris tardigradus nordicus']
+  parents:
+  - 9468
+1738049:
+  aliases: ['Loris tardigradus tardigradus']
+  parents:
+  - 9468
+126594:
+  aliases: ['Megaladapis sp.']
+  parents:
+  - 2620125
+322022:
+  aliases: ['Megaladapis sp. UA4821']
+  parents:
+  - 2620125
+322023:
+  aliases: ['Megaladapis sp. UA4822']
+  parents:
+  - 2620125
+322021:
+  aliases: ['Megaladapis sp. UA4823']
+  parents:
+  - 2620125
+322020:
+  aliases: ['Megaladapis sp. UA5482']
+  parents:
+  - 2620125
+1965102:
+  aliases: ['Mico']
+  parents:
+  - 9480
+3471683:
+  aliases: ['Microcebus sp.']
+  parents:
+  - 2630091
+469555:
+  aliases: ["Microcebus sp. 'anosynensis'"]
+  parents:
+  - 2630091
+469557:
+  aliases: ["Microcebus sp. 'mangabenensis'"]
+  parents:
+  - 2630091
+469556:
+  aliases: ["Microcebus sp. 'manombonensis'"]
+  parents:
+  - 2630091
+388736:
+  aliases: ['Microcebus sp. ANT5.1']
+  parents:
+  - 2630091
+412758:
+  aliases: ['Microcebus sp. Ambongabe']
+  parents:
+  - 2630091
+548482:
+  aliases: ['Microcebus sp. Anjiahely']
+  parents:
+  - 2630091
+418100:
+  aliases: ['Microcebus sp. Antanosy']
+  parents:
+  - 2630091
+412759:
+  aliases: ['Microcebus sp. Bora']
+  parents:
+  - 2630091
+764313:
+  aliases: ['Microcebus sp. DWW-2010a']
+  parents:
+  - 2630091
+270538:
+  aliases: ['Microcebus sp. EELHDZ M98']
+  parents:
+  - 2630091
+270540:
+  aliases: ['Microcebus sp. EELHDZ TAD23']
+  parents:
+  - 2630091
+270674:
+  aliases: ['Microcebus sp. EELHDZ VEV33']
+  parents:
+  - 2630091
+270675:
+  aliases: ['Microcebus sp. EELHDZ VEV35']
+  parents:
+  - 2630091
+2735722:
+  aliases: ['Microcebus sp. JM-2020']
+  parents:
+  - 2630091
+412760:
+  aliases: ['Microcebus sp. Mahajamba-Est']
+  parents:
+  - 2630091
+412761:
+  aliases: ['Microcebus sp. Maroakata']
+  parents:
+  - 2630091
+1310125:
+  aliases: ["Microcebus sp. d'Ambre"]
+  parents:
+  - 2630091
+2683930:
+  aliases: ['Microcebus sp. south Manambery']
+  parents:
+  - 2630091
+415977:
+  aliases: ['Mirza sp. 001y03']
+  parents:
+  - 2628182
+325165:
+  aliases: ['Nomascus']
+  parents:
+  - 9577
+310933:
+  aliases: ['Nycticebus coucang coucang']
+  parents:
+  - 9470
+2020906:
+  aliases: ['Nycticebus coucang insularis']
+  parents:
+  - 9470
+108082:
+  aliases: ['Nycticebus sp.']
+  parents:
+  - 2646861
+477174:
+  aliases: ['Otolemur garnettii garnettii']
+  parents:
+  - 30611
+337214:
+  aliases: ['Otolemur monteiri argentatus']
+  parents:
+  - 337212
+337213:
+  aliases: ['Otolemur monteiri monteiri']
+  parents:
+  - 337212
+322027:
+  aliases: ['Palaeopropithecus sp. KPK-2005']
+  parents:
+  - 2619300
+322025:
+  aliases: ['Palaeopropithecus sp. UA4466']
+  parents:
+  - 2619300
+322026:
+  aliases: ['Palaeopropithecus sp. UA6184']
+  parents:
+  - 2619300
+9473:
+  aliases: ['Perodicticus potto edwarsi']
+  parents:
+  - 9472
+261737:
+  aliases: ['Perodicticus potto ibeanus']
+  parents:
+  - 9472
+30597:
+  aliases: ['Pithecia']
+  parents:
+  - 38039
+1812035:
+  aliases: ['Plecturocebus']
+  parents:
+  - 38069
+607660:
+  aliases: ['Ponginae']
+  parents:
+  - 9604
+475619:
+  aliases: ['Propithecus deckenii coronatus']
+  parents:
+  - 475618
+481705:
+  aliases: ['Propithecus deckenii deckenii']
+  parents:
+  - 475618
+171945:
+  aliases: ['Propithecus diadema diadema']
+  parents:
+  - 83281
+171947:
+  aliases: ['Propithecus diadema marshi']
+  parents:
+  - 83281
+39582:
+  aliases: ['Propithecus sp.']
+  parents:
+  - 2677806
+3092528:
+  aliases: ['Propithecus sp. m MH-2023']
+  parents:
+  - 2677806
+122229:
+  aliases: ['Propithecus verreauxi verreauxi']
+  parents:
+  - 34825
+9486:
+  aliases: ['Saguinus']
+  parents:
+  - 9480
+9520:
+  aliases: ['Saimiri']
+  parents:
+  - 378850
+1532884:
+  aliases: ['Sapajus']
+  parents:
+  - 38070
+325166:
+  aliases: ['Symphalangus']
+  parents:
+  - 9577
+30612:
+  aliases: ['Tarsius sp.']
+  parents:
+  - 2624233
+1748402:
+  aliases: ['Tarsius sp. CD-2015']
+  parents:
+  - 2624233
+662655:
+  aliases: ['Tarsius sp. FFA-2009a']
+  parents:
+  - 2624233
+87289:
+  aliases: ['Varecia variegata variegata']
+  parents:
+  - 9455
+3030689:
+  aliases: ['Xanthonycticebus sp. i MB-2023']
+  parents:
+  - 3030688
+2490930:
+  aliases: ['Xenothrix']
+  parents:
+  - 2490929
+2688256:
+  aliases: ['unclassified Aotus (in: primates)']
+  parents:
+  - 9504
+3085340:
+  aliases: ['unclassified Callitrichinae']
+  parents:
+  - 9480
+2922387:
+  aliases: ['unclassified Hominidae']
+  parents:
+  - 9604
+54134:
+  aliases: ['Allenopithecus']
+  parents:
+  - 9528
+2059839:
+  aliases: ['Allochrocebus']
+  parents:
+  - 9528
+30590:
+  aliases: ['Alouatta belzebul']
+  parents:
+  - 9499
+9502:
+  aliases: ['Alouatta caraya']
+  parents:
+  - 9499
+2905217:
+  aliases: ['Alouatta discolor']
+  parents:
+  - 9499
+182256:
+  aliases: ['Alouatta guariba']
+  parents:
+  - 9499
+2946512:
+  aliases: ['Alouatta juara']
+  parents:
+  - 9499
+198115:
+  aliases: ['Alouatta macconnelli']
+  parents:
+  - 9499
+30589:
+  aliases: ['Alouatta palliata']
+  parents:
+  - 9499
+2487933:
+  aliases: ['Alouatta palliata x Alouatta pigra']
+  parents:
+  - 9499
+182253:
+  aliases: ['Alouatta pigra']
+  parents:
+  - 9499
+121123:
+  aliases: ['Alouatta sara']
+  parents:
+  - 9499
+9503:
+  aliases: ['Alouatta seniculus']
+  parents:
+  - 9499
+163110:
+  aliases: ['Alouatta stramineus']
+  parents:
+  - 9499
+2905218:
+  aliases: ['Alouatta ululata']
+  parents:
+  - 9499
+120088:
+  aliases: ['Aotus azarai azarai']
+  parents:
+  - 30591
+280755:
+  aliases: ['Aotus azarai boliviensis']
+  parents:
+  - 30591
+867331:
+  aliases: ['Aotus azarai infulatus']
+  parents:
+  - 30591
+231953:
+  aliases: ['Aotus sp. (in: primates)']
+  parents:
+  - 2688256
+1002694:
+  aliases: ['Aotus sp. AVB-2011']
+  parents:
+  - 2688256
+413234:
+  aliases: ['Aotus sp. Aot1']
+  parents:
+  - 2688256
+1230482:
+  aliases: ['Aotus sp. LC-2012']
+  parents:
+  - 2688256
+1090913:
+  aliases: ['Aotus sp. MAS-2011']
+  parents:
+  - 2688256
+222417:
+  aliases: ['Aotus sp. NIM-2003']
+  parents:
+  - 2688256
+261316:
+  aliases: ['Aotus sp. PDE-2004']
+  parents:
+  - 2688256
+940829:
+  aliases: ['Aotus sp. SHM-2010']
+  parents:
+  - 2688256
+9507:
+  aliases: ['Ateles belzebuth']
+  parents:
+  - 9506
+118643:
+  aliases: ['Ateles chamek']
+  parents:
+  - 9506
+9508:
+  aliases: ['Ateles fusciceps']
+  parents:
+  - 9506
+9509:
+  aliases: ['Ateles geoffroyi']
+  parents:
+  - 9506
+129801:
+  aliases: ['Ateles hybridus']
+  parents:
+  - 9506
+1529884:
+  aliases: ['Ateles marginatus']
+  parents:
+  - 9506
+9510:
+  aliases: ['Ateles paniscus']
+  parents:
+  - 9506
+36234:
+  aliases: ['Ateles paniscus x Ateles fusciceps']
+  parents:
+  - 9506
+30594:
+  aliases: ['Brachyteles arachnoides']
+  parents:
+  - 30593
+342807:
+  aliases: ['Brachyteles hypoxanthus']
+  parents:
+  - 30593
+2937889:
+  aliases: ['Cacajao amuna']
+  parents:
+  - 30595
+535896:
+  aliases: ['Cacajao ayresi']
+  parents:
+  - 30595
+30596:
+  aliases: ['Cacajao calvus']
+  parents:
+  - 30595
+535897:
+  aliases: ['Cacajao hosomi']
+  parents:
+  - 30595
+70825:
+  aliases: ['Cacajao melanocephalus']
+  parents:
+  - 30595
+70927:
+  aliases: ['Cacajao rubicundus']
+  parents:
+  - 30595
+1965113:
+  aliases: ['Calibella']
+  parents:
+  - 9481
+1861701:
+  aliases: ['Callicebus caquetensis']
+  parents:
+  - 9522
+867333:
+  aliases: ['Callicebus coimbrai']
+  parents:
+  - 9522
+1290433:
+  aliases: ['Callicebus dubius']
+  parents:
+  - 9522
+867334:
+  aliases: ['Callicebus nigrifrons']
+  parents:
+  - 9522
+1861702:
+  aliases: ['Callicebus ornatus']
+  parents:
+  - 9522
+70814:
+  aliases: ['Callicebus personatus']
+  parents:
+  - 9522
+9495:
+  aliases: ['Callimico goeldii']
+  parents:
+  - 9494
+1965096:
+  aliases: ['Callithrix']
+  parents:
+  - 9481
+38020:
+  aliases: ['Callitrichinae sp.']
+  parents:
+  - 3085340
+2826950:
+  aliases: ['Cebuella niveiventris']
+  parents:
+  - 1965109
+9493:
+  aliases: ['Cebuella pygmaea']
+  parents:
+  - 1965109
+3317177:
+  aliases: ['Cebus aequatorialis']
+  parents:
+  - 9513
+9514:
+  aliases: ['Cebus albifrons']
+  parents:
+  - 9513
+9516:
+  aliases: ['Cebus capucinus']
+  parents:
+  - 9513
+3128532:
+  aliases: ['Cebus castaneus']
+  parents:
+  - 9513
+2715852:
+  aliases: ['Cebus imitator']
+  parents:
+  - 9513
+37294:
+  aliases: ['Cebus kaapori']
+  parents:
+  - 9513
+37295:
+  aliases: ['Cebus olivaceus']
+  parents:
+  - 9513
+1985288:
+  aliases: ['Cebus unicolor']
+  parents:
+  - 9513
+1985289:
+  aliases: ['Cebus versicolor']
+  parents:
+  - 9513
+9529:
+  aliases: ['Cercocebus']
+  parents:
+  - 9528
+9533:
+  aliases: ['Cercopithecus']
+  parents:
+  - 9528
+2487712:
+  aliases: ['Cheracebus lucifer']
+  parents:
+  - 1812102
+210166:
+  aliases: ['Cheracebus lugens']
+  parents:
+  - 1812102
+1812106:
+  aliases: ['Cheracebus medemi']
+  parents:
+  - 1812102
+1560619:
+  aliases: ['Cheracebus purinus']
+  parents:
+  - 1812102
+1812110:
+  aliases: ['Cheracebus regulus']
+  parents:
+  - 1812102
+30592:
+  aliases: ['Cheracebus torquatus']
+  parents:
+  - 1812102
+198627:
+  aliases: ['Chiropotes albinasus']
+  parents:
+  - 9524
+626367:
+  aliases: ['Chiropotes albinasus x satanas']
+  parents:
+  - 9524
+658221:
+  aliases: ['Chiropotes chiropotes']
+  parents:
+  - 9524
+280163:
+  aliases: ['Chiropotes israelita']
+  parents:
+  - 9524
+3134011:
+  aliases: ['Chiropotes sagulatus']
+  parents:
+  - 9524
+9525:
+  aliases: ['Chiropotes satanas']
+  parents:
+  - 9524
+202458:
+  aliases: ['Chiropotes satanas x albinasus']
+  parents:
+  - 9524
+280160:
+  aliases: ['Chiropotes utahickae']
+  parents:
+  - 9524
+392815:
+  aliases: ['Chlorocebus']
+  parents:
+  - 9528
+9570:
+  aliases: ['Colobus']
+  parents:
+  - 9569
+9537:
+  aliases: ['Erythrocebus']
+  parents:
+  - 9528
+9592:
+  aliases: ['Gorilla']
+  parents:
+  - 207598
+2922388:
+  aliases: ['Hominidae sp.']
+  parents:
+  - 2922387
+9605:
+  aliases: ['Homo']
+  parents:
+  - 207598
+2883641:
+  aliases: ['Homo sapiens x Pan troglodytes tetraploid cell line']
+  parents:
+  - 2883640
+61851:
+  aliases: ['Hoolock hoolock']
+  parents:
+  - 325167
+593543:
+  aliases: ['Hoolock leuconedys']
+  parents:
+  - 325167
+1934191:
+  aliases: ['Hoolock leuconedys x Hoolock tianxing']
+  parents:
+  - 325167
+1934190:
+  aliases: ['Hoolock tianxing']
+  parents:
+  - 325167
+9579:
+  aliases: ['Hylobates agilis']
+  parents:
+  - 9578
+2768845:
+  aliases: ['Hylobates agilis x Hylobates albibarbis']
+  parents:
+  - 9578
+716691:
+  aliases: ['Hylobates albibarbis']
+  parents:
+  - 9578
+3370097:
+  aliases: ['Hylobates funereus']
+  parents:
+  - 9578
+9587:
+  aliases: ['Hylobates klossii']
+  parents:
+  - 9578
+9580:
+  aliases: ['Hylobates lar']
+  parents:
+  - 9578
+2841023:
+  aliases: ['Hylobates lar x Hylobates pileatus']
+  parents:
+  - 9578
+81572:
+  aliases: ['Hylobates moloch']
+  parents:
+  - 9578
+9588:
+  aliases: ['Hylobates muelleri']
+  parents:
+  - 9578
+9589:
+  aliases: ['Hylobates pileatus']
+  parents:
+  - 9578
+767357:
+  aliases: ['Lagothrix cana']
+  parents:
+  - 9518
+2565305:
+  aliases: ['Lagothrix flavicauda']
+  parents:
+  - 9518
+9519:
+  aliases: ['Lagothrix lagotricha']
+  parents:
+  - 9518
+767355:
+  aliases: ['Lagothrix lugens']
+  parents:
+  - 9518
+767356:
+  aliases: ['Lagothrix poeppigii']
+  parents:
+  - 9518
+2565306:
+  aliases: ['Lagothrix tschudii']
+  parents:
+  - 9518
+1618156:
+  aliases: ['Leontocebus cruzlimai']
+  parents:
+  - 2681187
+9487:
+  aliases: ['Leontocebus fuscicollis']
+  parents:
+  - 2681187
+2918762:
+  aliases: ['Leontocebus fuscus']
+  parents:
+  - 2681187
+9489:
+  aliases: ['Leontocebus nigricollis']
+  parents:
+  - 2681187
+122388:
+  aliases: ['Leontocebus tripartitus']
+  parents:
+  - 2681187
+57374:
+  aliases: ['Leontopithecus chrysomelas']
+  parents:
+  - 30587
+58710:
+  aliases: ['Leontopithecus chrysopygus']
+  parents:
+  - 30587
+30588:
+  aliases: ['Leontopithecus rosalia']
+  parents:
+  - 30587
+75565:
+  aliases: ['Lophocebus']
+  parents:
+  - 9528
+9539:
+  aliases: ['Macaca']
+  parents:
+  - 9528
+9567:
+  aliases: ['Mandrillus']
+  parents:
+  - 9528
+9482:
+  aliases: ['Mico argentatus']
+  parents:
+  - 1965102
+198701:
+  aliases: ['Mico cf. emiliae']
+  parents:
+  - 1965102
+3370242:
+  aliases: ['Mico chrysoleucos']
+  parents:
+  - 1965102
+48842:
+  aliases: ['Mico emiliae']
+  parents:
+  - 1965102
+52232:
+  aliases: ['Mico humeralifer']
+  parents:
+  - 1965102
+666519:
+  aliases: ['Mico humilis']
+  parents:
+  - 1965102
+2592805:
+  aliases: ['Mico intermedius']
+  parents:
+  - 1965102
+2592806:
+  aliases: ['Mico leucippe']
+  parents:
+  - 1965102
+2592807:
+  aliases: ['Mico marcai']
+  parents:
+  - 1965102
+57377:
+  aliases: ['Mico mauesi']
+  parents:
+  - 1965102
+1090896:
+  aliases: ['Mico melanurus']
+  parents:
+  - 1965102
+2592808:
+  aliases: ['Mico munduruku']
+  parents:
+  - 1965102
+1127763:
+  aliases: ['Mico rondoni']
+  parents:
+  - 1965102
+198702:
+  aliases: ['Mico saterei']
+  parents:
+  - 1965102
+2850016:
+  aliases: ['Mico schneideri']
+  parents:
+  - 1965102
+36230:
+  aliases: ['Miopithecus']
+  parents:
+  - 9528
+43779:
+  aliases: ['Nasalis']
+  parents:
+  - 9569
+1616038:
+  aliases: ['Nomascus annamensis']
+  parents:
+  - 325165
+2170374:
+  aliases: ['Nomascus cf. leucogenys SSH-2018']
+  parents:
+  - 325165
+29089:
+  aliases: ['Nomascus concolor']
+  parents:
+  - 325165
+61852:
+  aliases: ['Nomascus gabriellae']
+  parents:
+  - 325165
+2170372:
+  aliases: ['Nomascus gabriellae x Nomascus siki']
+  parents:
+  - 325165
+693984:
+  aliases: ['Nomascus hainanus']
+  parents:
+  - 325165
+61853:
+  aliases: ['Nomascus leucogenys']
+  parents:
+  - 325165
+2768844:
+  aliases: ['Nomascus leucogenys x Nomascus gabriellae']
+  parents:
+  - 325165
+2170373:
+  aliases: ['Nomascus leucogenys x Nomascus siki']
+  parents:
+  - 325165
+327374:
+  aliases: ['Nomascus nasutus']
+  parents:
+  - 325165
+9586:
+  aliases: ['Nomascus siki']
+  parents:
+  - 325165
+9596:
+  aliases: ['Pan']
+  parents:
+  - 207598
+9554:
+  aliases: ['Papio']
+  parents:
+  - 9528
+591932:
+  aliases: ['Piliocolobus']
+  parents:
+  - 9569
+2839867:
+  aliases: ['Pithecia aequatorialis']
+  parents:
+  - 30597
+2946514:
+  aliases: ['Pithecia albicans']
+  parents:
+  - 30597
+2946515:
+  aliases: ['Pithecia chrysocephala']
+  parents:
+  - 30597
+2946516:
+  aliases: ['Pithecia hirsuta']
+  parents:
+  - 30597
+30598:
+  aliases: ['Pithecia irrorata']
+  parents:
+  - 30597
+2946517:
+  aliases: ['Pithecia mittermeieri']
+  parents:
+  - 30597
+595220:
+  aliases: ['Pithecia monachus']
+  parents:
+  - 30597
+2946518:
+  aliases: ['Pithecia pissinatti']
+  parents:
+  - 30597
+43777:
+  aliases: ['Pithecia pithecia']
+  parents:
+  - 30597
+2946519:
+  aliases: ['Pithecia vanzolinii']
+  parents:
+  - 30597
+1812036:
+  aliases: ['Plecturocebus bernhardi']
+  parents:
+  - 1812035
+1812042:
+  aliases: ['Plecturocebus brunneus']
+  parents:
+  - 1812035
+867332:
+  aliases: ['Plecturocebus caligatus']
+  parents:
+  - 1812035
+1812037:
+  aliases: ['Plecturocebus cinerascens']
+  parents:
+  - 1812035
+202457:
+  aliases: ['Plecturocebus cupreus']
+  parents:
+  - 1812035
+2839868:
+  aliases: ['Plecturocebus discolor']
+  parents:
+  - 1812035
+230833:
+  aliases: ['Plecturocebus donacophilus']
+  parents:
+  - 1812035
+2946520:
+  aliases: ['Plecturocebus dubius']
+  parents:
+  - 1812035
+2488670:
+  aliases: ['Plecturocebus grovesi']
+  parents:
+  - 1812035
+78255:
+  aliases: ['Plecturocebus hoffmannsi']
+  parents:
+  - 1812035
+1812038:
+  aliases: ['Plecturocebus miltoni']
+  parents:
+  - 1812035
+9523:
+  aliases: ['Plecturocebus moloch']
+  parents:
+  - 1812035
+3370595:
+  aliases: ['Plecturocebus oenanthe']
+  parents:
+  - 1812035
+3370601:
+  aliases: ['Plecturocebus toppini']
+  parents:
+  - 1812035
+2487713:
+  aliases: ['Plecturocebus vieirai']
+  parents:
+  - 1812035
+9599:
+  aliases: ['Pongo']
+  parents:
+  - 607660
+9573:
+  aliases: ['Presbytis']
+  parents:
+  - 9569
+164647:
+  aliases: ['Procolobus']
+  parents:
+  - 9569
+54132:
+  aliases: ['Pygathrix']
+  parents:
+  - 9569
+542827:
+  aliases: ['Rhinopithecus']
+  parents:
+  - 9569
+371038:
+  aliases: ['Rungwecebus']
+  parents:
+  - 9528
+37588:
+  aliases: ['Saguinus bicolor']
+  parents:
+  - 9486
+43778:
+  aliases: ['Saguinus geoffroyi']
+  parents:
+  - 9486
+2586293:
+  aliases: ['Saguinus geoffroyi x Saguinus leucopus']
+  parents:
+  - 9486
+873073:
+  aliases: ['Saguinus graellsi']
+  parents:
+  - 9486
+9491:
+  aliases: ['Saguinus imperator']
+  parents:
+  - 9486
+1079039:
+  aliases: ['Saguinus inustus']
+  parents:
+  - 9486
+78454:
+  aliases: ['Saguinus labiatus']
+  parents:
+  - 9486
+290597:
+  aliases: ['Saguinus leucopus']
+  parents:
+  - 9486
+356666:
+  aliases: ['Saguinus martinsi']
+  parents:
+  - 9486
+873067:
+  aliases: ['Saguinus melanoleucus']
+  parents:
+  - 9486
+30586:
+  aliases: ['Saguinus midas']
+  parents:
+  - 9486
+9488:
+  aliases: ['Saguinus mystax']
+  parents:
+  - 9486
+356665:
+  aliases: ['Saguinus niger']
+  parents:
+  - 9486
+9490:
+  aliases: ['Saguinus oedipus']
+  parents:
+  - 9486
+2586294:
+  aliases: ['Saguinus oedipus x Saguinus leucopus']
+  parents:
+  - 9486
+2918763:
+  aliases: ['Saguinus ursulus']
+  parents:
+  - 9486
+3370761:
+  aliases: ['Saguinus weddelli']
+  parents:
+  - 9486
+27679:
+  aliases: ['Saimiri boliviensis']
+  parents:
+  - 9520
+2946521:
+  aliases: ['Saimiri cassiquiarensis']
+  parents:
+  - 9520
+2946522:
+  aliases: ['Saimiri macrodon']
+  parents:
+  - 9520
+70928:
+  aliases: ['Saimiri oerstedii']
+  parents:
+  - 9520
+9521:
+  aliases: ['Saimiri sciureus']
+  parents:
+  - 9520
+66265:
+  aliases: ['Saimiri ustus']
+  parents:
+  - 9520
+1561161:
+  aliases: ['Saimiri vanzolinii']
+  parents:
+  - 9520
+9515:
+  aliases: ['Sapajus apella']
+  parents:
+  - 1532884
+649471:
+  aliases: ['Sapajus cay']
+  parents:
+  - 1532884
+1112861:
+  aliases: ['Sapajus flavius']
+  parents:
+  - 1532884
+1126382:
+  aliases: ['Sapajus libidinosus']
+  parents:
+  - 1532884
+867366:
+  aliases: ['Sapajus nigritus']
+  parents:
+  - 1532884
+174599:
+  aliases: ['Sapajus xanthosternos']
+  parents:
+  - 1532884
+88028:
+  aliases: ['Semnopithecus']
+  parents:
+  - 9569
+1203020:
+  aliases: ['Simias']
+  parents:
+  - 9569
+9590:
+  aliases: ['Symphalangus syndactylus']
+  parents:
+  - 325166
+9564:
+  aliases: ['Theropithecus']
+  parents:
+  - 9528
+54136:
+  aliases: ['Trachypithecus']
+  parents:
+  - 9569
+2490931:
+  aliases: ['Xenothrix mcgregori']
+  parents:
+  - 2490930
+2623697:
+  aliases: ['unclassified Alouatta']
+  parents:
+  - 9499
+120432:
+  aliases: ['unclassified Ateles']
+  parents:
+  - 9506
+2704456:
+  aliases: ['unclassified Cacajao']
+  parents:
+  - 30595
+2627897:
+  aliases: ['unclassified Callicebus']
+  parents:
+  - 9522
+2634122:
+  aliases: ['unclassified Callimico']
+  parents:
+  - 9494
+3406878:
+  aliases: ['unclassified Callithrix (in: primates)']
+  parents:
+  - 9481
+2618788:
+  aliases: ['unclassified Cebus']
+  parents:
+  - 9513
+3074503:
+  aliases: ['unclassified Cercopithecinae']
+  parents:
+  - 9528
+2649368:
+  aliases: ['unclassified Chiropotes']
+  parents:
+  - 9524
+2647113:
+  aliases: ['unclassified Hylobates']
+  parents:
+  - 9578
+2645779:
+  aliases: ['unclassified Lagothrix']
+  parents:
+  - 9518
+2850015:
+  aliases: ['unclassified Mico']
+  parents:
+  - 1965102
+2646430:
+  aliases: ['unclassified Pithecia']
+  parents:
+  - 30597
+2642123:
+  aliases: ['unclassified Saguinus']
+  parents:
+  - 9486
+2635411:
+  aliases: ['unclassified Saimiri']
+  parents:
+  - 9520
+2619504:
+  aliases: ['unclassified Sapajus']
+  parents:
+  - 1532884
+54135:
+  aliases: ['Allenopithecus nigroviridis']
+  parents:
+  - 54134
+100224:
+  aliases: ['Allochrocebus lhoesti']
+  parents:
+  - 2059839
+147649:
+  aliases: ['Allochrocebus preussi']
+  parents:
+  - 2059839
+147650:
+  aliases: ['Allochrocebus solatus']
+  parents:
+  - 2059839
+182257:
+  aliases: ['Alouatta belzebul belzebul']
+  parents:
+  - 30590
+183328:
+  aliases: ['Alouatta guariba clamitans']
+  parents:
+  - 182256
+182252:
+  aliases: ['Alouatta palliata aequatorialis']
+  parents:
+  - 30589
+182249:
+  aliases: ['Alouatta palliata coibensis']
+  parents:
+  - 30589
+182248:
+  aliases: ['Alouatta palliata mexicana']
+  parents:
+  - 30589
+182250:
+  aliases: ['Alouatta palliata palliata']
+  parents:
+  - 30589
+182251:
+  aliases: ['Alouatta palliata trabeata']
+  parents:
+  - 30589
+1347729:
+  aliases: ['Alouatta seniculus puruensis']
+  parents:
+  - 9503
+182254:
+  aliases: ['Alouatta seniculus seniculus']
+  parents:
+  - 9503
+9501:
+  aliases: ['Alouatta sp.']
+  parents:
+  - 2623697
+118644:
+  aliases: ['Ateles belzebuth marginatus']
+  parents:
+  - 9507
+183327:
+  aliases: ['Ateles fusciceps robustus']
+  parents:
+  - 9508
+1497546:
+  aliases: ['Ateles fusciceps rufiventris']
+  parents:
+  - 9508
+1497547:
+  aliases: ['Ateles geoffroyi azuerensis']
+  parents:
+  - 9509
+795835:
+  aliases: ['Ateles geoffroyi frontatus']
+  parents:
+  - 9509
+1214775:
+  aliases: ['Ateles geoffroyi ornatus']
+  parents:
+  - 9509
+118647:
+  aliases: ['Ateles geoffroyi panamensis']
+  parents:
+  - 9509
+118648:
+  aliases: ['Ateles geoffroyi vellerosus']
+  parents:
+  - 9509
+118649:
+  aliases: ['Ateles geoffroyi yucatanensis']
+  parents:
+  - 9509
+1230481:
+  aliases: ['Ateles hybridus hybridus']
+  parents:
+  - 129801
+9511:
+  aliases: ['Ateles sp.']
+  parents:
+  - 120432
+2746757:
+  aliases: ['Ateles sp. Ate-1']
+  parents:
+  - 120432
+2746758:
+  aliases: ['Ateles sp. Ate-2']
+  parents:
+  - 120432
+1967450:
+  aliases: ['Ateles sp. EG-2017']
+  parents:
+  - 120432
+278713:
+  aliases: ['Ateles sp. JPV-2004']
+  parents:
+  - 120432
+269772:
+  aliases: ['Ateles sp. KO-2004']
+  parents:
+  - 120432
+119629:
+  aliases: ['Ateles sp. haplotype Abh10']
+  parents:
+  - 120432
+119630:
+  aliases: ['Ateles sp. haplotype Abh11']
+  parents:
+  - 120432
+119638:
+  aliases: ['Ateles sp. haplotype Abh19']
+  parents:
+  - 120432
+119628:
+  aliases: ['Ateles sp. haplotype Abh9']
+  parents:
+  - 120432
+119632:
+  aliases: ['Ateles sp. haplotype Afr19']
+  parents:
+  - 120432
+119633:
+  aliases: ['Ateles sp. haplotype Afr20']
+  parents:
+  - 120432
+119634:
+  aliases: ['Ateles sp. haplotype Afr21']
+  parents:
+  - 120432
+119640:
+  aliases: ['Ateles sp. haplotype Afr27']
+  parents:
+  - 120432
+119639:
+  aliases: ['Ateles sp. haplotype Agp13']
+  parents:
+  - 120432
+119631:
+  aliases: ['Ateles sp. haplotype Agsubspp. 16']
+  parents:
+  - 120432
+85699:
+  aliases: ['Cacajao calvus calvus']
+  parents:
+  - 30596
+658398:
+  aliases: ['Cacajao calvus novaesi']
+  parents:
+  - 30596
+658400:
+  aliases: ['Cacajao calvus rubicundus']
+  parents:
+  - 30596
+2946513:
+  aliases: ['Cacajao calvus ucayalii']
+  parents:
+  - 30596
+2704457:
+  aliases: ['Cacajao sp. CTGAM5666']
+  parents:
+  - 2704456
+78274:
+  aliases: ['Callicebus personatus nigrifrons']
+  parents:
+  - 70814
+78275:
+  aliases: ['Callicebus personatus personatus']
+  parents:
+  - 70814
+116962:
+  aliases: ['Callicebus sp.']
+  parents:
+  - 2627897
+1861704:
+  aliases: ['Callicebus sp. 1 MH-2016']
+  parents:
+  - 2627897
+1861705:
+  aliases: ['Callicebus sp. 2 MH-2016']
+  parents:
+  - 2627897
+1090915:
+  aliases: ['Callicebus sp. MAS-2011']
+  parents:
+  - 2627897
+2650809:
+  aliases: ['Callicebus sp. n. GD-2019']
+  parents:
+  - 2627897
+1758239:
+  aliases: ['Callimico sp.']
+  parents:
+  - 2634122
+1090914:
+  aliases: ['Callimico sp. MAS-2011']
+  parents:
+  - 2634122
+57375:
+  aliases: ['Callithrix aurita']
+  parents:
+  - 1965096
+1346251:
+  aliases: ['Callithrix flaviceps']
+  parents:
+  - 1965096
+52231:
+  aliases: ['Callithrix geoffroyi']
+  parents:
+  - 1965096
+9483:
+  aliases: ['Callithrix jacchus']
+  parents:
+  - 1965096
+1476500:
+  aliases: ['Callithrix jacchus x penicillata']
+  parents:
+  - 1965096
+867363:
+  aliases: ['Callithrix kuhlii']
+  parents:
+  - 1965096
+57378:
+  aliases: ['Callithrix penicillata']
+  parents:
+  - 1965096
+9485:
+  aliases: ['Callithrix sp.']
+  parents:
+  - 1965096
+2765886:
+  aliases: ['Callithrix sp. 1 JM-2020']
+  parents:
+  - 3406878
+2765895:
+  aliases: ['Callithrix sp. 10 JM-2020']
+  parents:
+  - 3406878
+2765896:
+  aliases: ['Callithrix sp. 11 JM-2020']
+  parents:
+  - 3406878
+2765897:
+  aliases: ['Callithrix sp. 12 JM-2020']
+  parents:
+  - 3406878
+2765898:
+  aliases: ['Callithrix sp. 13 JM-2020']
+  parents:
+  - 3406878
+2765899:
+  aliases: ['Callithrix sp. 14 JM-2020']
+  parents:
+  - 3406878
+2765900:
+  aliases: ['Callithrix sp. 15 JM-2020']
+  parents:
+  - 3406878
+2765901:
+  aliases: ['Callithrix sp. 16 JM-2020']
+  parents:
+  - 3406878
+2765902:
+  aliases: ['Callithrix sp. 17 JM-2020']
+  parents:
+  - 3406878
+2765903:
+  aliases: ['Callithrix sp. 18 JM-2020']
+  parents:
+  - 3406878
+2765887:
+  aliases: ['Callithrix sp. 2 JM-2020']
+  parents:
+  - 3406878
+2765888:
+  aliases: ['Callithrix sp. 3 JM-2020']
+  parents:
+  - 3406878
+2765889:
+  aliases: ['Callithrix sp. 4 JM-2020']
+  parents:
+  - 3406878
+2765890:
+  aliases: ['Callithrix sp. 5 JM-2020']
+  parents:
+  - 3406878
+2765891:
+  aliases: ['Callithrix sp. 6 JM-2020']
+  parents:
+  - 3406878
+2765892:
+  aliases: ['Callithrix sp. 7 JM-2020']
+  parents:
+  - 3406878
+2765893:
+  aliases: ['Callithrix sp. 8 JM-2020']
+  parents:
+  - 3406878
+2765894:
+  aliases: ['Callithrix sp. 9 JM-2020']
+  parents:
+  - 3406878
+2873328:
+  aliases: ['Callithrix sp. BJT022']
+  parents:
+  - 3406878
+217956:
+  aliases: ['Callithrix sp. DB-2003']
+  parents:
+  - 1965096
+1985287:
+  aliases: ['Cebus olivaceus castaneus']
+  parents:
+  - 37295
+1090893:
+  aliases: ['Cebus olivaceus nigrivittatus']
+  parents:
+  - 37295
+9517:
+  aliases: ['Cebus sp.']
+  parents:
+  - 2618788
+1967451:
+  aliases: ['Cebus sp. 1 EG-2017']
+  parents:
+  - 2618788
+1967452:
+  aliases: ['Cebus sp. 2 EG-2017']
+  parents:
+  - 2618788
+1090916:
+  aliases: ['Cebus sp. MAS-2011']
+  parents:
+  - 2618788
+255237:
+  aliases: ['Cercocebus agilis']
+  parents:
+  - 9529
+9531:
+  aliases: ['Cercocebus atys']
+  parents:
+  - 9529
+75569:
+  aliases: ['Cercocebus chrysogaster']
+  parents:
+  - 9529
+9532:
+  aliases: ['Cercocebus galeritus']
+  parents:
+  - 9529
+3074498:
+  aliases: ['Cercocebus lunulatus']
+  parents:
+  - 9529
+9530:
+  aliases: ['Cercocebus torquatus']
+  parents:
+  - 9529
+867370:
+  aliases: ['Cercopithecus albogularis']
+  parents:
+  - 9533
+36223:
+  aliases: ['Cercopithecus ascanius']
+  parents:
+  - 9533
+303588:
+  aliases: ['Cercopithecus campbelli']
+  parents:
+  - 9533
+9535:
+  aliases: ['Cercopithecus cephus']
+  parents:
+  - 9533
+1137511:
+  aliases: ['Cercopithecus denti']
+  parents:
+  - 9533
+36224:
+  aliases: ['Cercopithecus diana']
+  parents:
+  - 9533
+1137474:
+  aliases: ['Cercopithecus doggetti']
+  parents:
+  - 9533
+161496:
+  aliases: ['Cercopithecus erythrogaster']
+  parents:
+  - 9533
+167130:
+  aliases: ['Cercopithecus erythrotis']
+  parents:
+  - 9533
+9536:
+  aliases: ['Cercopithecus hamlyni']
+  parents:
+  - 9533
+1137481:
+  aliases: ['Cercopithecus kandti']
+  parents:
+  - 9533
+1191211:
+  aliases: ['Cercopithecus lomamiensis']
+  parents:
+  - 9533
+36225:
+  aliases: ['Cercopithecus mitis']
+  parents:
+  - 9533
+36226:
+  aliases: ['Cercopithecus mona']
+  parents:
+  - 9533
+36227:
+  aliases: ['Cercopithecus neglectus']
+  parents:
+  - 9533
+36228:
+  aliases: ['Cercopithecus nictitans']
+  parents:
+  - 9533
+100487:
+  aliases: ['Cercopithecus petaurista']
+  parents:
+  - 9533
+102108:
+  aliases: ['Cercopithecus pogonias']
+  parents:
+  - 9533
+1137049:
+  aliases: ['Cercopithecus roloway']
+  parents:
+  - 9533
+1579530:
+  aliases: ['Cercopithecus sclateri']
+  parents:
+  - 9533
+263448:
+  aliases: ['Cercopithecus wolfi']
+  parents:
+  - 9533
+1758238:
+  aliases: ['Chiropotes sp.']
+  parents:
+  - 2649368
+2736752:
+  aliases: ['Chiropotes sp. CTGAM5363']
+  parents:
+  - 2649368
+2704455:
+  aliases: ['Chiropotes sp. CTGAM5663']
+  parents:
+  - 2649368
+1090917:
+  aliases: ['Chiropotes sp. MAS-2011']
+  parents:
+  - 2649368
+1472258:
+  aliases: ['Chiropotes sp. ZFMK_2008.244']
+  parents:
+  - 2649368
+9534:
+  aliases: ['Chlorocebus aethiops']
+  parents:
+  - 392815
+1903316:
+  aliases: ['Chlorocebus aethiops x Chlorocebus pygerythrus']
+  parents:
+  - 392815
+1476079:
+  aliases: ['Chlorocebus aethiops x djamdjamensis']
+  parents:
+  - 392815
+460675:
+  aliases: ['Chlorocebus cynosuros']
+  parents:
+  - 392815
+1284215:
+  aliases: ['Chlorocebus djamdjamensis']
+  parents:
+  - 392815
+3369779:
+  aliases: ['Chlorocebus dryas']
+  parents:
+  - 392815
+60710:
+  aliases: ['Chlorocebus pygerythrus']
+  parents:
+  - 392815
+60711:
+  aliases: ['Chlorocebus sabaeus']
+  parents:
+  - 392815
+60712:
+  aliases: ['Chlorocebus tantalus']
+  parents:
+  - 392815
+54131:
+  aliases: ['Colobus angolensis']
+  parents:
+  - 9570
+33548:
+  aliases: ['Colobus guereza']
+  parents:
+  - 9570
+9572:
+  aliases: ['Colobus polykomos']
+  parents:
+  - 9570
+517012:
+  aliases: ['Colobus satanas']
+  parents:
+  - 9570
+378195:
+  aliases: ['Colobus vellerosus']
+  parents:
+  - 9570
+378196:
+  aliases: ['Colobus vellerosus x angolensis']
+  parents:
+  - 9570
+9538:
+  aliases: ['Erythrocebus patas']
+  parents:
+  - 9537
+499232:
+  aliases: ['Gorilla beringei']
+  parents:
+  - 9592
+9593:
+  aliases: ['Gorilla gorilla']
+  parents:
+  - 9592
+1425170:
+  aliases: ['Homo heidelbergensis']
+  parents:
+  - 9605
+9606:
+  aliases: ['Homo sapiens']
+  parents:
+  - 9605
+716690:
+  aliases: ['Hylobates agilis agilis']
+  parents:
+  - 9579
+9583:
+  aliases: ['Hylobates agilis unko']
+  parents:
+  - 9579
+716695:
+  aliases: ['Hylobates lar carpenteri']
+  parents:
+  - 9580
+716696:
+  aliases: ['Hylobates lar entelloides']
+  parents:
+  - 9580
+716697:
+  aliases: ['Hylobates lar lar']
+  parents:
+  - 9580
+716698:
+  aliases: ['Hylobates lar vestitus']
+  parents:
+  - 9580
+716694:
+  aliases: ['Hylobates muelleri abbotti']
+  parents:
+  - 9588
+716692:
+  aliases: ['Hylobates muelleri muelleri']
+  parents:
+  - 9588
+9581:
+  aliases: ['Hylobates sp.']
+  parents:
+  - 2647113
+288892:
+  aliases: ['Hylobates sp. AMA-2004']
+  parents:
+  - 2647113
+419588:
+  aliases: ['Hylobates sp. ECACC MLA144']
+  parents:
+  - 2647113
+280856:
+  aliases: ['Hylobates sp. IGL-2004']
+  parents:
+  - 2647113
+2768846:
+  aliases: ['Hylobates sp. KM-2020']
+  parents:
+  - 2647113
+2023128:
+  aliases: ['Hylobates sp. OH-2017']
+  parents:
+  - 2647113
+425245:
+  aliases: ['Hylobates sp. PS-2007']
+  parents:
+  - 2647113
+150249:
+  aliases: ['Hylobates sp. TIB-201']
+  parents:
+  - 2647113
+638937:
+  aliases: ['Lagothrix sp. CCS-2009a']
+  parents:
+  - 2645779
+1967456:
+  aliases: ['Lagothrix sp. EG-2017']
+  parents:
+  - 2645779
+48018:
+  aliases: ['Leontocebus fuscicollis fuscicollis']
+  parents:
+  - 9487
+881947:
+  aliases: ['Leontocebus fuscicollis illigeri']
+  parents:
+  - 9487
+881950:
+  aliases: ['Leontocebus fuscicollis lagonotus']
+  parents:
+  - 9487
+881946:
+  aliases: ['Leontocebus fuscicollis leucogenys']
+  parents:
+  - 9487
+881949:
+  aliases: ['Leontocebus fuscicollis nigrifrons']
+  parents:
+  - 9487
+343424:
+  aliases: ['Leontocebus fuscicollis weddelli']
+  parents:
+  - 9487
+873070:
+  aliases: ['Leontocebus nigricollis nigricollis']
+  parents:
+  - 9489
+75567:
+  aliases: ['Lophocebus albigena']
+  parents:
+  - 75565
+75566:
+  aliases: ['Lophocebus aterrimus']
+  parents:
+  - 75565
+9540:
+  aliases: ['Macaca arctoides']
+  parents:
+  - 9539
+9551:
+  aliases: ['Macaca assamensis']
+  parents:
+  - 9539
+281404:
+  aliases: ['Macaca balantak']
+  parents:
+  - 9539
+281405:
+  aliases: ['Macaca balantak x tonkeana']
+  parents:
+  - 9539
+90381:
+  aliases: ['Macaca brunnescens']
+  parents:
+  - 9539
+78449:
+  aliases: ['Macaca cyclopis']
+  parents:
+  - 9539
+9541:
+  aliases: ['Macaca fascicularis']
+  parents:
+  - 9539
+3016450:
+  aliases: ['Macaca fascicularis x Macaca mulatta']
+  parents:
+  - 9539
+9542:
+  aliases: ['Macaca fuscata']
+  parents:
+  - 9539
+90382:
+  aliases: ['Macaca hecki']
+  parents:
+  - 9539
+171293:
+  aliases: ['Macaca hecki x tonkeana']
+  parents:
+  - 9539
+90387:
+  aliases: ['Macaca leonina']
+  parents:
+  - 9539
+1885588:
+  aliases: ['Macaca leucogenys']
+  parents:
+  - 9539
+90383:
+  aliases: ['Macaca maura']
+  parents:
+  - 9539
+168259:
+  aliases: ['Macaca maura x tonkeana']
+  parents:
+  - 9539
+9544:
+  aliases: ['Macaca mulatta']
+  parents:
+  - 9539
+402888:
+  aliases: ['Macaca munzala']
+  parents:
+  - 9539
+9545:
+  aliases: ['Macaca nemestrina']
+  parents:
+  - 9539
+54600:
+  aliases: ['Macaca nigra']
+  parents:
+  - 9539
+90384:
+  aliases: ['Macaca nigrescens']
+  parents:
+  - 9539
+90385:
+  aliases: ['Macaca ochreata']
+  parents:
+  - 9539
+230653:
+  aliases: ['Macaca pagensis']
+  parents:
+  - 9539
+9548:
+  aliases: ['Macaca radiata']
+  parents:
+  - 9539
+244255:
+  aliases: ['Macaca siberu']
+  parents:
+  - 9539
+54601:
+  aliases: ['Macaca silenus']
+  parents:
+  - 9539
+9552:
+  aliases: ['Macaca sinica']
+  parents:
+  - 9539
+9546:
+  aliases: ['Macaca sylvanus']
+  parents:
+  - 9539
+54602:
+  aliases: ['Macaca thibetana']
+  parents:
+  - 9539
+40843:
+  aliases: ['Macaca tonkeana']
+  parents:
+  - 9539
+9568:
+  aliases: ['Mandrillus leucophaeus']
+  parents:
+  - 9567
+9561:
+  aliases: ['Mandrillus sphinx']
+  parents:
+  - 9567
+867362:
+  aliases: ['Mico argentatus argentatus']
+  parents:
+  - 9482
+2946523:
+  aliases: ['Mico sp. n. MJ-2022']
+  parents:
+  - 2850015
+100488:
+  aliases: ['Miopithecus ogouensis']
+  parents:
+  - 36230
+36231:
+  aliases: ['Miopithecus talapoin']
+  parents:
+  - 36230
+43780:
+  aliases: ['Nasalis larvatus']
+  parents:
+  - 43779
+716684:
+  aliases: ['Nomascus concolor concolor']
+  parents:
+  - 29089
+423450:
+  aliases: ['Nomascus concolor furvogaster']
+  parents:
+  - 29089
+423449:
+  aliases: ['Nomascus concolor jingdongensis']
+  parents:
+  - 29089
+716685:
+  aliases: ['Nomascus concolor lu']
+  parents:
+  - 29089
+9597:
+  aliases: ['Pan paniscus']
+  parents:
+  - 9596
+9598:
+  aliases: ['Pan troglodytes']
+  parents:
+  - 9596
+9555:
+  aliases: ['Papio anubis']
+  parents:
+  - 9554
+1945556:
+  aliases: ['Papio anubis x Papio cynocephalus']
+  parents:
+  - 9554
+1945557:
+  aliases: ['Papio anubis x Papio ursinus']
+  parents:
+  - 9554
+1560552:
+  aliases: ['Papio anubis x hamadryas']
+  parents:
+  - 9554
+9556:
+  aliases: ['Papio cynocephalus']
+  parents:
+  - 9554
+208510:
+  aliases: ['Papio cynocephalus x Papio anubis']
+  parents:
+  - 9554
+9557:
+  aliases: ['Papio hamadryas']
+  parents:
+  - 9554
+208091:
+  aliases: ['Papio kindae']
+  parents:
+  - 9554
+1945558:
+  aliases: ['Papio kindae x Papio cynocephalus']
+  parents:
+  - 9554
+1945559:
+  aliases: ['Papio kindae x Papio ursinus griseipes']
+  parents:
+  - 9554
+100937:
+  aliases: ['Papio papio']
+  parents:
+  - 9554
+36229:
+  aliases: ['Papio ursinus']
+  parents:
+  - 9554
+3074504:
+  aliases: ['Papionini sp.']
+  parents:
+  - 3074503
+164648:
+  aliases: ['Piliocolobus badius']
+  parents:
+  - 591932
+591938:
+  aliases: ['Piliocolobus foai']
+  parents:
+  - 591932
+591933:
+  aliases: ['Piliocolobus gordonorum']
+  parents:
+  - 591932
+591937:
+  aliases: ['Piliocolobus kirkii']
+  parents:
+  - 591932
+591944:
+  aliases: ['Piliocolobus pennantii']
+  parents:
+  - 591932
+591945:
+  aliases: ['Piliocolobus preussi']
+  parents:
+  - 591932
+591934:
+  aliases: ['Piliocolobus rufomitratus']
+  parents:
+  - 591932
+591936:
+  aliases: ['Piliocolobus tephrosceles']
+  parents:
+  - 591932
+591935:
+  aliases: ['Piliocolobus tholloni']
+  parents:
+  - 591932
+285955:
+  aliases: ['Pithecia pithecia pithecia']
+  parents:
+  - 43777
+1758237:
+  aliases: ['Pithecia sp.']
+  parents:
+  - 2646430
+2946524:
+  aliases: ['Pithecia sp. MJ-2022']
+  parents:
+  - 2646430
+2704458:
+  aliases: ['Pithecia sp. UFPA Pit22']
+  parents:
+  - 2646430
+285954:
+  aliases: ['Plecturocebus donacophilus donacophilus']
+  parents:
+  - 230833
+9601:
+  aliases: ['Pongo abelii']
+  parents:
+  - 9599
+502961:
+  aliases: ['Pongo abelii x pygmaeus']
+  parents:
+  - 9599
+9600:
+  aliases: ['Pongo pygmaeus']
+  parents:
+  - 9599
+2051901:
+  aliases: ['Pongo tapanuliensis']
+  parents:
+  - 9599
+3370610:
+  aliases: ['Presbytis bicolor']
+  parents:
+  - 9573
+1046090:
+  aliases: ['Presbytis chrysomelas']
+  parents:
+  - 9573
+78452:
+  aliases: ['Presbytis comata']
+  parents:
+  - 9573
+78453:
+  aliases: ['Presbytis femoralis']
+  parents:
+  - 9573
+1046092:
+  aliases: ['Presbytis frontata']
+  parents:
+  - 9573
+1046093:
+  aliases: ['Presbytis hosei']
+  parents:
+  - 9573
+78451:
+  aliases: ['Presbytis melalophos']
+  parents:
+  - 9573
+1046098:
+  aliases: ['Presbytis potenziani']
+  parents:
+  - 9573
+1046101:
+  aliases: ['Presbytis rubicunda']
+  parents:
+  - 9573
+66055:
+  aliases: ['Presbytis senex']
+  parents:
+  - 9573
+3370616:
+  aliases: ['Presbytis siberu']
+  parents:
+  - 9573
+3370617:
+  aliases: ['Presbytis sumatrana']
+  parents:
+  - 9573
+1046103:
+  aliases: ['Presbytis thomasi']
+  parents:
+  - 9573
+373033:
+  aliases: ['Procolobus verus']
+  parents:
+  - 164647
+693712:
+  aliases: ['Pygathrix cinerea']
+  parents:
+  - 54132
+1194332:
+  aliases: ['Pygathrix cinerea 1 RL-2012']
+  parents:
+  - 54132
+1194333:
+  aliases: ['Pygathrix cinerea 2 RL-2012']
+  parents:
+  - 54132
+54133:
+  aliases: ['Pygathrix nemaeus']
+  parents:
+  - 54132
+310352:
+  aliases: ['Pygathrix nigripes']
+  parents:
+  - 54132
+66062:
+  aliases: ['Rhinopithecus avunculus']
+  parents:
+  - 542827
+61621:
+  aliases: ['Rhinopithecus bieti']
+  parents:
+  - 542827
+1194334:
+  aliases: ['Rhinopithecus bieti 1 RL-2012']
+  parents:
+  - 542827
+1194335:
+  aliases: ['Rhinopithecus bieti 2 RL-2012']
+  parents:
+  - 542827
+224329:
+  aliases: ['Rhinopithecus brelichi']
+  parents:
+  - 542827
+61622:
+  aliases: ['Rhinopithecus roxellana']
+  parents:
+  - 542827
+1194336:
+  aliases: ['Rhinopithecus strykeri']
+  parents:
+  - 542827
+371039:
+  aliases: ['Rungwecebus kipunji']
+  parents:
+  - 371038
+37589:
+  aliases: ['Saguinus bicolor bicolor']
+  parents:
+  - 37588
+881951:
+  aliases: ['Saguinus imperator subgrisescens']
+  parents:
+  - 9491
+873066:
+  aliases: ['Saguinus labiatus labiatus']
+  parents:
+  - 78454
+2918764:
+  aliases: ['Saguinus labiatus rufiventer']
+  parents:
+  - 78454
+3104633:
+  aliases: ['Saguinus martinsi ochraceus']
+  parents:
+  - 356666
+873068:
+  aliases: ['Saguinus melanoleucus melanoleucus']
+  parents:
+  - 873067
+78354:
+  aliases: ['Saguinus midas midas']
+  parents:
+  - 30586
+873069:
+  aliases: ['Saguinus mystax mystax']
+  parents:
+  - 9488
+2979364:
+  aliases: ['Saguinus mystax pileatus']
+  parents:
+  - 9488
+2979365:
+  aliases: ['Saguinus mystax pluto']
+  parents:
+  - 9488
+100754:
+  aliases: ['Saguinus sp.']
+  parents:
+  - 2642123
+2952760:
+  aliases: ['Saguinus sp. CN232']
+  parents:
+  - 2642123
+2952761:
+  aliases: ['Saguinus sp. CN274']
+  parents:
+  - 2642123
+2952762:
+  aliases: ['Saguinus sp. CN287']
+  parents:
+  - 2642123
+2952796:
+  aliases: ['Saguinus sp. CTGA163']
+  parents:
+  - 2642123
+1967463:
+  aliases: ['Saguinus sp. EG-2017']
+  parents:
+  - 2642123
+2931043:
+  aliases: ['Saguinus sp. INUSTUS706']
+  parents:
+  - 2642123
+2952770:
+  aliases: ['Saguinus sp. INUSTUS708']
+  parents:
+  - 2642123
+2952769:
+  aliases: ['Saguinus sp. INUSTUS723']
+  parents:
+  - 2642123
+2946525:
+  aliases: ['Saguinus sp. MJ-2022']
+  parents:
+  - 2642123
+2952797:
+  aliases: ['Saguinus sp. SBB1000']
+  parents:
+  - 2642123
+2952798:
+  aliases: ['Saguinus sp. SBB1115']
+  parents:
+  - 2642123
+2918757:
+  aliases: ['Saguinus sp. SBBXSMA711']
+  parents:
+  - 2642123
+2952766:
+  aliases: ['Saguinus sp. SG15']
+  parents:
+  - 2642123
+2931044:
+  aliases: ['Saguinus sp. SG17']
+  parents:
+  - 2642123
+2931045:
+  aliases: ['Saguinus sp. SG19']
+  parents:
+  - 2642123
+2952767:
+  aliases: ['Saguinus sp. SG20']
+  parents:
+  - 2642123
+2952765:
+  aliases: ['Saguinus sp. SG25']
+  parents:
+  - 2642123
+2931051:
+  aliases: ['Saguinus sp. SG26']
+  parents:
+  - 2642123
+2952768:
+  aliases: ['Saguinus sp. SIM_F']
+  parents:
+  - 2642123
+2931047:
+  aliases: ['Saguinus sp. SLEUCALI']
+  parents:
+  - 2642123
+2952799:
+  aliases: ['Saguinus sp. SMA57']
+  parents:
+  - 2642123
+2952800:
+  aliases: ['Saguinus sp. SMAR567']
+  parents:
+  - 2642123
+2952771:
+  aliases: ['Saguinus sp. SMI1278']
+  parents:
+  - 2642123
+2931046:
+  aliases: ['Saguinus sp. SMI218']
+  parents:
+  - 2642123
+2952764:
+  aliases: ['Saguinus sp. SMI250']
+  parents:
+  - 2642123
+2952763:
+  aliases: ['Saguinus sp. SMI257']
+  parents:
+  - 2642123
+2952759:
+  aliases: ['Saguinus sp. SMIRC21']
+  parents:
+  - 2642123
+2918756:
+  aliases: ['Saguinus sp. SMIXSBB']
+  parents:
+  - 2642123
+2931048:
+  aliases: ['Saguinus sp. SOEDCALI']
+  parents:
+  - 2642123
+2931049:
+  aliases: ['Saguinus sp. SW4466']
+  parents:
+  - 2642123
+260575:
+  aliases: ['Saguinus sp. T1030']
+  parents:
+  - 2642123
+2931050:
+  aliases: ['Saguinus sp. TMDSU']
+  parents:
+  - 2642123
+2979366:
+  aliases: ['Saguinus sp. k TH-2022']
+  parents:
+  - 2642123
+39432:
+  aliases: ['Saimiri boliviensis boliviensis']
+  parents:
+  - 27679
+495297:
+  aliases: ['Saimiri boliviensis peruviensis']
+  parents:
+  - 27679
+942008:
+  aliases: ['Saimiri oerstedii citrinellus']
+  parents:
+  - 70928
+867380:
+  aliases: ['Saimiri oerstedii oerstedii']
+  parents:
+  - 70928
+495298:
+  aliases: ['Saimiri sciureus albigena']
+  parents:
+  - 9521
+495299:
+  aliases: ['Saimiri sciureus cassiquiarensis']
+  parents:
+  - 9521
+198114:
+  aliases: ['Saimiri sciureus collinsi']
+  parents:
+  - 9521
+495300:
+  aliases: ['Saimiri sciureus macrodon']
+  parents:
+  - 9521
+190117:
+  aliases: ['Saimiri sciureus sciureus']
+  parents:
+  - 9521
+1561164:
+  aliases: ['Saimiri sp.']
+  parents:
+  - 2635411
+1967464:
+  aliases: ['Saimiri sp. 1 EG-2017']
+  parents:
+  - 2635411
+1967465:
+  aliases: ['Saimiri sp. 2 EG-2017']
+  parents:
+  - 2635411
+1967466:
+  aliases: ['Saimiri sp. 3 EG-2017']
+  parents:
+  - 2635411
+1090919:
+  aliases: ['Saimiri sp. MAS-2011']
+  parents:
+  - 2635411
+174598:
+  aliases: ['Sapajus apella apella']
+  parents:
+  - 9515
+1547595:
+  aliases: ['Sapajus apella macrocephalus']
+  parents:
+  - 9515
+1532888:
+  aliases: ['Sapajus apella margaritae']
+  parents:
+  - 9515
+867367:
+  aliases: ['Sapajus nigritus robustus']
+  parents:
+  - 867366
+1874197:
+  aliases: ['Sapajus sp.']
+  parents:
+  - 2619504
+2093836:
+  aliases: ['Sapajus sp. 10 FD-2018']
+  parents:
+  - 2619504
+2093837:
+  aliases: ['Sapajus sp. 22 FD-2018']
+  parents:
+  - 2619504
+2093835:
+  aliases: ['Sapajus sp. 9 FD-2018']
+  parents:
+  - 2619504
+2093839:
+  aliases: ['Sapajus sp. M12 FD-2018']
+  parents:
+  - 2619504
+2093840:
+  aliases: ['Sapajus sp. M39 FD-2018']
+  parents:
+  - 2619504
+2093838:
+  aliases: ['Sapajus sp. M5 FD-2018']
+  parents:
+  - 2619504
+2805706:
+  aliases: ['Sapajus sp. Pr035']
+  parents:
+  - 2619504
+2805936:
+  aliases: ['Semnopithecus ajax']
+  parents:
+  - 88028
+88029:
+  aliases: ['Semnopithecus entellus']
+  parents:
+  - 88028
+867382:
+  aliases: ['Semnopithecus hector']
+  parents:
+  - 88028
+1208734:
+  aliases: ['Semnopithecus hypoleucos']
+  parents:
+  - 88028
+1208733:
+  aliases: ['Semnopithecus priam']
+  parents:
+  - 88028
+2804203:
+  aliases: ['Semnopithecus schistaceus']
+  parents:
+  - 88028
+170207:
+  aliases: ['Simias concolor']
+  parents:
+  - 1203020
+405039:
+  aliases: ['Symphalangus syndactylus syndactylus']
+  parents:
+  - 9590
+9565:
+  aliases: ['Theropithecus gelada']
+  parents:
+  - 9564
+222416:
+  aliases: ['Trachypithecus auratus']
+  parents:
+  - 54136
+271261:
+  aliases: ['Trachypithecus barbei']
+  parents:
+  - 54136
+122765:
+  aliases: ['Trachypithecus cristatus']
+  parents:
+  - 54136
+465717:
+  aliases: ['Trachypithecus delacouri']
+  parents:
+  - 54136
+54180:
+  aliases: ['Trachypithecus francoisi']
+  parents:
+  - 54136
+744437:
+  aliases: ['Trachypithecus francoisi x poliocephalus']
+  parents:
+  - 54136
+164650:
+  aliases: ['Trachypithecus geei']
+  parents:
+  - 54136
+271260:
+  aliases: ['Trachypithecus germaini']
+  parents:
+  - 54136
+867383:
+  aliases: ['Trachypithecus hatinhensis']
+  parents:
+  - 54136
+66063:
+  aliases: ['Trachypithecus johnii']
+  parents:
+  - 54136
+465718:
+  aliases: ['Trachypithecus laotum']
+  parents:
+  - 54136
+1966384:
+  aliases: ['Trachypithecus mauritius']
+  parents:
+  - 54136
+54181:
+  aliases: ['Trachypithecus obscurus']
+  parents:
+  - 54136
+61618:
+  aliases: ['Trachypithecus phayrei']
+  parents:
+  - 54136
+164651:
+  aliases: ['Trachypithecus pileatus']
+  parents:
+  - 54136
+465719:
+  aliases: ['Trachypithecus poliocephalus']
+  parents:
+  - 54136
+1042121:
+  aliases: ['Trachypithecus shortridgei']
+  parents:
+  - 54136
+54137:
+  aliases: ['Trachypithecus vetulus']
+  parents:
+  - 54136
+2665952:
+  aliases: ['environmental samples']
+  parents:
+  - 9605
+2959323:
+  aliases: ['unclassified Cercocebus']
+  parents:
+  - 9529
+2618071:
+  aliases: ['unclassified Cercopithecus']
+  parents:
+  - 9533
+2685534:
+  aliases: ['unclassified Chlorocebus']
+  parents:
+  - 392815
+2618863:
+  aliases: ['unclassified Colobus']
+  parents:
+  - 9570
+2813598:
+  aliases: ['unclassified Homo']
+  parents:
+  - 9605
+2623225:
+  aliases: ['unclassified Macaca']
+  parents:
+  - 9539
+3612877:
+  aliases: ['unclassified Pan']
+  parents:
+  - 9596
+2632072:
+  aliases: ['unclassified Papio']
+  parents:
+  - 9554
+2624844:
+  aliases: ['unclassified Pongo']
+  parents:
+  - 9599
+2651172:
+  aliases: ['unclassified Presbytis']
+  parents:
+  - 9573
+2644350:
+  aliases: ['unclassified Rhinopithecus']
+  parents:
+  - 542827
+2632571:
+  aliases: ['unclassified Semnopithecus']
+  parents:
+  - 88028
+2623509:
+  aliases: ['unclassified Trachypithecus']
+  parents:
+  - 54136
+1137512:
+  aliases: ['Allochrocebus preussi insularis']
+  parents:
+  - 147649
+1137513:
+  aliases: ['Allochrocebus preussi preussi']
+  parents:
+  - 147649
+1592215:
+  aliases: ['Cercocebus atys atys']
+  parents:
+  - 9531
+3413534:
+  aliases: ['Cercocebus sp.']
+  parents:
+  - 2959323
+2959324:
+  aliases: ['Cercocebus sp. Y45']
+  parents:
+  - 2959323
+81944:
+  aliases: ['Cercocebus torquatus torquatus']
+  parents:
+  - 9530
+1137444:
+  aliases: ['Cercopithecus albogularis albotorquatus']
+  parents:
+  - 867370
+1137476:
+  aliases: ['Cercopithecus albogularis erythrarchus']
+  parents:
+  - 867370
+1137483:
+  aliases: ['Cercopithecus albogularis francescae']
+  parents:
+  - 867370
+867372:
+  aliases: ['Cercopithecus albogularis kolbi']
+  parents:
+  - 867370
+1137484:
+  aliases: ['Cercopithecus albogularis labiatus']
+  parents:
+  - 867370
+1137488:
+  aliases: ['Cercopithecus albogularis moloneyi']
+  parents:
+  - 867370
+1137489:
+  aliases: ['Cercopithecus albogularis monoides']
+  parents:
+  - 867370
+192855:
+  aliases: ['Cercopithecus ascanius ascanius']
+  parents:
+  - 36223
+192856:
+  aliases: ['Cercopithecus ascanius katangae']
+  parents:
+  - 36223
+192857:
+  aliases: ['Cercopithecus ascanius schmidti']
+  parents:
+  - 36223
+192858:
+  aliases: ['Cercopithecus ascanius whitesidei']
+  parents:
+  - 36223
+304410:
+  aliases: ['Cercopithecus campbelli lowei']
+  parents:
+  - 303588
+192859:
+  aliases: ['Cercopithecus cephus cephodes']
+  parents:
+  - 9535
+192860:
+  aliases: ['Cercopithecus cephus cephus']
+  parents:
+  - 9535
+167131:
+  aliases: ['Cercopithecus cephus ngottoensis']
+  parents:
+  - 9535
+304409:
+  aliases: ['Cercopithecus erythrogaster erythrogaster']
+  parents:
+  - 161496
+1137433:
+  aliases: ['Cercopithecus erythrogaster pococki']
+  parents:
+  - 161496
+1137435:
+  aliases: ['Cercopithecus erythrotis camerunensis']
+  parents:
+  - 167130
+1137434:
+  aliases: ['Cercopithecus erythrotis erythrotis']
+  parents:
+  - 167130
+867373:
+  aliases: ['Cercopithecus hamlyni hamlyni']
+  parents:
+  - 9536
+1137473:
+  aliases: ['Cercopithecus mitis boutourlinii']
+  parents:
+  - 36225
+1137480:
+  aliases: ['Cercopithecus mitis heymansi']
+  parents:
+  - 36225
+1137482:
+  aliases: ['Cercopithecus mitis mitis']
+  parents:
+  - 36225
+1137490:
+  aliases: ['Cercopithecus mitis opisthostictus']
+  parents:
+  - 36225
+1137491:
+  aliases: ['Cercopithecus mitis stuhlmanni']
+  parents:
+  - 36225
+192861:
+  aliases: ['Cercopithecus mona campbelli']
+  parents:
+  - 36226
+100489:
+  aliases: ['Cercopithecus mona mona']
+  parents:
+  - 36226
+1137494:
+  aliases: ['Cercopithecus nictitans martini']
+  parents:
+  - 36228
+1137495:
+  aliases: ['Cercopithecus nictitans nictitans']
+  parents:
+  - 36228
+192893:
+  aliases: ['Cercopithecus petaurista buettikoferi']
+  parents:
+  - 100487
+192862:
+  aliases: ['Cercopithecus petaurista petaurista']
+  parents:
+  - 100487
+192863:
+  aliases: ['Cercopithecus pogonias grayi']
+  parents:
+  - 102108
+1137506:
+  aliases: ['Cercopithecus pogonias nigripes']
+  parents:
+  - 102108
+1137507:
+  aliases: ['Cercopithecus pogonias pogonias']
+  parents:
+  - 102108
+1137509:
+  aliases: ['Cercopithecus pogonias schwarzianus']
+  parents:
+  - 102108
+3413535:
+  aliases: ['Cercopithecus sp.']
+  parents:
+  - 2618071
+2959303:
+  aliases: ['Cercopithecus sp. T1676']
+  parents:
+  - 2618071
+2959302:
+  aliases: ['Cercopithecus sp. T1713']
+  parents:
+  - 2618071
+2959304:
+  aliases: ['Cercopithecus sp. T1714']
+  parents:
+  - 2618071
+2959300:
+  aliases: ['Cercopithecus sp. T2598']
+  parents:
+  - 2618071
+2959305:
+  aliases: ['Cercopithecus sp. T2601']
+  parents:
+  - 2618071
+2959325:
+  aliases: ['Cercopithecus sp. T2610']
+  parents:
+  - 2618071
+2959301:
+  aliases: ['Cercopithecus sp. T2619']
+  parents:
+  - 2618071
+2959306:
+  aliases: ['Cercopithecus sp. T2632']
+  parents:
+  - 2618071
+2959311:
+  aliases: ['Cercopithecus sp. T2647']
+  parents:
+  - 2618071
+2959330:
+  aliases: ['Cercopithecus sp. T2648']
+  parents:
+  - 2618071
+2959326:
+  aliases: ['Cercopithecus sp. T2649']
+  parents:
+  - 2618071
+2959329:
+  aliases: ['Cercopithecus sp. T2665']
+  parents:
+  - 2618071
+2959331:
+  aliases: ['Cercopithecus sp. T2678']
+  parents:
+  - 2618071
+2959307:
+  aliases: ['Cercopithecus sp. T2681']
+  parents:
+  - 2618071
+2959312:
+  aliases: ['Cercopithecus sp. T2682']
+  parents:
+  - 2618071
+2959313:
+  aliases: ['Cercopithecus sp. T2685']
+  parents:
+  - 2618071
+2959308:
+  aliases: ['Cercopithecus sp. T2688']
+  parents:
+  - 2618071
+2959310:
+  aliases: ['Cercopithecus sp. T2689']
+  parents:
+  - 2618071
+2959309:
+  aliases: ['Cercopithecus sp. T2690']
+  parents:
+  - 2618071
+1144881:
+  aliases: ['Cercopithecus sp. WMS-2012']
+  parents:
+  - 2618071
+2959327:
+  aliases: ['Cercopithecus sp. Y36']
+  parents:
+  - 2618071
+2959328:
+  aliases: ['Cercopithecus sp. Y40']
+  parents:
+  - 2618071
+1137505:
+  aliases: ['Cercopithecus wolfi elegans']
+  parents:
+  - 263448
+1137508:
+  aliases: ['Cercopithecus wolfi pyrogaster']
+  parents:
+  - 263448
+867374:
+  aliases: ['Cercopithecus wolfi wolfi']
+  parents:
+  - 263448
+101841:
+  aliases: ['Chlorocebus aethiops aethiops']
+  parents:
+  - 9534
+100936:
+  aliases: ['Chlorocebus aethiops vervet']
+  parents:
+  - 9534
+508712:
+  aliases: ['Chlorocebus pygerythrus hilgerti']
+  parents:
+  - 60710
+460674:
+  aliases: ['Chlorocebus pygerythrus pygerythrus']
+  parents:
+  - 60710
+2269071:
+  aliases: ['Chlorocebus pygerythrus x Chlorocebus aethiops']
+  parents:
+  - 60710
+2282232:
+  aliases: ['Chlorocebus sp. LDS-2018']
+  parents:
+  - 2685534
+1090918:
+  aliases: ['Chlorocebus sp. MAS-2011']
+  parents:
+  - 2685534
+1284216:
+  aliases: ['Chlorocebus sp. TH-2013']
+  parents:
+  - 2685534
+508710:
+  aliases: ['Chlorocebus tantalus budgetti']
+  parents:
+  - 60712
+336983:
+  aliases: ['Colobus angolensis palliatus']
+  parents:
+  - 54131
+373031:
+  aliases: ['Colobus guereza caudatus']
+  parents:
+  - 33548
+132548:
+  aliases: ['Colobus guereza kikuyuensis']
+  parents:
+  - 33548
+373030:
+  aliases: ['Colobus guereza matschiei']
+  parents:
+  - 33548
+373032:
+  aliases: ['Colobus guereza occidentalis']
+  parents:
+  - 33548
+517013:
+  aliases: ['Colobus satanas satanas']
+  parents:
+  - 517012
+34824:
+  aliases: ['Colobus sp.']
+  parents:
+  - 2618863
+288544:
+  aliases: ['Colobus sp. DTG-2004']
+  parents:
+  - 2618863
+325172:
+  aliases: ['Colobus sp. MB-2005']
+  parents:
+  - 2618863
+3591507:
+  aliases: ['Colobus sp. T76239-1']
+  parents:
+  - 2618863
+1159185:
+  aliases: ['Gorilla beringei beringei']
+  parents:
+  - 499232
+46359:
+  aliases: ['Gorilla beringei graueri']
+  parents:
+  - 499232
+406788:
+  aliases: ['Gorilla gorilla diehli']
+  parents:
+  - 9593
+9595:
+  aliases: ['Gorilla gorilla gorilla']
+  parents:
+  - 9593
+183511:
+  aliases: ['Gorilla gorilla uellensis']
+  parents:
+  - 9593
+2665953:
+  aliases: ['Homo sapiens environmental sample']
+  parents:
+  - 2665952
+63221:
+  aliases: ['Homo sapiens neanderthalensis']
+  parents:
+  - 9606
+741158:
+  aliases: ["Homo sapiens subsp. 'Denisova'"]
+  parents:
+  - 9606
+2813599:
+  aliases: ['Homo sp.']
+  parents:
+  - 2813598
+75568:
+  aliases: ['Lophocebus albigena albigena']
+  parents:
+  - 75567
+1411634:
+  aliases: ['Macaca assamensis assamensis']
+  parents:
+  - 9551
+1747270:
+  aliases: ['Macaca fascicularis aureus']
+  parents:
+  - 9541
+1215360:
+  aliases: ['Macaca fascicularis fascicularis']
+  parents:
+  - 9541
+90386:
+  aliases: ['Macaca fascicularis philippinensis']
+  parents:
+  - 9541
+9543:
+  aliases: ['Macaca fuscata fuscata']
+  parents:
+  - 9542
+179089:
+  aliases: ['Macaca fuscata yakui']
+  parents:
+  - 9542
+1654737:
+  aliases: ['Macaca mulatta brevicaudus']
+  parents:
+  - 9544
+1449913:
+  aliases: ['Macaca mulatta lasiotus']
+  parents:
+  - 9544
+2008792:
+  aliases: ['Macaca mulatta vestita']
+  parents:
+  - 9544
+90388:
+  aliases: ['Macaca nemestrina nemestrina']
+  parents:
+  - 9545
+439030:
+  aliases: ['Macaca radiata radiata']
+  parents:
+  - 9548
+9549:
+  aliases: ['Macaca sp.']
+  parents:
+  - 2623225
+2838830:
+  aliases: ['Macaca sp. XT-2021']
+  parents:
+  - 2623225
+257877:
+  aliases: ['Macaca thibetana thibetana']
+  parents:
+  - 54602
+560240:
+  aliases: ['Miopithecus talapoin talapoin']
+  parents:
+  - 36231
+3612878:
+  aliases: ['Pan sp.']
+  parents:
+  - 3612877
+756884:
+  aliases: ['Pan troglodytes ellioti']
+  parents:
+  - 9598
+37010:
+  aliases: ['Pan troglodytes schweinfurthii']
+  parents:
+  - 9598
+37011:
+  aliases: ['Pan troglodytes troglodytes']
+  parents:
+  - 9598
+37012:
+  aliases: ['Pan troglodytes verus']
+  parents:
+  - 9598
+1294088:
+  aliases: ['Pan troglodytes verus x troglodytes']
+  parents:
+  - 9598
+211508:
+  aliases: ['Papio anubis anubis']
+  parents:
+  - 9555
+106398:
+  aliases: ['Papio cynocephalus cynocephalus']
+  parents:
+  - 9556
+501791:
+  aliases: ['Papio cynocephalus ibeanus']
+  parents:
+  - 9556
+9562:
+  aliases: ['Papio hamadryas hamadryas']
+  parents:
+  - 9557
+61183:
+  aliases: ['Papio sp.']
+  parents:
+  - 2632072
+285280:
+  aliases: ['Papio sp. Africa-2004']
+  parents:
+  - 2632072
+425246:
+  aliases: ['Papio sp. PS-2007']
+  parents:
+  - 2632072
+208090:
+  aliases: ['Papio ursinus griseipes']
+  parents:
+  - 36229
+208089:
+  aliases: ['Papio ursinus ursinus']
+  parents:
+  - 36229
+491852:
+  aliases: ['Piliocolobus badius badius']
+  parents:
+  - 164648
+491853:
+  aliases: ['Piliocolobus badius temminckii']
+  parents:
+  - 164648
+2753605:
+  aliases: ['Pongo pygmaeus morio']
+  parents:
+  - 9600
+9602:
+  aliases: ['Pongo pygmaeus pygmaeus']
+  parents:
+  - 9600
+2753606:
+  aliases: ['Pongo pygmaeus wurmbii']
+  parents:
+  - 9600
+9603:
+  aliases: ['Pongo sp.']
+  parents:
+  - 2624844
+272114:
+  aliases: ['Presbytis comata comata']
+  parents:
+  - 78452
+1046091:
+  aliases: ['Presbytis comata fredericae']
+  parents:
+  - 78452
+1840579:
+  aliases: ['Presbytis femoralis femoralis']
+  parents:
+  - 78453
+1840580:
+  aliases: ['Presbytis femoralis percura']
+  parents:
+  - 78453
+1046094:
+  aliases: ['Presbytis hosei hosei']
+  parents:
+  - 1046093
+1046096:
+  aliases: ['Presbytis melalophos melalophos']
+  parents:
+  - 78451
+272115:
+  aliases: ['Presbytis melalophos mitrata']
+  parents:
+  - 78451
+1046099:
+  aliases: ['Presbytis potenziani potenziani']
+  parents:
+  - 1046098
+1046102:
+  aliases: ['Presbytis rubicunda rubicunda']
+  parents:
+  - 1046101
+2822462:
+  aliases: ['Presbytis sp. Pres2']
+  parents:
+  - 2651172
+303485:
+  aliases: ['Pygathrix nemaeus nemaeus']
+  parents:
+  - 54133
+1859147:
+  aliases: ['Rhinopithecus sp.']
+  parents:
+  - 2644350
+867381:
+  aliases: ['Semnopithecus entellus entellus']
+  parents:
+  - 88029
+1778600:
+  aliases: ['Semnopithecus sp.']
+  parents:
+  - 2632571
+272118:
+  aliases: ['Trachypithecus auratus auratus']
+  parents:
+  - 222416
+449596:
+  aliases: ['Trachypithecus auratus mauritius']
+  parents:
+  - 222416
+36233:
+  aliases: ['Trachypithecus auratus pyrrhus']
+  parents:
+  - 222416
+272119:
+  aliases: ['Trachypithecus francoisi francoisi']
+  parents:
+  - 54180
+272121:
+  aliases: ['Trachypithecus phayrei crepuscula']
+  parents:
+  - 61618
+1118394:
+  aliases: ['Trachypithecus phayrei holotephreus']
+  parents:
+  - 61618
+272120:
+  aliases: ['Trachypithecus phayrei phayrei']
+  parents:
+  - 61618
+1268362:
+  aliases: ['Trachypithecus phayrei shanicus']
+  parents:
+  - 61618
+662738:
+  aliases: ['Trachypithecus poliocephalus leucocephalus']
+  parents:
+  - 465719
+1118393:
+  aliases: ['Trachypithecus poliocephalus poliocephalus']
+  parents:
+  - 465719
+580599:
+  aliases: ['Trachypithecus sp.']
+  parents:
+  - 2623509
+614071:
+  aliases: ['Trachypithecus vetulus vetulus']
+  parents:
+  - 54137

--- a/definitions/taxonomy/2026-04-15/lineages.yaml
+++ b/definitions/taxonomy/2026-04-15/lineages.yaml
@@ -2,32540 +2,32540 @@
   aliases: ['Mosquitos']
   parents: []
 43816:
-  aliases: ['Anophelinae']
+  aliases: []
   parents:
   - 7157
 43817:
-  aliases: ['Culicinae']
+  aliases: []
   parents:
   - 7157
 43818:
-  aliases: ['Toxorhynchitinae']
+  aliases: []
   parents:
   - 7157
 359183:
-  aliases: ['environmental samples']
+  aliases: []
   parents:
   - 7157
 342889:
-  aliases: ['unclassified Culicidae']
+  aliases: []
   parents:
   - 7157
 1620265:
-  aliases: ['Aedeomyiini']
+  aliases: []
   parents:
   - 43817
 1056966:
-  aliases: ['Aedini']
+  aliases: []
   parents:
   - 43817
 7164:
-  aliases: ['Anopheles']
+  aliases: []
   parents:
   - 43816
 53562:
-  aliases: ['Bironella']
+  aliases: []
   parents:
   - 43816
 139051:
-  aliases: ['Chagasia']
+  aliases: []
   parents:
   - 43816
 2853107:
-  aliases: ['Culicidae Ae_JM910']
+  aliases: []
   parents:
   - 342889
 2853111:
-  aliases: ['Culicidae P_269_FSTHT']
+  aliases: []
   parents:
   - 342889
 2853109:
-  aliases: ['Culicidae P_270_FSTHT']
+  aliases: []
   parents:
   - 342889
 2853108:
-  aliases: ['Culicidae P_278_FSTHT']
+  aliases: []
   parents:
   - 342889
 2853110:
-  aliases: ['Culicidae P_321_FSTCO']
+  aliases: []
   parents:
   - 342889
 359184:
-  aliases: ['Culicidae environmental sample']
+  aliases: []
   parents:
   - 359183
 2766978:
-  aliases: ['Culicidae sp.']
+  aliases: []
   parents:
   - 342889
 2308251:
-  aliases: ['Culicidae sp. 08TTML-2107']
+  aliases: []
   parents:
   - 342889
 2030136:
-  aliases: ['Culicidae sp. 1 LC-2017']
+  aliases: []
   parents:
   - 342889
 2030137:
-  aliases: ['Culicidae sp. 2 LC-2017']
+  aliases: []
   parents:
   - 342889
 2030573:
-  aliases: ['Culicidae sp. 2JG16-30_Tr']
+  aliases: []
   parents:
   - 342889
 2030574:
-  aliases: ['Culicidae sp. 2JG20-14_Tr']
+  aliases: []
   parents:
   - 342889
 2030494:
-  aliases: ['Culicidae sp. 5JB33-4_Hw']
+  aliases: []
   parents:
   - 342889
 2030497:
-  aliases: ['Culicidae sp. 5JBr2-3_Wy']
+  aliases: []
   parents:
   - 342889
 2086771:
-  aliases: ['Culicidae sp. 7507_011']
+  aliases: []
   parents:
   - 342889
 2086772:
-  aliases: ['Culicidae sp. 7508_010']
+  aliases: []
   parents:
   - 342889
 2030576:
-  aliases: ['Culicidae sp. ANT190-1_Cx']
+  aliases: []
   parents:
   - 342889
 2030577:
-  aliases: ['Culicidae sp. ANT190-3_Cx']
+  aliases: []
   parents:
   - 342889
 2030578:
-  aliases: ['Culicidae sp. ANT190-4_Cx']
+  aliases: []
   parents:
   - 342889
 2030553:
-  aliases: ['Culicidae sp. ANT245-4_Hw']
+  aliases: []
   parents:
   - 342889
 2030523:
-  aliases: ['Culicidae sp. ANT249-11_Hw']
+  aliases: []
   parents:
   - 342889
 2030492:
-  aliases: ['Culicidae sp. ANT249-13_Hw']
+  aliases: []
   parents:
   - 342889
 2030571:
-  aliases: ['Culicidae sp. ANT249-14_Hw']
+  aliases: []
   parents:
   - 342889
 2030493:
-  aliases: ['Culicidae sp. ANT254-1_Hw']
+  aliases: []
   parents:
   - 342889
 2030592:
-  aliases: ['Culicidae sp. ANT263-10_Cx']
+  aliases: []
   parents:
   - 342889
 2030599:
-  aliases: ['Culicidae sp. ANT263-11_Cx']
+  aliases: []
   parents:
   - 342889
 2030590:
-  aliases: ['Culicidae sp. ANT263-12_Cx']
+  aliases: []
   parents:
   - 342889
 2030595:
-  aliases: ['Culicidae sp. ANT263-13_Cx']
+  aliases: []
   parents:
   - 342889
 2030584:
-  aliases: ['Culicidae sp. ANT263-16_Cx']
+  aliases: []
   parents:
   - 342889
 2030589:
-  aliases: ['Culicidae sp. ANT263-17_Cx']
+  aliases: []
   parents:
   - 342889
 2030587:
-  aliases: ['Culicidae sp. ANT263-19_Cx']
+  aliases: []
   parents:
   - 342889
 2030585:
-  aliases: ['Culicidae sp. ANT263-20_Cx']
+  aliases: []
   parents:
   - 342889
 2030593:
-  aliases: ['Culicidae sp. ANT263-21_Cx']
+  aliases: []
   parents:
   - 342889
 2030601:
-  aliases: ['Culicidae sp. ANT263-22_Cx']
+  aliases: []
   parents:
   - 342889
 2030591:
-  aliases: ['Culicidae sp. ANT263-23_Cx']
+  aliases: []
   parents:
   - 342889
 2030600:
-  aliases: ['Culicidae sp. ANT263-24_Cx']
+  aliases: []
   parents:
   - 342889
 2030602:
-  aliases: ['Culicidae sp. ANT263-25_Cx']
+  aliases: []
   parents:
   - 342889
 2030596:
-  aliases: ['Culicidae sp. ANT263-26_Cx']
+  aliases: []
   parents:
   - 342889
 2030586:
-  aliases: ['Culicidae sp. ANT263-27_Cx']
+  aliases: []
   parents:
   - 342889
 2030594:
-  aliases: ['Culicidae sp. ANT263-5_Cx']
+  aliases: []
   parents:
   - 342889
 2030597:
-  aliases: ['Culicidae sp. ANT263-6_Cx']
+  aliases: []
   parents:
   - 342889
 2030588:
-  aliases: ['Culicidae sp. ANT263-7_Cx']
+  aliases: []
   parents:
   - 342889
 2030598:
-  aliases: ['Culicidae sp. ANT263-8_Cx']
+  aliases: []
   parents:
   - 342889
 2030629:
-  aliases: ['Culicidae sp. ANT265-1_Hw']
+  aliases: []
   parents:
   - 342889
 2030628:
-  aliases: ['Culicidae sp. ANT265-3_Hw']
+  aliases: []
   parents:
   - 342889
 2030516:
-  aliases: ['Culicidae sp. ANT265-4_An']
+  aliases: []
   parents:
   - 342889
 2030505:
-  aliases: ['Culicidae sp. ANT265-5_Cx']
+  aliases: []
   parents:
   - 342889
 2030521:
-  aliases: ['Culicidae sp. ANT72-12_Tr']
+  aliases: []
   parents:
   - 342889
 2030520:
-  aliases: ['Culicidae sp. ANT72-7_Tr']
+  aliases: []
   parents:
   - 342889
 2030519:
-  aliases: ['Culicidae sp. ANT72-9_Tr']
+  aliases: []
   parents:
   - 342889
 2030502:
-  aliases: ['Culicidae sp. ANT79-131_Wy']
+  aliases: []
   parents:
   - 342889
 2030567:
-  aliases: ['Culicidae sp. BA-ANT-A-001_Hw']
+  aliases: []
   parents:
   - 342889
 2030625:
-  aliases: ['Culicidae sp. BA-ANT-A-002_Hw']
+  aliases: []
   parents:
   - 342889
 2030568:
-  aliases: ['Culicidae sp. BA-ANT-A-003_Hw']
+  aliases: []
   parents:
   - 342889
 2030563:
-  aliases: ['Culicidae sp. BA-ANT-A-004_Hw']
+  aliases: []
   parents:
   - 342889
 1829238:
-  aliases: ['Culicidae sp. BIOAI177-14']
+  aliases: []
   parents:
   - 342889
 1829239:
-  aliases: ['Culicidae sp. BIOAI591-14']
+  aliases: []
   parents:
   - 342889
 2533783:
-  aliases: ['Culicidae sp. BIOUG06197-H10']
+  aliases: []
   parents:
   - 342889
 2533784:
-  aliases: ['Culicidae sp. BIOUG06326-H09']
+  aliases: []
   parents:
   - 342889
 2533785:
-  aliases: ['Culicidae sp. BIOUG06350-E10']
+  aliases: []
   parents:
   - 342889
 2533786:
-  aliases: ['Culicidae sp. BIOUG06535-F01']
+  aliases: []
   parents:
   - 342889
 2556735:
-  aliases: ['Culicidae sp. BIOUG06618-E04']
+  aliases: []
   parents:
   - 342889
 2533787:
-  aliases: ['Culicidae sp. BIOUG07470-C05']
+  aliases: []
   parents:
   - 342889
 2533788:
-  aliases: ['Culicidae sp. BIOUG09685-E10']
+  aliases: []
   parents:
   - 342889
 2556736:
-  aliases: ['Culicidae sp. BIOUG10185-D09']
+  aliases: []
   parents:
   - 342889
 2533789:
-  aliases: ['Culicidae sp. BIOUG16832-H08']
+  aliases: []
   parents:
   - 342889
 2556737:
-  aliases: ['Culicidae sp. BIOUG17186-C01']
+  aliases: []
   parents:
   - 342889
 2533790:
-  aliases: ['Culicidae sp. BIOUG17221-A02']
+  aliases: []
   parents:
   - 342889
 2556738:
-  aliases: ['Culicidae sp. BIOUG17862-A04']
+  aliases: []
   parents:
   - 342889
 2556739:
-  aliases: ['Culicidae sp. BIOUG18015-D07']
+  aliases: []
   parents:
   - 342889
 2533791:
-  aliases: ['Culicidae sp. BIOUG20840-H02']
+  aliases: []
   parents:
   - 342889
 2308250:
-  aliases: ['Culicidae sp. BIOUG25752-E12']
+  aliases: []
   parents:
   - 342889
 2533792:
-  aliases: ['Culicidae sp. BIOUG27097-H02']
+  aliases: []
   parents:
   - 342889
 2030514:
-  aliases: ['Culicidae sp. BJ2011-15_An']
+  aliases: []
   parents:
   - 342889
 2030549:
-  aliases: ['Culicidae sp. BJ2011-20_Hw']
+  aliases: []
   parents:
   - 342889
 2030572:
-  aliases: ['Culicidae sp. BJ2011-4-2_Hw']
+  aliases: []
   parents:
   - 342889
 2030499:
-  aliases: ['Culicidae sp. BJ2011-5-4_Wy']
+  aliases: []
   parents:
   - 342889
 1886925:
-  aliases: ['Culicidae sp. BOLD-2016']
+  aliases: []
   parents:
   - 342889
 1304428:
-  aliases: ['Culicidae sp. BOLD:AAA3748']
+  aliases: []
   parents:
   - 342889
 1304429:
-  aliases: ['Culicidae sp. BOLD:AAA3750']
+  aliases: []
   parents:
   - 342889
 1838892:
-  aliases: ['Culicidae sp. BOLD:AAA3751']
+  aliases: []
   parents:
   - 342889
 1861244:
-  aliases: ['Culicidae sp. BOLD:AAA4751']
+  aliases: []
   parents:
   - 342889
 1304436:
-  aliases: ['Culicidae sp. BOLD:AAA6145']
+  aliases: []
   parents:
   - 342889
 1829240:
-  aliases: ['Culicidae sp. BOLD:AAA6148']
+  aliases: []
   parents:
   - 342889
 1829241:
-  aliases: ['Culicidae sp. BOLD:AAA7067']
+  aliases: []
   parents:
   - 342889
 1861245:
-  aliases: ['Culicidae sp. BOLD:AAA7661']
+  aliases: []
   parents:
   - 342889
 1304441:
-  aliases: ['Culicidae sp. BOLD:AAB1098']
+  aliases: []
   parents:
   - 342889
 1861246:
-  aliases: ['Culicidae sp. BOLD:AAB5696']
+  aliases: []
   parents:
   - 342889
 1304447:
-  aliases: ['Culicidae sp. BOLD:AAB6338']
+  aliases: []
   parents:
   - 342889
 1829242:
-  aliases: ['Culicidae sp. BOLD:AAB6943']
+  aliases: []
   parents:
   - 342889
 1861247:
-  aliases: ['Culicidae sp. BOLD:AAC0584']
+  aliases: []
   parents:
   - 342889
 1861248:
-  aliases: ['Culicidae sp. BOLD:AAC5210']
+  aliases: []
   parents:
   - 342889
 1838893:
-  aliases: ['Culicidae sp. BOLD:AAC9062']
+  aliases: []
   parents:
   - 342889
 1829243:
-  aliases: ['Culicidae sp. BOLD:AAC9132']
+  aliases: []
   parents:
   - 342889
 1829244:
-  aliases: ['Culicidae sp. BOLD:AAD3254']
+  aliases: []
   parents:
   - 342889
 1838894:
-  aliases: ['Culicidae sp. BOLD:AAD4406']
+  aliases: []
   parents:
   - 342889
 1304466:
-  aliases: ['Culicidae sp. BOLD:AAD7982']
+  aliases: []
   parents:
   - 342889
 1838895:
-  aliases: ['Culicidae sp. BOLD:AAE3210']
+  aliases: []
   parents:
   - 342889
 1838896:
-  aliases: ['Culicidae sp. BOLD:AAF2904']
+  aliases: []
   parents:
   - 342889
 2658544:
-  aliases: ['Culicidae sp. BOLD:AAG3845']
+  aliases: []
   parents:
   - 342889
 1754367:
-  aliases: ['Culicidae sp. BOLD:AAI1618']
+  aliases: []
   parents:
   - 342889
 1846870:
-  aliases: ['Culicidae sp. BOLD:AAJ7123']
+  aliases: []
   parents:
   - 342889
 1693837:
-  aliases: ['Culicidae sp. BOLD:AAL9067']
+  aliases: []
   parents:
   - 342889
 1838897:
-  aliases: ['Culicidae sp. BOLD:AAM4536']
+  aliases: []
   parents:
   - 342889
 2658542:
-  aliases: ['Culicidae sp. BOLD:AAP3603']
+  aliases: []
   parents:
   - 342889
 2658541:
-  aliases: ['Culicidae sp. BOLD:AAP3605']
+  aliases: []
   parents:
   - 342889
 1846871:
-  aliases: ['Culicidae sp. BOLD:AAP8896']
+  aliases: []
   parents:
   - 342889
 1829245:
-  aliases: ['Culicidae sp. BOLD:AAT9780']
+  aliases: []
   parents:
   - 342889
 2658543:
-  aliases: ['Culicidae sp. BOLD:AAV4158']
+  aliases: []
   parents:
   - 342889
 1838898:
-  aliases: ['Culicidae sp. BOLD:ABY6464']
+  aliases: []
   parents:
   - 342889
 1743932:
-  aliases: ['Culicidae sp. BOLD:ACC5413']
+  aliases: []
   parents:
   - 342889
 1749811:
-  aliases: ['Culicidae sp. BOLD:ACG3697']
+  aliases: []
   parents:
   - 342889
 1744282:
-  aliases: ['Culicidae sp. BOLD:ACG8894']
+  aliases: []
   parents:
   - 342889
 1749812:
-  aliases: ['Culicidae sp. BOLD:ACI3313']
+  aliases: []
   parents:
   - 342889
 1744301:
-  aliases: ['Culicidae sp. BOLD:ACI3314']
+  aliases: []
   parents:
   - 342889
 1749813:
-  aliases: ['Culicidae sp. BOLD:ACI6369']
+  aliases: []
   parents:
   - 342889
 1741580:
-  aliases: ['Culicidae sp. BOLD:ACI8783']
+  aliases: []
   parents:
   - 342889
 1693838:
-  aliases: ['Culicidae sp. BOLD:ACJ5399']
+  aliases: []
   parents:
   - 342889
 2030555:
-  aliases: ['Culicidae sp. C002-534-7_Hw']
+  aliases: []
   parents:
   - 342889
 2030579:
-  aliases: ['Culicidae sp. C002-559-7_An']
+  aliases: []
   parents:
   - 342889
 2030623:
-  aliases: ['Culicidae sp. CO002-552-006_Hw']
+  aliases: []
   parents:
   - 342889
 2030619:
-  aliases: ['Culicidae sp. CO02-534-7_Hw']
+  aliases: []
   parents:
   - 342889
 2030618:
-  aliases: ['Culicidae sp. CO02-559-9_Hw']
+  aliases: []
   parents:
   - 342889
 2030512:
-  aliases: ['Culicidae sp. COO2-559-7_An']
+  aliases: []
   parents:
   - 342889
 1457332:
-  aliases: ['Culicidae sp. ILOV_contig1']
+  aliases: []
   parents:
   - 342889
 1457333:
-  aliases: ['Culicidae sp. ILOV_contig2']
+  aliases: []
   parents:
   - 342889
 1457334:
-  aliases: ['Culicidae sp. ILOV_contig3']
+  aliases: []
   parents:
   - 342889
 1457335:
-  aliases: ['Culicidae sp. ILOV_contig4']
+  aliases: []
   parents:
   - 342889
 2030522:
-  aliases: ['Culicidae sp. JBB11-2_Tr']
+  aliases: []
   parents:
   - 342889
 2030575:
-  aliases: ['Culicidae sp. JBB21-4_Tr']
+  aliases: []
   parents:
   - 342889
 2030500:
-  aliases: ['Culicidae sp. JBB31-1_Wy']
+  aliases: []
   parents:
   - 342889
 2030517:
-  aliases: ['Culicidae sp. JBB31-2_Wy']
+  aliases: []
   parents:
   - 342889
 2030547:
-  aliases: ['Culicidae sp. JBI13-4_Hw']
+  aliases: []
   parents:
   - 342889
 2030544:
-  aliases: ['Culicidae sp. JBI15-7_Hw']
+  aliases: []
   parents:
   - 342889
 2030526:
-  aliases: ['Culicidae sp. JBI18-12_Hw']
+  aliases: []
   parents:
   - 342889
 2030501:
-  aliases: ['Culicidae sp. JBJ011-016_Wy']
+  aliases: []
   parents:
   - 342889
 2030518:
-  aliases: ['Culicidae sp. JBJ11-16_Wy']
+  aliases: []
   parents:
   - 342889
 2030503:
-  aliases: ['Culicidae sp. JPS017_Wy']
+  aliases: []
   parents:
   - 342889
 2030508:
-  aliases: ['Culicidae sp. JPS118_An']
+  aliases: []
   parents:
   - 342889
 2030507:
-  aliases: ['Culicidae sp. JPS120_An']
+  aliases: []
   parents:
   - 342889
 2030513:
-  aliases: ['Culicidae sp. JPS124_An']
+  aliases: []
   parents:
   - 342889
 2030552:
-  aliases: ['Culicidae sp. JPS15_Hw']
+  aliases: []
   parents:
   - 342889
 2030551:
-  aliases: ['Culicidae sp. JPS29_Hw']
+  aliases: []
   parents:
   - 342889
 2030647:
-  aliases: ['Culicidae sp. JPS35_Hw/Oc']
+  aliases: []
   parents:
   - 342889
 2030545:
-  aliases: ['Culicidae sp. JPS35_Hw/Och']
+  aliases: []
   parents:
   - 342889
 2030496:
-  aliases: ['Culicidae sp. JQC001-006_Hw']
+  aliases: []
   parents:
   - 342889
 2030511:
-  aliases: ['Culicidae sp. JQC002-006_An']
+  aliases: []
   parents:
   - 342889
 2030515:
-  aliases: ['Culicidae sp. JQC002-12_An']
+  aliases: []
   parents:
   - 342889
 2030510:
-  aliases: ['Culicidae sp. JQC002-17_An']
+  aliases: []
   parents:
   - 342889
 2030548:
-  aliases: ['Culicidae sp. JQC002-18_Hw']
+  aliases: []
   parents:
   - 342889
 2030542:
-  aliases: ['Culicidae sp. JQC002-19_Hw/Oc']
+  aliases: []
   parents:
   - 342889
 2030509:
-  aliases: ['Culicidae sp. JQC002-31_An']
+  aliases: []
   parents:
   - 342889
 2030580:
-  aliases: ['Culicidae sp. JQC002-6_An']
+  aliases: []
   parents:
   - 342889
 2030498:
-  aliases: ['Culicidae sp. JQPV003-11_Wy']
+  aliases: []
   parents:
   - 342889
 2030536:
-  aliases: ['Culicidae sp. JQQ002-001_Oc']
+  aliases: []
   parents:
   - 342889
 2030603:
-  aliases: ['Culicidae sp. JQQ002-4_Oc']
+  aliases: []
   parents:
   - 342889
 2030583:
-  aliases: ['Culicidae sp. JQQ003-082_Oc']
+  aliases: []
   parents:
   - 342889
 2030604:
-  aliases: ['Culicidae sp. JQQ003-119_Oc']
+  aliases: []
   parents:
   - 342889
 2030537:
-  aliases: ['Culicidae sp. JQQ003-126_Oc']
+  aliases: []
   parents:
   - 342889
 2030582:
-  aliases: ['Culicidae sp. JQQ003-13_Oc']
+  aliases: []
   parents:
   - 342889
 2030529:
-  aliases: ['Culicidae sp. JQQ003-33_Oc']
+  aliases: []
   parents:
   - 342889
 2030532:
-  aliases: ['Culicidae sp. JQQ003-37_Oc']
+  aliases: []
   parents:
   - 342889
 2030535:
-  aliases: ['Culicidae sp. JQQ003-42_Oc']
+  aliases: []
   parents:
   - 342889
 2030606:
-  aliases: ['Culicidae sp. JQQ003-43_Oc']
+  aliases: []
   parents:
   - 342889
 2030605:
-  aliases: ['Culicidae sp. JQQ003-46_Oc']
+  aliases: []
   parents:
   - 342889
 2030531:
-  aliases: ['Culicidae sp. JQQ003-49_Oc']
+  aliases: []
   parents:
   - 342889
 2030534:
-  aliases: ['Culicidae sp. JQQ003-52_Oc']
+  aliases: []
   parents:
   - 342889
 2030539:
-  aliases: ['Culicidae sp. JQQ003-54_Oc']
+  aliases: []
   parents:
   - 342889
 2030533:
-  aliases: ['Culicidae sp. JQQ003-66_Oc']
+  aliases: []
   parents:
   - 342889
 2030530:
-  aliases: ['Culicidae sp. JQQ003-73_Oc']
+  aliases: []
   parents:
   - 342889
 2030538:
-  aliases: ['Culicidae sp. JQQ003-78_Oc']
+  aliases: []
   parents:
   - 342889
 2030540:
-  aliases: ['Culicidae sp. JQQ003-94_Oc']
+  aliases: []
   parents:
   - 342889
 2030506:
-  aliases: ['Culicidae sp. JQQ004-101_Cx']
+  aliases: []
   parents:
   - 342889
 2030641:
-  aliases: ['Culicidae sp. JSHA16-13_Hw']
+  aliases: []
   parents:
   - 342889
 2030642:
-  aliases: ['Culicidae sp. JSHA16-18_Hw']
+  aliases: []
   parents:
   - 342889
 2030639:
-  aliases: ['Culicidae sp. JSHA16-1_Hw']
+  aliases: []
   parents:
   - 342889
 2030627:
-  aliases: ['Culicidae sp. JSHA16-9_Hw']
+  aliases: []
   parents:
   - 342889
 2030620:
-  aliases: ['Culicidae sp. JSHA36-11_Hw']
+  aliases: []
   parents:
   - 342889
 2030643:
-  aliases: ['Culicidae sp. JSHA36-4_Hw']
+  aliases: []
   parents:
   - 342889
 2030645:
-  aliases: ['Culicidae sp. JSHA36-6_Hw']
+  aliases: []
   parents:
   - 342889
 2030640:
-  aliases: ['Culicidae sp. JSHA36-9_Hw']
+  aliases: []
   parents:
   - 342889
 2030616:
-  aliases: ['Culicidae sp. JSHA39-2_Hw']
+  aliases: []
   parents:
   - 342889
 2030554:
-  aliases: ['Culicidae sp. JSHA47-1_Hw']
+  aliases: []
   parents:
   - 342889
 2030624:
-  aliases: ['Culicidae sp. JSHA48-2_Hw']
+  aliases: []
   parents:
   - 342889
 2030617:
-  aliases: ['Culicidae sp. JSHA53_Hw']
+  aliases: []
   parents:
   - 342889
 1457336:
-  aliases: ['Culicidae sp. LAMV_M07_contig1']
+  aliases: []
   parents:
   - 342889
 1457337:
-  aliases: ['Culicidae sp. LAMV_M07_contig2']
+  aliases: []
   parents:
   - 342889
 1457338:
-  aliases: ['Culicidae sp. LAMV_M07_contig3']
+  aliases: []
   parents:
   - 342889
 1457339:
-  aliases: ['Culicidae sp. LAMV_M07_contig4']
+  aliases: []
   parents:
   - 342889
 1457340:
-  aliases: ['Culicidae sp. LAMV_M07_contig5']
+  aliases: []
   parents:
   - 342889
 1457341:
-  aliases: ['Culicidae sp. LAMV_M07_contig6']
+  aliases: []
   parents:
   - 342889
 1457342:
-  aliases: ['Culicidae sp. LAMV_M07_contig7']
+  aliases: []
   parents:
   - 342889
 1457343:
-  aliases: ['Culicidae sp. LAMV_M07_contig8']
+  aliases: []
   parents:
   - 342889
 1457344:
-  aliases: ['Culicidae sp. LAMV_M07_contig9']
+  aliases: []
   parents:
   - 342889
 342890:
-  aliases: ['Culicidae sp. M32']
+  aliases: []
   parents:
   - 342889
 342891:
-  aliases: ['Culicidae sp. M36']
+  aliases: []
   parents:
   - 342889
 342892:
-  aliases: ['Culicidae sp. M53']
+  aliases: []
   parents:
   - 342889
 1688407:
-  aliases: ['Culicidae sp. N17AM']
+  aliases: []
   parents:
   - 342889
 1688408:
-  aliases: ['Culicidae sp. N21AM3']
+  aliases: []
   parents:
   - 342889
 1688409:
-  aliases: ['Culicidae sp. N22AM2']
+  aliases: []
   parents:
   - 342889
 1688410:
-  aliases: ['Culicidae sp. N23AM']
+  aliases: []
   parents:
   - 342889
 1688411:
-  aliases: ['Culicidae sp. N23BM']
+  aliases: []
   parents:
   - 342889
 1688412:
-  aliases: ['Culicidae sp. N24AM']
+  aliases: []
   parents:
   - 342889
 1688413:
-  aliases: ['Culicidae sp. N28AM']
+  aliases: []
   parents:
   - 342889
 1688414:
-  aliases: ['Culicidae sp. N36AM']
+  aliases: []
   parents:
   - 342889
 1688415:
-  aliases: ['Culicidae sp. N36AM2']
+  aliases: []
   parents:
   - 342889
 1688416:
-  aliases: ['Culicidae sp. N38B.M2']
+  aliases: []
   parents:
   - 342889
 1688417:
-  aliases: ['Culicidae sp. N39BM3']
+  aliases: []
   parents:
   - 342889
 1688418:
-  aliases: ['Culicidae sp. Ne39M']
+  aliases: []
   parents:
   - 342889
 2030622:
-  aliases: ['Culicidae sp. PS1013-10_Hw']
+  aliases: []
   parents:
   - 342889
 2030644:
-  aliases: ['Culicidae sp. PS1014-1_Hw']
+  aliases: []
   parents:
   - 342889
 2030560:
-  aliases: ['Culicidae sp. PSI-19_Hw']
+  aliases: []
   parents:
   - 342889
 2030566:
-  aliases: ['Culicidae sp. PSI-21_Hw']
+  aliases: []
   parents:
   - 342889
 2030543:
-  aliases: ['Culicidae sp. PSI-24_Hw']
+  aliases: []
   parents:
   - 342889
 2030564:
-  aliases: ['Culicidae sp. PSI-25_Hw']
+  aliases: []
   parents:
   - 342889
 2030565:
-  aliases: ['Culicidae sp. PSI-35_Hw']
+  aliases: []
   parents:
   - 342889
 2030527:
-  aliases: ['Culicidae sp. PSI-39_Hw']
+  aliases: []
   parents:
   - 342889
 2030557:
-  aliases: ['Culicidae sp. PSI-45_Hw']
+  aliases: []
   parents:
   - 342889
 2030558:
-  aliases: ['Culicidae sp. PSI-57_Hw']
+  aliases: []
   parents:
   - 342889
 2030559:
-  aliases: ['Culicidae sp. PSI-59_Hw']
+  aliases: []
   parents:
   - 342889
 2030528:
-  aliases: ['Culicidae sp. PSI-60_Hw']
+  aliases: []
   parents:
   - 342889
 2030562:
-  aliases: ['Culicidae sp. PSI-66_Hw']
+  aliases: []
   parents:
   - 342889
 2030556:
-  aliases: ['Culicidae sp. PSI-76_Hw']
+  aliases: []
   parents:
   - 342889
 2030550:
-  aliases: ['Culicidae sp. PSI004-003_Hw']
+  aliases: []
   parents:
   - 342889
 2030504:
-  aliases: ['Culicidae sp. PSI005-2_Cx']
+  aliases: []
   parents:
   - 342889
 2030570:
-  aliases: ['Culicidae sp. PSI012-4_Hw']
+  aliases: []
   parents:
   - 342889
 2030495:
-  aliases: ['Culicidae sp. PSI012-5_Hw']
+  aliases: []
   parents:
   - 342889
 2030569:
-  aliases: ['Culicidae sp. PSI013-10_Hw']
+  aliases: []
   parents:
   - 342889
 2030608:
-  aliases: ['Culicidae sp. PSI013-11']
+  aliases: []
   parents:
   - 342889
 2030613:
-  aliases: ['Culicidae sp. PSI013-14_Hw']
+  aliases: []
   parents:
   - 342889
 2030646:
-  aliases: ['Culicidae sp. PSI013-15_Hw']
+  aliases: []
   parents:
   - 342889
 2030621:
-  aliases: ['Culicidae sp. PSI013-9_Hw']
+  aliases: []
   parents:
   - 342889
 2030615:
-  aliases: ['Culicidae sp. PSI015-001_Hw']
+  aliases: []
   parents:
   - 342889
 2030525:
-  aliases: ['Culicidae sp. PSI015-1_Hw']
+  aliases: []
   parents:
   - 342889
 2030611:
-  aliases: ['Culicidae sp. PSI016-1_Hw']
+  aliases: []
   parents:
   - 342889
 2030524:
-  aliases: ['Culicidae sp. PSI018-1_Hw']
+  aliases: []
   parents:
   - 342889
 2030614:
-  aliases: ['Culicidae sp. PSI020-1_Hw']
+  aliases: []
   parents:
   - 342889
 2030631:
-  aliases: ['Culicidae sp. PSI12_Oc']
+  aliases: []
   parents:
   - 342889
 2030541:
-  aliases: ['Culicidae sp. PSI14_Hw/Oc']
+  aliases: []
   parents:
   - 342889
 2030546:
-  aliases: ['Culicidae sp. PSI23_Hw/Oc']
+  aliases: []
   parents:
   - 342889
 2030561:
-  aliases: ['Culicidae sp. PSI32_Hw']
+  aliases: []
   parents:
   - 342889
 2030626:
-  aliases: ['Culicidae sp. PSI40_Hw']
+  aliases: []
   parents:
   - 342889
 1921263:
-  aliases: ['Culicidae sp. RC2-003']
+  aliases: []
   parents:
   - 342889
 1749814:
-  aliases: ['Culicidae sp. SSJAA387-13']
+  aliases: []
   parents:
   - 342889
 1861249:
-  aliases: ['Culicidae sp. SSJAE5198-13']
+  aliases: []
   parents:
   - 342889
 1861250:
-  aliases: ['Culicidae sp. SSJAE9915-13']
+  aliases: []
   parents:
   - 342889
 1861251:
-  aliases: ['Culicidae sp. SSJAE9917-13']
+  aliases: []
   parents:
   - 342889
 1861252:
-  aliases: ['Culicidae sp. SSJAE9923-13']
+  aliases: []
   parents:
   - 342889
 1861253:
-  aliases: ['Culicidae sp. SSJAE9977-13']
+  aliases: []
   parents:
   - 342889
 1861254:
-  aliases: ['Culicidae sp. SSROA519-14']
+  aliases: []
   parents:
   - 342889
 409340:
-  aliases: ['Culicidae sp. Sallum-2006']
+  aliases: []
   parents:
   - 342889
 2744801:
-  aliases: ['Culicidae sp. W1']
+  aliases: []
   parents:
   - 342889
 2743523:
-  aliases: ['Culicidae sp. W10']
+  aliases: []
   parents:
   - 342889
 2742516:
-  aliases: ['Culicidae sp. W2']
+  aliases: []
   parents:
   - 342889
 2742517:
-  aliases: ['Culicidae sp. W3']
+  aliases: []
   parents:
   - 342889
 2742518:
-  aliases: ['Culicidae sp. W4']
+  aliases: []
   parents:
   - 342889
 2742519:
-  aliases: ['Culicidae sp. W5']
+  aliases: []
   parents:
   - 342889
 2743672:
-  aliases: ['Culicidae sp. W6']
+  aliases: []
   parents:
   - 342889
 2744364:
-  aliases: ['Culicidae sp. W7']
+  aliases: []
   parents:
   - 342889
 2743524:
-  aliases: ['Culicidae sp. W9']
+  aliases: []
   parents:
   - 342889
 1677833:
-  aliases: ['Culicidae sp. ZFMK PR005-Colombia']
+  aliases: []
   parents:
   - 342889
 2892218:
-  aliases: ['Culicidae sp. ZMUO 012838']
+  aliases: []
   parents:
   - 342889
 2892219:
-  aliases: ['Culicidae sp. ZMUO 012839']
+  aliases: []
   parents:
   - 342889
 2892220:
-  aliases: ['Culicidae sp. ZMUO 012840']
+  aliases: []
   parents:
   - 342889
 2892221:
-  aliases: ['Culicidae sp. ZMUO 012841']
+  aliases: []
   parents:
   - 342889
 2892222:
-  aliases: ['Culicidae sp. ZMUO 012842']
+  aliases: []
   parents:
   - 342889
 1900190:
-  aliases: ['Culicidae sp. sc_00010']
+  aliases: []
   parents:
   - 342889
 1900191:
-  aliases: ['Culicidae sp. sc_00377']
+  aliases: []
   parents:
   - 342889
 1900192:
-  aliases: ['Culicidae sp. sc_01319']
+  aliases: []
   parents:
   - 342889
 1900193:
-  aliases: ['Culicidae sp. sc_01327']
+  aliases: []
   parents:
   - 342889
 1900194:
-  aliases: ['Culicidae sp. sc_01371']
+  aliases: []
   parents:
   - 342889
 1900195:
-  aliases: ['Culicidae sp. sc_01973']
+  aliases: []
   parents:
   - 342889
 1900196:
-  aliases: ['Culicidae sp. sc_01974']
+  aliases: []
   parents:
   - 342889
 1900197:
-  aliases: ['Culicidae sp. sc_02090']
+  aliases: []
   parents:
   - 342889
 1900198:
-  aliases: ['Culicidae sp. sc_02111']
+  aliases: []
   parents:
   - 342889
 1900199:
-  aliases: ['Culicidae sp. sc_02121']
+  aliases: []
   parents:
   - 342889
 1900200:
-  aliases: ['Culicidae sp. sc_02702']
+  aliases: []
   parents:
   - 342889
 1900201:
-  aliases: ['Culicidae sp. sc_02703']
+  aliases: []
   parents:
   - 342889
 1900202:
-  aliases: ['Culicidae sp. sc_02856']
+  aliases: []
   parents:
   - 342889
 1900203:
-  aliases: ['Culicidae sp. sc_02857']
+  aliases: []
   parents:
   - 342889
 1900204:
-  aliases: ['Culicidae sp. sc_02858']
+  aliases: []
   parents:
   - 342889
 1900205:
-  aliases: ['Culicidae sp. sc_05279']
+  aliases: []
   parents:
   - 342889
 1900206:
-  aliases: ['Culicidae sp. sc_05280']
+  aliases: []
   parents:
   - 342889
 1900207:
-  aliases: ['Culicidae sp. sc_05290']
+  aliases: []
   parents:
   - 342889
 1900208:
-  aliases: ['Culicidae sp. sc_05334']
+  aliases: []
   parents:
   - 342889
 1900209:
-  aliases: ['Culicidae sp. sc_05400']
+  aliases: []
   parents:
   - 342889
 1900210:
-  aliases: ['Culicidae sp. sc_05401']
+  aliases: []
   parents:
   - 342889
 1900211:
-  aliases: ['Culicidae sp. sc_05593']
+  aliases: []
   parents:
   - 342889
 1900212:
-  aliases: ['Culicidae sp. sc_05594']
+  aliases: []
   parents:
   - 342889
 1900213:
-  aliases: ['Culicidae sp. sc_05595']
+  aliases: []
   parents:
   - 342889
 1900214:
-  aliases: ['Culicidae sp. sc_05789']
+  aliases: []
   parents:
   - 342889
 1900215:
-  aliases: ['Culicidae sp. sc_05960']
+  aliases: []
   parents:
   - 342889
 1900216:
-  aliases: ['Culicidae sp. sc_06471']
+  aliases: []
   parents:
   - 342889
 1900217:
-  aliases: ['Culicidae sp. sc_06676']
+  aliases: []
   parents:
   - 342889
 1900218:
-  aliases: ['Culicidae sp. sc_07008']
+  aliases: []
   parents:
   - 342889
 1900219:
-  aliases: ['Culicidae sp. sc_07177']
+  aliases: []
   parents:
   - 342889
 1900220:
-  aliases: ['Culicidae sp. sc_07178']
+  aliases: []
   parents:
   - 342889
 1900221:
-  aliases: ['Culicidae sp. sc_07181']
+  aliases: []
   parents:
   - 342889
 1900222:
-  aliases: ['Culicidae sp. sc_07189']
+  aliases: []
   parents:
   - 342889
 1900223:
-  aliases: ['Culicidae sp. sc_07844']
+  aliases: []
   parents:
   - 342889
 1900224:
-  aliases: ['Culicidae sp. sc_07850']
+  aliases: []
   parents:
   - 342889
 53550:
-  aliases: ['Culicini']
+  aliases: []
   parents:
   - 43817
 308729:
-  aliases: ['Culisetini']
+  aliases: []
   parents:
   - 43817
 308727:
-  aliases: ['Ficalbiini']
+  aliases: []
   parents:
   - 43817
 308728:
-  aliases: ['Hodgesiini']
+  aliases: []
   parents:
   - 43817
 254792:
-  aliases: ['Mansoniini']
+  aliases: []
   parents:
   - 43817
 149617:
-  aliases: ['Orthopodmyiini']
+  aliases: []
   parents:
   - 43817
 53549:
-  aliases: ['Sabethini']
+  aliases: []
   parents:
   - 43817
 46207:
-  aliases: ['Toxorhynchites']
+  aliases: []
   parents:
   - 43818
 149616:
-  aliases: ['Uranotaeniini']
+  aliases: []
   parents:
   - 43817
 2785975:
-  aliases: ['unclassified Anophelinae']
+  aliases: []
   parents:
   - 43816
 1693839:
-  aliases: ['unclassified Culicinae']
+  aliases: []
   parents:
   - 43817
 1548035:
-  aliases: ['Acartomyia']
+  aliases: []
   parents:
   - 1056966
 139057:
-  aliases: ['Aedeomyia']
+  aliases: []
   parents:
   - 1620265
 7158:
-  aliases: ['Aedes']
+  aliases: []
   parents:
   - 1056966
 44482:
-  aliases: ['Anopheles']
+  aliases: []
   parents:
   - 7164
 2785976:
-  aliases: ['Anophelinae sp.']
+  aliases: []
   parents:
   - 2785975
 124916:
-  aliases: ['Armigeres']
+  aliases: []
   parents:
   - 1056966
 53563:
-  aliases: ['Bironella']
+  aliases: []
   parents:
   - 53562
 425230:
-  aliases: ['Borichinda']
+  aliases: []
   parents:
   - 1056966
 53564:
-  aliases: ['Brugella']
+  aliases: []
   parents:
   - 53562
 2067443:
-  aliases: ['Catageiomyia']
+  aliases: []
   parents:
   - 1056966
 44534:
-  aliases: ['Cellia']
+  aliases: []
   parents:
   - 7164
 139052:
-  aliases: ['Chagasia bathana']
+  aliases: []
   parents:
   - 139051
 1426896:
-  aliases: ['Chagasia bonneae']
+  aliases: []
   parents:
   - 139051
 1426901:
-  aliases: ['Chagasia nr. fajardi BOLD:AAW1401']
+  aliases: []
   parents:
   - 139051
 1245380:
-  aliases: ['Collessius']
+  aliases: []
   parents:
   - 1056966
 329110:
-  aliases: ['Coquillettidia']
+  aliases: []
   parents:
   - 254792
 7174:
-  aliases: ['Culex']
+  aliases: []
   parents:
   - 53550
 2939109:
-  aliases: ['Culicinae sp.']
+  aliases: []
   parents:
   - 1693839
 2587930:
-  aliases: ['Culicinae sp. BAH_28365_A06']
+  aliases: []
   parents:
   - 1693839
 2308252:
-  aliases: ['Culicinae sp. BARS_2015_41_075']
+  aliases: []
   parents:
   - 1693839
 2308280:
-  aliases: ['Culicinae sp. BARS_2015_41_076']
+  aliases: []
   parents:
   - 1693839
 2308355:
-  aliases: ['Culicinae sp. BARS_2015_41_112']
+  aliases: []
   parents:
   - 1693839
 2308343:
-  aliases: ['Culicinae sp. BARS_2016_77_057']
+  aliases: []
   parents:
   - 1693839
 2327010:
-  aliases: ['Culicinae sp. BBDCP558-10']
+  aliases: []
   parents:
   - 1693839
 2308352:
-  aliases: ['Culicinae sp. BIOUG01402-B07']
+  aliases: []
   parents:
   - 1693839
 2308339:
-  aliases: ['Culicinae sp. BIOUG01402-C11']
+  aliases: []
   parents:
   - 1693839
 2533793:
-  aliases: ['Culicinae sp. BIOUG11374-H02']
+  aliases: []
   parents:
   - 1693839
 2557229:
-  aliases: ['Culicinae sp. BIOUG11377-H09']
+  aliases: []
   parents:
   - 1693839
 2533794:
-  aliases: ['Culicinae sp. BIOUG11668-A03']
+  aliases: []
   parents:
   - 1693839
 2208792:
-  aliases: ['Culicinae sp. BIOUG11985-E01']
+  aliases: []
   parents:
   - 1693839
 2533795:
-  aliases: ['Culicinae sp. BIOUG17745-C12']
+  aliases: []
   parents:
   - 1693839
 2533796:
-  aliases: ['Culicinae sp. BIOUG17771-F04']
+  aliases: []
   parents:
   - 1693839
 2208793:
-  aliases: ['Culicinae sp. BIOUG17863-D07']
+  aliases: []
   parents:
   - 1693839
 2533797:
-  aliases: ['Culicinae sp. BIOUG18015-A03']
+  aliases: []
   parents:
   - 1693839
 2533798:
-  aliases: ['Culicinae sp. BIOUG18113-A02']
+  aliases: []
   parents:
   - 1693839
 2208794:
-  aliases: ['Culicinae sp. BIOUG18381-D02']
+  aliases: []
   parents:
   - 1693839
 2533799:
-  aliases: ['Culicinae sp. BIOUG18454-E12']
+  aliases: []
   parents:
   - 1693839
 2208795:
-  aliases: ['Culicinae sp. BIOUG20564-D08']
+  aliases: []
   parents:
   - 1693839
 2208796:
-  aliases: ['Culicinae sp. BIOUG20666-F07']
+  aliases: []
   parents:
   - 1693839
 2208797:
-  aliases: ['Culicinae sp. BIOUG20666-F09']
+  aliases: []
   parents:
   - 1693839
 2208798:
-  aliases: ['Culicinae sp. BIOUG20869-B08']
+  aliases: []
   parents:
   - 1693839
 2208799:
-  aliases: ['Culicinae sp. BIOUG20869-D06']
+  aliases: []
   parents:
   - 1693839
 2208800:
-  aliases: ['Culicinae sp. BIOUG20869-E02']
+  aliases: []
   parents:
   - 1693839
 2208801:
-  aliases: ['Culicinae sp. BIOUG20878-F02']
+  aliases: []
   parents:
   - 1693839
 2533800:
-  aliases: ['Culicinae sp. BIOUG21061-F01']
+  aliases: []
   parents:
   - 1693839
 2208802:
-  aliases: ['Culicinae sp. BIOUG21103-G05']
+  aliases: []
   parents:
   - 1693839
 2208803:
-  aliases: ['Culicinae sp. BIOUG21104-H01']
+  aliases: []
   parents:
   - 1693839
 2208804:
-  aliases: ['Culicinae sp. BIOUG21106-D09']
+  aliases: []
   parents:
   - 1693839
 2208805:
-  aliases: ['Culicinae sp. BIOUG21113-G01']
+  aliases: []
   parents:
   - 1693839
 2208806:
-  aliases: ['Culicinae sp. BIOUG21114-F08']
+  aliases: []
   parents:
   - 1693839
 2208807:
-  aliases: ['Culicinae sp. BIOUG21162-C02']
+  aliases: []
   parents:
   - 1693839
 2208808:
-  aliases: ['Culicinae sp. BIOUG21641-C01']
+  aliases: []
   parents:
   - 1693839
 2208809:
-  aliases: ['Culicinae sp. BIOUG21641-D01']
+  aliases: []
   parents:
   - 1693839
 2208810:
-  aliases: ['Culicinae sp. BIOUG21642-F07']
+  aliases: []
   parents:
   - 1693839
 2208811:
-  aliases: ['Culicinae sp. BIOUG21868-D04']
+  aliases: []
   parents:
   - 1693839
 2208812:
-  aliases: ['Culicinae sp. BIOUG21868-D11']
+  aliases: []
   parents:
   - 1693839
 2208813:
-  aliases: ['Culicinae sp. BIOUG21868-D12']
+  aliases: []
   parents:
   - 1693839
 2208814:
-  aliases: ['Culicinae sp. BIOUG21868-H11']
+  aliases: []
   parents:
   - 1693839
 2308305:
-  aliases: ['Culicinae sp. BIOUG22042-G12']
+  aliases: []
   parents:
   - 1693839
 2208815:
-  aliases: ['Culicinae sp. BIOUG22131-G07']
+  aliases: []
   parents:
   - 1693839
 2208816:
-  aliases: ['Culicinae sp. BIOUG22134-A08']
+  aliases: []
   parents:
   - 1693839
 2208817:
-  aliases: ['Culicinae sp. BIOUG22134-E04']
+  aliases: []
   parents:
   - 1693839
 2208818:
-  aliases: ['Culicinae sp. BIOUG22134-G01']
+  aliases: []
   parents:
   - 1693839
 2208819:
-  aliases: ['Culicinae sp. BIOUG22134-G02']
+  aliases: []
   parents:
   - 1693839
 2208820:
-  aliases: ['Culicinae sp. BIOUG22135-A12']
+  aliases: []
   parents:
   - 1693839
 2208821:
-  aliases: ['Culicinae sp. BIOUG22135-D02']
+  aliases: []
   parents:
   - 1693839
 2208822:
-  aliases: ['Culicinae sp. BIOUG22135-D09']
+  aliases: []
   parents:
   - 1693839
 2208823:
-  aliases: ['Culicinae sp. BIOUG22135-H04']
+  aliases: []
   parents:
   - 1693839
 2208824:
-  aliases: ['Culicinae sp. BIOUG22136-A01']
+  aliases: []
   parents:
   - 1693839
 2208825:
-  aliases: ['Culicinae sp. BIOUG22136-F09']
+  aliases: []
   parents:
   - 1693839
 2208826:
-  aliases: ['Culicinae sp. BIOUG22138-D08']
+  aliases: []
   parents:
   - 1693839
 2208827:
-  aliases: ['Culicinae sp. BIOUG22138-E05']
+  aliases: []
   parents:
   - 1693839
 2208828:
-  aliases: ['Culicinae sp. BIOUG22138-F01']
+  aliases: []
   parents:
   - 1693839
 2208829:
-  aliases: ['Culicinae sp. BIOUG22139-B08']
+  aliases: []
   parents:
   - 1693839
 2208830:
-  aliases: ['Culicinae sp. BIOUG22139-B11']
+  aliases: []
   parents:
   - 1693839
 2208831:
-  aliases: ['Culicinae sp. BIOUG22139-C10']
+  aliases: []
   parents:
   - 1693839
 2208832:
-  aliases: ['Culicinae sp. BIOUG22139-C12']
+  aliases: []
   parents:
   - 1693839
 2208833:
-  aliases: ['Culicinae sp. BIOUG22139-G10']
+  aliases: []
   parents:
   - 1693839
 2208834:
-  aliases: ['Culicinae sp. BIOUG22139-H09']
+  aliases: []
   parents:
   - 1693839
 2208835:
-  aliases: ['Culicinae sp. BIOUG22158-F04']
+  aliases: []
   parents:
   - 1693839
 2208836:
-  aliases: ['Culicinae sp. BIOUG22376-B11']
+  aliases: []
   parents:
   - 1693839
 2208837:
-  aliases: ['Culicinae sp. BIOUG22429-A08']
+  aliases: []
   parents:
   - 1693839
 2208838:
-  aliases: ['Culicinae sp. BIOUG22429-B07']
+  aliases: []
   parents:
   - 1693839
 2208839:
-  aliases: ['Culicinae sp. BIOUG22430-A03']
+  aliases: []
   parents:
   - 1693839
 2208840:
-  aliases: ['Culicinae sp. BIOUG22430-A10']
+  aliases: []
   parents:
   - 1693839
 2208841:
-  aliases: ['Culicinae sp. BIOUG22430-B12']
+  aliases: []
   parents:
   - 1693839
 2208842:
-  aliases: ['Culicinae sp. BIOUG22430-D11']
+  aliases: []
   parents:
   - 1693839
 2208843:
-  aliases: ['Culicinae sp. BIOUG22430-F04']
+  aliases: []
   parents:
   - 1693839
 2308309:
-  aliases: ['Culicinae sp. BIOUG22432-G08']
+  aliases: []
   parents:
   - 1693839
 2308307:
-  aliases: ['Culicinae sp. BIOUG22515-B11']
+  aliases: []
   parents:
   - 1693839
 2308253:
-  aliases: ['Culicinae sp. BIOUG22524-A01']
+  aliases: []
   parents:
   - 1693839
 2308265:
-  aliases: ['Culicinae sp. BIOUG22524-A03']
+  aliases: []
   parents:
   - 1693839
 2308335:
-  aliases: ['Culicinae sp. BIOUG22524-A05']
+  aliases: []
   parents:
   - 1693839
 2308351:
-  aliases: ['Culicinae sp. BIOUG22524-E02']
+  aliases: []
   parents:
   - 1693839
 2308297:
-  aliases: ['Culicinae sp. BIOUG22524-E05']
+  aliases: []
   parents:
   - 1693839
 2308316:
-  aliases: ['Culicinae sp. BIOUG22524-E07']
+  aliases: []
   parents:
   - 1693839
 2308342:
-  aliases: ['Culicinae sp. BIOUG22524-E11']
+  aliases: []
   parents:
   - 1693839
 2308260:
-  aliases: ['Culicinae sp. BIOUG22524-F03']
+  aliases: []
   parents:
   - 1693839
 2308321:
-  aliases: ['Culicinae sp. BIOUG22524-F04']
+  aliases: []
   parents:
   - 1693839
 2308302:
-  aliases: ['Culicinae sp. BIOUG22524-G05']
+  aliases: []
   parents:
   - 1693839
 2308301:
-  aliases: ['Culicinae sp. BIOUG22524-G08']
+  aliases: []
   parents:
   - 1693839
 2308275:
-  aliases: ['Culicinae sp. BIOUG22524-H03']
+  aliases: []
   parents:
   - 1693839
 2308332:
-  aliases: ['Culicinae sp. BIOUG22524-H09']
+  aliases: []
   parents:
   - 1693839
 2208844:
-  aliases: ['Culicinae sp. BIOUG22858-B06']
+  aliases: []
   parents:
   - 1693839
 2208845:
-  aliases: ['Culicinae sp. BIOUG22859-E03']
+  aliases: []
   parents:
   - 1693839
 2208846:
-  aliases: ['Culicinae sp. BIOUG22860-H02']
+  aliases: []
   parents:
   - 1693839
 2308326:
-  aliases: ['Culicinae sp. BIOUG22956-A05']
+  aliases: []
   parents:
   - 1693839
 2308347:
-  aliases: ['Culicinae sp. BIOUG22959-A03']
+  aliases: []
   parents:
   - 1693839
 2308266:
-  aliases: ['Culicinae sp. BIOUG22960-H04']
+  aliases: []
   parents:
   - 1693839
 2308259:
-  aliases: ['Culicinae sp. BIOUG23267-F05']
+  aliases: []
   parents:
   - 1693839
 2208847:
-  aliases: ['Culicinae sp. BIOUG23382-B10']
+  aliases: []
   parents:
   - 1693839
 2208848:
-  aliases: ['Culicinae sp. BIOUG23383-A01']
+  aliases: []
   parents:
   - 1693839
 2308279:
-  aliases: ['Culicinae sp. BIOUG23535-A06']
+  aliases: []
   parents:
   - 1693839
 2308285:
-  aliases: ['Culicinae sp. BIOUG23580-C10']
+  aliases: []
   parents:
   - 1693839
 2308295:
-  aliases: ['Culicinae sp. BIOUG23666-A05']
+  aliases: []
   parents:
   - 1693839
 2208849:
-  aliases: ['Culicinae sp. BIOUG23678-C01']
+  aliases: []
   parents:
   - 1693839
 2208850:
-  aliases: ['Culicinae sp. BIOUG23787-G02']
+  aliases: []
   parents:
   - 1693839
 2308274:
-  aliases: ['Culicinae sp. BIOUG24097-E12']
+  aliases: []
   parents:
   - 1693839
 2308286:
-  aliases: ['Culicinae sp. BIOUG24355-H09']
+  aliases: []
   parents:
   - 1693839
 2208851:
-  aliases: ['Culicinae sp. BIOUG24582-F04']
+  aliases: []
   parents:
   - 1693839
 2208852:
-  aliases: ['Culicinae sp. BIOUG24639-C02']
+  aliases: []
   parents:
   - 1693839
 2533801:
-  aliases: ['Culicinae sp. BIOUG24639-E10']
+  aliases: []
   parents:
   - 1693839
 2208853:
-  aliases: ['Culicinae sp. BIOUG24639-F12']
+  aliases: []
   parents:
   - 1693839
 2308330:
-  aliases: ['Culicinae sp. BIOUG25706-E08']
+  aliases: []
   parents:
   - 1693839
 2308258:
-  aliases: ['Culicinae sp. BIOUG25809-B08']
+  aliases: []
   parents:
   - 1693839
 2308272:
-  aliases: ['Culicinae sp. BIOUG25809-B10']
+  aliases: []
   parents:
   - 1693839
 2308345:
-  aliases: ['Culicinae sp. BIOUG25810-D09']
+  aliases: []
   parents:
   - 1693839
 2308325:
-  aliases: ['Culicinae sp. BIOUG26011-B07']
+  aliases: []
   parents:
   - 1693839
 2308324:
-  aliases: ['Culicinae sp. BIOUG26011-E01']
+  aliases: []
   parents:
   - 1693839
 2308261:
-  aliases: ['Culicinae sp. BIOUG26011-F10']
+  aliases: []
   parents:
   - 1693839
 2308304:
-  aliases: ['Culicinae sp. BIOUG26012-A06']
+  aliases: []
   parents:
   - 1693839
 2308314:
-  aliases: ['Culicinae sp. BIOUG26012-A12']
+  aliases: []
   parents:
   - 1693839
 2308300:
-  aliases: ['Culicinae sp. BIOUG26012-C02']
+  aliases: []
   parents:
   - 1693839
 2308333:
-  aliases: ['Culicinae sp. BIOUG26012-C12']
+  aliases: []
   parents:
   - 1693839
 2308334:
-  aliases: ['Culicinae sp. BIOUG26012-E08']
+  aliases: []
   parents:
   - 1693839
 2308306:
-  aliases: ['Culicinae sp. BIOUG26012-E09']
+  aliases: []
   parents:
   - 1693839
 2308257:
-  aliases: ['Culicinae sp. BIOUG26012-F06']
+  aliases: []
   parents:
   - 1693839
 2308292:
-  aliases: ['Culicinae sp. BIOUG26012-H04']
+  aliases: []
   parents:
   - 1693839
 2308346:
-  aliases: ['Culicinae sp. BIOUG26012-H10']
+  aliases: []
   parents:
   - 1693839
 2308350:
-  aliases: ['Culicinae sp. BIOUG26017-A07']
+  aliases: []
   parents:
   - 1693839
 2308282:
-  aliases: ['Culicinae sp. BIOUG26017-A09']
+  aliases: []
   parents:
   - 1693839
 2308310:
-  aliases: ['Culicinae sp. BIOUG26017-B04']
+  aliases: []
   parents:
   - 1693839
 2308354:
-  aliases: ['Culicinae sp. BIOUG26017-B08']
+  aliases: []
   parents:
   - 1693839
 2308269:
-  aliases: ['Culicinae sp. BIOUG26017-C05']
+  aliases: []
   parents:
   - 1693839
 2308356:
-  aliases: ['Culicinae sp. BIOUG26017-C09']
+  aliases: []
   parents:
   - 1693839
 2308281:
-  aliases: ['Culicinae sp. BIOUG26017-C10']
+  aliases: []
   parents:
   - 1693839
 2308263:
-  aliases: ['Culicinae sp. BIOUG26017-D01']
+  aliases: []
   parents:
   - 1693839
 2308289:
-  aliases: ['Culicinae sp. BIOUG26017-D03']
+  aliases: []
   parents:
   - 1693839
 2308273:
-  aliases: ['Culicinae sp. BIOUG26017-E01']
+  aliases: []
   parents:
   - 1693839
 2308264:
-  aliases: ['Culicinae sp. BIOUG26017-E05']
+  aliases: []
   parents:
   - 1693839
 2308312:
-  aliases: ['Culicinae sp. BIOUG26017-H06']
+  aliases: []
   parents:
   - 1693839
 2308267:
-  aliases: ['Culicinae sp. BIOUG26018-H08']
+  aliases: []
   parents:
   - 1693839
 2308327:
-  aliases: ['Culicinae sp. BIOUG26019-A04']
+  aliases: []
   parents:
   - 1693839
 2208854:
-  aliases: ['Culicinae sp. BIOUG26185-E09']
+  aliases: []
   parents:
   - 1693839
 2208855:
-  aliases: ['Culicinae sp. BIOUG26185-E11']
+  aliases: []
   parents:
   - 1693839
 2208856:
-  aliases: ['Culicinae sp. BIOUG26185-H10']
+  aliases: []
   parents:
   - 1693839
 2308322:
-  aliases: ['Culicinae sp. BIOUG26213-B04']
+  aliases: []
   parents:
   - 1693839
 2308277:
-  aliases: ['Culicinae sp. BIOUG26213-B07']
+  aliases: []
   parents:
   - 1693839
 2208857:
-  aliases: ['Culicinae sp. BIOUG26261-B12']
+  aliases: []
   parents:
   - 1693839
 2308348:
-  aliases: ['Culicinae sp. BIOUG26576-E01']
+  aliases: []
   parents:
   - 1693839
 2308270:
-  aliases: ['Culicinae sp. BIOUG26576-F02']
+  aliases: []
   parents:
   - 1693839
 2308336:
-  aliases: ['Culicinae sp. BIOUG26576-H09']
+  aliases: []
   parents:
   - 1693839
 2208858:
-  aliases: ['Culicinae sp. BIOUG26660-H05']
+  aliases: []
   parents:
   - 1693839
 2208859:
-  aliases: ['Culicinae sp. BIOUG26782-F04']
+  aliases: []
   parents:
   - 1693839
 2208860:
-  aliases: ['Culicinae sp. BIOUG27097-A01']
+  aliases: []
   parents:
   - 1693839
 2208861:
-  aliases: ['Culicinae sp. BIOUG27104-E12']
+  aliases: []
   parents:
   - 1693839
 2208862:
-  aliases: ['Culicinae sp. BIOUG27226-C11']
+  aliases: []
   parents:
   - 1693839
 2208863:
-  aliases: ['Culicinae sp. BIOUG27359-C04']
+  aliases: []
   parents:
   - 1693839
 2208864:
-  aliases: ['Culicinae sp. BIOUG27360-A03']
+  aliases: []
   parents:
   - 1693839
 2208865:
-  aliases: ['Culicinae sp. BIOUG27486-B03']
+  aliases: []
   parents:
   - 1693839
 2308288:
-  aliases: ['Culicinae sp. BIOUG31032-G10']
+  aliases: []
   parents:
   - 1693839
 2308338:
-  aliases: ['Culicinae sp. BIOUG31041-G09']
+  aliases: []
   parents:
   - 1693839
 2308296:
-  aliases: ['Culicinae sp. BIOUG31043-G10']
+  aliases: []
   parents:
   - 1693839
 2308319:
-  aliases: ['Culicinae sp. BIOUG31046-B12']
+  aliases: []
   parents:
   - 1693839
 2308271:
-  aliases: ['Culicinae sp. BIOUG31047-A10']
+  aliases: []
   parents:
   - 1693839
 2308317:
-  aliases: ['Culicinae sp. BIOUG31050-C04']
+  aliases: []
   parents:
   - 1693839
 2308287:
-  aliases: ['Culicinae sp. BIOUG31069-F10']
+  aliases: []
   parents:
   - 1693839
 2308299:
-  aliases: ['Culicinae sp. BIOUG31069-H02']
+  aliases: []
   parents:
   - 1693839
 2308283:
-  aliases: ['Culicinae sp. BIOUG31088-F10']
+  aliases: []
   parents:
   - 1693839
 2308276:
-  aliases: ['Culicinae sp. BIOUG31088-G03']
+  aliases: []
   parents:
   - 1693839
 2308294:
-  aliases: ['Culicinae sp. BIOUG31120-B06']
+  aliases: []
   parents:
   - 1693839
 2308323:
-  aliases: ['Culicinae sp. BIOUG31120-C02']
+  aliases: []
   parents:
   - 1693839
 2308293:
-  aliases: ['Culicinae sp. BIOUG31121-D08']
+  aliases: []
   parents:
   - 1693839
 2308341:
-  aliases: ['Culicinae sp. BIOUG31121-G04']
+  aliases: []
   parents:
   - 1693839
 2308255:
-  aliases: ['Culicinae sp. BIOUG31801-F05']
+  aliases: []
   parents:
   - 1693839
 2308331:
-  aliases: ['Culicinae sp. BIOUG31834-E10']
+  aliases: []
   parents:
   - 1693839
 2308262:
-  aliases: ['Culicinae sp. BIOUG31834-F08']
+  aliases: []
   parents:
   - 1693839
 2308291:
-  aliases: ['Culicinae sp. BIOUG31834-H05']
+  aliases: []
   parents:
   - 1693839
 2308349:
-  aliases: ['Culicinae sp. BIOUG31863-B12']
+  aliases: []
   parents:
   - 1693839
 2308254:
-  aliases: ['Culicinae sp. BIOUG31863-C01']
+  aliases: []
   parents:
   - 1693839
 2308290:
-  aliases: ['Culicinae sp. BIOUG31863-C02']
+  aliases: []
   parents:
   - 1693839
 2308311:
-  aliases: ['Culicinae sp. BIOUG31863-C03']
+  aliases: []
   parents:
   - 1693839
 2308315:
-  aliases: ['Culicinae sp. BIOUG31991-C01']
+  aliases: []
   parents:
   - 1693839
 2308320:
-  aliases: ['Culicinae sp. BIOUG32136-G08']
+  aliases: []
   parents:
   - 1693839
 2308308:
-  aliases: ['Culicinae sp. BIOUG32138-G12']
+  aliases: []
   parents:
   - 1693839
 2308344:
-  aliases: ['Culicinae sp. BIOUG32139-A07']
+  aliases: []
   parents:
   - 1693839
 2308313:
-  aliases: ['Culicinae sp. BIOUG32141-H10']
+  aliases: []
   parents:
   - 1693839
 2308353:
-  aliases: ['Culicinae sp. BIOUG32165-F01']
+  aliases: []
   parents:
   - 1693839
 2308337:
-  aliases: ['Culicinae sp. BIOUG32167-E10']
+  aliases: []
   parents:
   - 1693839
 2308278:
-  aliases: ['Culicinae sp. BIOUG32168-D12']
+  aliases: []
   parents:
   - 1693839
 2308298:
-  aliases: ['Culicinae sp. BIOUG32187-C10']
+  aliases: []
   parents:
   - 1693839
 2308284:
-  aliases: ['Culicinae sp. BIOUG32187-E09']
+  aliases: []
   parents:
   - 1693839
 2308318:
-  aliases: ['Culicinae sp. BIOUG32187-F10']
+  aliases: []
   parents:
   - 1693839
 2308268:
-  aliases: ['Culicinae sp. BIOUG32188-F11']
+  aliases: []
   parents:
   - 1693839
 2308329:
-  aliases: ['Culicinae sp. BIOUG32188-G09']
+  aliases: []
   parents:
   - 1693839
 2308328:
-  aliases: ['Culicinae sp. BIOUG32272-G07']
+  aliases: []
   parents:
   - 1693839
 2308340:
-  aliases: ['Culicinae sp. BIOUG32273-D08']
+  aliases: []
   parents:
   - 1693839
 2308303:
-  aliases: ['Culicinae sp. BIOUG32311-H10']
+  aliases: []
   parents:
   - 1693839
 2308256:
-  aliases: ['Culicinae sp. BIOUG32484-G01']
+  aliases: []
   parents:
   - 1693839
 1881760:
-  aliases: ['Culicinae sp. BOLD-2016']
+  aliases: []
   parents:
   - 1693839
 1693840:
-  aliases: ['Culicinae sp. BOLD:AAA3748']
+  aliases: []
   parents:
   - 1693839
 1693841:
-  aliases: ['Culicinae sp. BOLD:AAA3750']
+  aliases: []
   parents:
   - 1693839
 1741581:
-  aliases: ['Culicinae sp. BOLD:AAA3751']
+  aliases: []
   parents:
   - 1693839
 1741582:
-  aliases: ['Culicinae sp. BOLD:AAA6145']
+  aliases: []
   parents:
   - 1693839
 1693842:
-  aliases: ['Culicinae sp. BOLD:AAA6148']
+  aliases: []
   parents:
   - 1693839
 1741583:
-  aliases: ['Culicinae sp. BOLD:AAA7067']
+  aliases: []
   parents:
   - 1693839
 1693843:
-  aliases: ['Culicinae sp. BOLD:AAB1098']
+  aliases: []
   parents:
   - 1693839
 1693844:
-  aliases: ['Culicinae sp. BOLD:AAB2539']
+  aliases: []
   parents:
   - 1693839
 1722173:
-  aliases: ['Culicinae sp. BOLD:AAB5696']
+  aliases: []
   parents:
   - 1693839
 1693845:
-  aliases: ['Culicinae sp. BOLD:AAB6338']
+  aliases: []
   parents:
   - 1693839
 1693846:
-  aliases: ['Culicinae sp. BOLD:AAC9062']
+  aliases: []
   parents:
   - 1693839
 1822824:
-  aliases: ['Culicinae sp. BOLD:AAC9531']
+  aliases: []
   parents:
   - 1693839
 1749815:
-  aliases: ['Culicinae sp. BOLD:AAD3254']
+  aliases: []
   parents:
   - 1693839
 1749816:
-  aliases: ['Culicinae sp. BOLD:AAD4326']
+  aliases: []
   parents:
   - 1693839
 1722174:
-  aliases: ['Culicinae sp. BOLD:AAD4355']
+  aliases: []
   parents:
   - 1693839
 1722175:
-  aliases: ['Culicinae sp. BOLD:AAD4406']
+  aliases: []
   parents:
   - 1693839
 1754368:
-  aliases: ['Culicinae sp. BOLD:AAD7982']
+  aliases: []
   parents:
   - 1693839
 1722176:
-  aliases: ['Culicinae sp. BOLD:AAD8027']
+  aliases: []
   parents:
   - 1693839
 1693847:
-  aliases: ['Culicinae sp. BOLD:AAF2904']
+  aliases: []
   parents:
   - 1693839
 1724674:
-  aliases: ['Culicinae sp. BOLD:AAI1618']
+  aliases: []
   parents:
   - 1693839
 1693848:
-  aliases: ['Culicinae sp. BOLD:AAM4536']
+  aliases: []
   parents:
   - 1693839
 1693849:
-  aliases: ['Culicinae sp. BOLD:ABY6464']
+  aliases: []
   parents:
   - 1693839
 1822825:
-  aliases: ['Culicinae sp. BOLD:ACC5413']
+  aliases: []
   parents:
   - 1693839
 1693850:
-  aliases: ['Culicinae sp. BOLD:ACE6286']
+  aliases: []
   parents:
   - 1693839
 1822826:
-  aliases: ['Culicinae sp. CNPKE559-14']
+  aliases: []
   parents:
   - 1693839
 1754369:
-  aliases: ['Culicinae sp. CNWBG1694-13']
+  aliases: []
   parents:
   - 1693839
 1744653:
-  aliases: ['Culicinae sp. SSBAB2152-12']
+  aliases: []
   parents:
   - 1693839
 1744688:
-  aliases: ['Culicinae sp. SSBAD895-12']
+  aliases: []
   parents:
   - 1693839
 1744726:
-  aliases: ['Culicinae sp. SSBAE5252-13']
+  aliases: []
   parents:
   - 1693839
 1744727:
-  aliases: ['Culicinae sp. SSBAE5301-13']
+  aliases: []
   parents:
   - 1693839
 1744728:
-  aliases: ['Culicinae sp. SSBAE5321-13']
+  aliases: []
   parents:
   - 1693839
 1744730:
-  aliases: ['Culicinae sp. SSBAE5480-13']
+  aliases: []
   parents:
   - 1693839
 1744731:
-  aliases: ['Culicinae sp. SSBAE5509-13']
+  aliases: []
   parents:
   - 1693839
 1749817:
-  aliases: ['Culicinae sp. SSEIA7153-13']
+  aliases: []
   parents:
   - 1693839
 1749818:
-  aliases: ['Culicinae sp. SSEIB1985-13']
+  aliases: []
   parents:
   - 1693839
 1741584:
-  aliases: ['Culicinae sp. SSJAE2136-13']
+  aliases: []
   parents:
   - 1693839
 1693851:
-  aliases: ['Culicinae sp. SSPAB9906-13']
+  aliases: []
   parents:
   - 1693839
 1693852:
-  aliases: ['Culicinae sp. SSPAG130-13']
+  aliases: []
   parents:
   - 1693839
 1693853:
-  aliases: ['Culicinae sp. SSWLA4556-13']
+  aliases: []
   parents:
   - 1693839
 174825:
-  aliases: ['Culiseta']
+  aliases: []
   parents:
   - 308729
 53524:
-  aliases: ['Deinocerites']
+  aliases: []
   parents:
   - 53550
 317801:
-  aliases: ['Eretmapodites']
+  aliases: []
   parents:
   - 1056966
 308730:
-  aliases: ['Ficalbia']
+  aliases: []
   parents:
   - 308727
 2773402:
-  aliases: ['Gilesius']
+  aliases: []
   parents:
   - 1056966
 7180:
-  aliases: ['Haemagogus']
+  aliases: []
   parents:
   - 1056966
 317799:
-  aliases: ['Heizmannia']
+  aliases: []
   parents:
   - 1056966
 425228:
-  aliases: ['Hodgesia']
+  aliases: []
   parents:
   - 308728
 2007253:
-  aliases: ['Johnbelkinia']
+  aliases: []
   parents:
   - 53549
 68877:
-  aliases: ['Kerteszia']
+  aliases: []
   parents:
   - 7164
 704164:
-  aliases: ['Limatus']
+  aliases: []
   parents:
   - 53549
 273457:
-  aliases: ['Lophopodomyia']
+  aliases: []
   parents:
   - 7164
 53533:
-  aliases: ['Lutzia']
+  aliases: []
   parents:
   - 53550
 149618:
-  aliases: ['Malaya']
+  aliases: []
   parents:
   - 53549
 149459:
-  aliases: ['Mansonia']
+  aliases: []
   parents:
   - 254792
 704166:
-  aliases: ['Maorigoeldia']
+  aliases: []
   parents:
   - 53549
 308736:
-  aliases: ['Mimomyia']
+  aliases: []
   parents:
   - 308727
 53565:
-  aliases: ['Neobironella']
+  aliases: []
   parents:
   - 53562
 1367702:
-  aliases: ['Nyctomyia']
+  aliases: []
   parents:
   - 1056966
 44543:
-  aliases: ['Nyssorhynchus']
+  aliases: []
   parents:
   - 7164
 190765:
-  aliases: ['Ochlerotatus']
+  aliases: []
   parents:
   - 1056966
 2007256:
-  aliases: ['Onirion']
+  aliases: []
   parents:
   - 53549
 317800:
-  aliases: ['Opifex']
+  aliases: []
   parents:
   - 1056966
 139053:
-  aliases: ['Orthopodomyia']
+  aliases: []
   parents:
   - 149617
 1245386:
-  aliases: ['Phagomyia']
+  aliases: []
   parents:
   - 1056966
 7182:
-  aliases: ['Psorophora']
+  aliases: []
   parents:
   - 1056966
 2007258:
-  aliases: ['Runchomyia']
+  aliases: []
   parents:
   - 53549
 53551:
-  aliases: ['Sabethes']
+  aliases: []
   parents:
   - 53549
 704168:
-  aliases: ['Shannoniana']
+  aliases: []
   parents:
   - 53549
 273456:
-  aliases: ['Stethomyia']
+  aliases: []
   parents:
   - 7164
 1608558:
-  aliases: ['Tanakaius']
+  aliases: []
   parents:
   - 1056966
 1245394:
-  aliases: ['Topomyia']
+  aliases: []
   parents:
   - 53549
 46208:
-  aliases: ['Toxorhynchites amboinensis']
+  aliases: []
   parents:
   - 46207
 1245331:
-  aliases: ['Toxorhynchites aurifluus']
+  aliases: []
   parents:
   - 46207
 332059:
-  aliases: ['Toxorhynchites brevipalpis']
+  aliases: []
   parents:
   - 46207
 2108402:
-  aliases: ['Toxorhynchites caatingensis']
+  aliases: []
   parents:
   - 46207
 1310325:
-  aliases: ['Toxorhynchites christophi']
+  aliases: []
   parents:
   - 46207
 1245332:
-  aliases: ['Toxorhynchites edwardsi']
+  aliases: []
   parents:
   - 46207
 1245333:
-  aliases: ['Toxorhynchites gravelyi']
+  aliases: []
   parents:
   - 46207
 2007224:
-  aliases: ['Toxorhynchites guadeloupensis']
+  aliases: []
   parents:
   - 46207
 2007225:
-  aliases: ['Toxorhynchites haemorrhoidalis']
+  aliases: []
   parents:
   - 46207
 1245334:
-  aliases: ['Toxorhynchites kempi']
+  aliases: []
   parents:
   - 46207
 2498889:
-  aliases: ['Toxorhynchites manicatus']
+  aliases: []
   parents:
   - 46207
 2007228:
-  aliases: ['Toxorhynchites moctezuma']
+  aliases: []
   parents:
   - 46207
 2875522:
-  aliases: ['Toxorhynchites okinawensis']
+  aliases: []
   parents:
   - 46207
 3014951:
-  aliases: ['Toxorhynchites portoricensis']
+  aliases: []
   parents:
   - 46207
 53553:
-  aliases: ['Toxorhynchites rutilus']
+  aliases: []
   parents:
   - 46207
 2681096:
-  aliases: ['Toxorhynchites speciosus']
+  aliases: []
   parents:
   - 46207
 498392:
-  aliases: ['Toxorhynchites splendens']
+  aliases: []
   parents:
   - 46207
 2587270:
-  aliases: ['Toxorhynchites sunthorni']
+  aliases: []
   parents:
   - 46207
 1969993:
-  aliases: ['Toxorhynchites theobaldi']
+  aliases: []
   parents:
   - 46207
 1652498:
-  aliases: ['Toxorhynchites towadensis']
+  aliases: []
   parents:
   - 46207
 1231455:
-  aliases: ['Toxorhynchites tyagii']
+  aliases: []
   parents:
   - 46207
 704162:
-  aliases: ['Trichoprosopon']
+  aliases: []
   parents:
   - 53549
 53567:
-  aliases: ['Tripteroides']
+  aliases: []
   parents:
   - 53549
 1245387:
-  aliases: ['Udaya']
+  aliases: []
   parents:
   - 1056966
 139055:
-  aliases: ['Uranotaenia']
+  aliases: []
   parents:
   - 149616
 317805:
-  aliases: ['Verrallina']
+  aliases: []
   parents:
   - 1056966
 174620:
-  aliases: ['Wyeomyia']
+  aliases: []
   parents:
   - 53549
 1424509:
-  aliases: ['Zeugnomyia']
+  aliases: []
   parents:
   - 1056966
 2811849:
-  aliases: ['environmental samples']
+  aliases: []
   parents:
   - 7164
 63365:
-  aliases: ['unclassified Anopheles']
+  aliases: []
   parents:
   - 7164
 2629023:
-  aliases: ['unclassified Chagasia']
+  aliases: []
   parents:
   - 139051
 2624694:
-  aliases: ['unclassified Toxorhynchites']
+  aliases: []
   parents:
   - 46207
 120875:
-  aliases: ['Acartomyia mariae']
+  aliases: []
   parents:
   - 1548035
 1548036:
-  aliases: ['Acartomyia phoeniciae']
+  aliases: []
   parents:
   - 1548035
 1548034:
-  aliases: ['Acartomyia zammitii']
+  aliases: []
   parents:
   - 1548035
 1701320:
-  aliases: ['Aedeomyia africana']
+  aliases: []
   parents:
   - 139057
 308708:
-  aliases: ['Aedeomyia catasticta']
+  aliases: []
   parents:
   - 139057
 1799668:
-  aliases: ['Aedeomyia furfurea']
+  aliases: []
   parents:
   - 139057
 1620266:
-  aliases: ['Aedeomyia madagascarica']
+  aliases: []
   parents:
   - 139057
 139058:
-  aliases: ['Aedeomyia squamipennis']
+  aliases: []
   parents:
   - 139057
 1806173:
-  aliases: ['Aedeomyia venustipes']
+  aliases: []
   parents:
   - 139057
 149531:
-  aliases: ['Aedes']
+  aliases: []
   parents:
   - 7158
 1806188:
-  aliases: ['Aedes incertae sedis']
+  aliases: []
   parents:
   - 7158
 53540:
-  aliases: ['Aedimorphus']
+  aliases: []
   parents:
   - 7158
 1640510:
-  aliases: ['Aedinus']
+  aliases: []
   parents:
   - 7174
 300144:
-  aliases: ['Albuginosus']
+  aliases: []
   parents:
   - 7158
 44483:
-  aliases: ['Angusticorn']
+  aliases: []
   parents:
   - 44482
 1426913:
-  aliases: ['Anoedioporpa']
+  aliases: []
   parents:
   - 7174
 2830294:
-  aliases: ['Anopheles (Anopheles) sp. 1485']
+  aliases: []
   parents:
   - 63365
 2830320:
-  aliases: ['Anopheles (Anopheles) sp. 200']
+  aliases: []
   parents:
   - 63365
 2830307:
-  aliases: ['Anopheles (Anopheles) sp. 2000']
+  aliases: []
   parents:
   - 63365
 2830321:
-  aliases: ['Anopheles (Anopheles) sp. 2024']
+  aliases: []
   parents:
   - 63365
 2830322:
-  aliases: ['Anopheles (Anopheles) sp. 2093']
+  aliases: []
   parents:
   - 63365
 2830295:
-  aliases: ['Anopheles (Anopheles) sp. 215']
+  aliases: []
   parents:
   - 63365
 2830308:
-  aliases: ['Anopheles (Anopheles) sp. 2649']
+  aliases: []
   parents:
   - 63365
 2830296:
-  aliases: ['Anopheles (Anopheles) sp. 3387']
+  aliases: []
   parents:
   - 63365
 2830309:
-  aliases: ['Anopheles (Anopheles) sp. 3394']
+  aliases: []
   parents:
   - 63365
 2830323:
-  aliases: ['Anopheles (Anopheles) sp. 3397']
+  aliases: []
   parents:
   - 63365
 2830324:
-  aliases: ['Anopheles (Anopheles) sp. 3398']
+  aliases: []
   parents:
   - 63365
 2830310:
-  aliases: ['Anopheles (Anopheles) sp. 3399']
+  aliases: []
   parents:
   - 63365
 2830325:
-  aliases: ['Anopheles (Anopheles) sp. 3404']
+  aliases: []
   parents:
   - 63365
 2830297:
-  aliases: ['Anopheles (Anopheles) sp. 3438']
+  aliases: []
   parents:
   - 63365
 2830311:
-  aliases: ['Anopheles (Anopheles) sp. 3456']
+  aliases: []
   parents:
   - 63365
 2830312:
-  aliases: ['Anopheles (Anopheles) sp. 3467']
+  aliases: []
   parents:
   - 63365
 2830313:
-  aliases: ['Anopheles (Anopheles) sp. 3471']
+  aliases: []
   parents:
   - 63365
 2830314:
-  aliases: ['Anopheles (Anopheles) sp. 3474']
+  aliases: []
   parents:
   - 63365
 2830298:
-  aliases: ['Anopheles (Anopheles) sp. 3522']
+  aliases: []
   parents:
   - 63365
 2830326:
-  aliases: ['Anopheles (Anopheles) sp. 3610']
+  aliases: []
   parents:
   - 63365
 2830315:
-  aliases: ['Anopheles (Anopheles) sp. 3614']
+  aliases: []
   parents:
   - 63365
 2830299:
-  aliases: ['Anopheles (Anopheles) sp. 3621']
+  aliases: []
   parents:
   - 63365
 2830327:
-  aliases: ['Anopheles (Anopheles) sp. 3622']
+  aliases: []
   parents:
   - 63365
 2830328:
-  aliases: ['Anopheles (Anopheles) sp. 3623']
+  aliases: []
   parents:
   - 63365
 2830316:
-  aliases: ['Anopheles (Anopheles) sp. 3626']
+  aliases: []
   parents:
   - 63365
 2830300:
-  aliases: ['Anopheles (Anopheles) sp. 3631']
+  aliases: []
   parents:
   - 63365
 2830329:
-  aliases: ['Anopheles (Anopheles) sp. 3632']
+  aliases: []
   parents:
   - 63365
 2830330:
-  aliases: ['Anopheles (Anopheles) sp. 3675']
+  aliases: []
   parents:
   - 63365
 2830301:
-  aliases: ['Anopheles (Anopheles) sp. 3680']
+  aliases: []
   parents:
   - 63365
 2830331:
-  aliases: ['Anopheles (Anopheles) sp. 3705']
+  aliases: []
   parents:
   - 63365
 2830302:
-  aliases: ['Anopheles (Anopheles) sp. 3732']
+  aliases: []
   parents:
   - 63365
 2830303:
-  aliases: ['Anopheles (Anopheles) sp. 3736']
+  aliases: []
   parents:
   - 63365
 2830304:
-  aliases: ['Anopheles (Anopheles) sp. 3742']
+  aliases: []
   parents:
   - 63365
 2830317:
-  aliases: ['Anopheles (Anopheles) sp. 3745']
+  aliases: []
   parents:
   - 63365
 2830318:
-  aliases: ['Anopheles (Anopheles) sp. 3749']
+  aliases: []
   parents:
   - 63365
 2830332:
-  aliases: ['Anopheles (Anopheles) sp. 3750']
+  aliases: []
   parents:
   - 63365
 2830305:
-  aliases: ['Anopheles (Anopheles) sp. 3753']
+  aliases: []
   parents:
   - 63365
 2830319:
-  aliases: ['Anopheles (Anopheles) sp. 3757']
+  aliases: []
   parents:
   - 63365
 2830306:
-  aliases: ['Anopheles (Anopheles) sp. 3762']
+  aliases: []
   parents:
   - 63365
 2830333:
-  aliases: ['Anopheles (Anopheles) sp. M12']
+  aliases: []
   parents:
   - 63365
 190375:
-  aliases: ['Anopheles acanthotorynus']
+  aliases: []
   parents:
   - 273456
 2171928:
-  aliases: ['Anopheles aff. konderi A PGF-2018']
+  aliases: []
   parents:
   - 44543
 2171929:
-  aliases: ['Anopheles aff. konderi B PGF-2018']
+  aliases: []
   parents:
   - 44543
 2171930:
-  aliases: ['Anopheles aff. konderi C PGF-2018']
+  aliases: []
   parents:
   - 44543
 2860267:
-  aliases: ['Anopheles aff. konderi C TMPO-2021']
+  aliases: []
   parents:
   - 44543
 2171931:
-  aliases: ['Anopheles aff. lutzii A PGF-2018']
+  aliases: []
   parents:
   - 44543
 2171932:
-  aliases: ['Anopheles aff. lutzii B PGF-2018']
+  aliases: []
   parents:
   - 44543
 2830290:
-  aliases: ['Anopheles aff. neivai A TMPO-2021a']
+  aliases: []
   parents:
   - 68877
 2830291:
-  aliases: ['Anopheles aff. neivai B TMPO-2021a']
+  aliases: []
   parents:
   - 68877
 596823:
-  aliases: ['Anopheles antunesi']
+  aliases: []
   parents:
   - 44543
 1833978:
-  aliases: ['Anopheles azaniae']
+  aliases: []
   parents:
   - 44534
 2972757:
-  aliases: ['Anopheles azevedoi']
+  aliases: []
   parents:
   - 44534
 3031291:
-  aliases: ['Anopheles bambusicolus']
+  aliases: []
   parents:
   - 68877
 139047:
-  aliases: ['Anopheles bellator']
+  aliases: []
   parents:
   - 68877
 3031302:
-  aliases: ['Anopheles bellator complex 2BB']
+  aliases: []
   parents:
   - 68877
 2044755:
-  aliases: ['Anopheles boliviensis']
+  aliases: []
   parents:
   - 68877
 3031303:
-  aliases: ['Anopheles boliviensis complex 1BB']
+  aliases: []
   parents:
   - 68877
 2748954:
-  aliases: ['Anopheles brohieri']
+  aliases: []
   parents:
   - 44534
 2564023:
-  aliases: ['Anopheles brunnipes']
+  aliases: []
   parents:
   - 44534
 185577:
-  aliases: ['Anopheles carnevalei']
+  aliases: []
   parents:
   - 44534
 3097606:
-  aliases: ['Anopheles cf. coustani/ziemanni']
+  aliases: []
   parents:
   - 63365
 2807519:
-  aliases: ['Anopheles cf. pharoensis']
+  aliases: []
   parents:
   - 44534
 3097607:
-  aliases: ['Anopheles cf. vaneedeni/longipalpis']
+  aliases: []
   parents:
   - 63365
 1632206:
-  aliases: ['Anopheles cinereus']
+  aliases: []
   parents:
   - 44534
 2219645:
-  aliases: ['Anopheles coluzzii x Anopheles arabiensis']
+  aliases: []
   parents:
   - 44534
 2219646:
-  aliases: ['Anopheles coluzzii x Anopheles quadriannulatus']
+  aliases: []
   parents:
   - 44534
 68878:
-  aliases: ['Anopheles cruzii']
+  aliases: []
   parents:
   - 68877
 2748953:
-  aliases: ['Anopheles dureni']
+  aliases: []
   parents:
   - 44534
 2811792:
-  aliases: ['Anopheles environmental sample']
+  aliases: []
   parents:
   - 2811849
 3135065:
-  aliases: ['Anopheles fuscivenosus']
+  aliases: []
   parents:
   - 44534
 2913601:
-  aliases: ['Anopheles gibbinsi']
+  aliases: []
   parents:
   - 44534
 2171669:
-  aliases: ['Anopheles gilesi']
+  aliases: []
   parents:
   - 273457
 1048867:
-  aliases: ['Anopheles guarani']
+  aliases: []
   parents:
   - 44543
 1162629:
-  aliases: ['Anopheles hackeri']
+  aliases: []
   parents:
   - 44534
 1049720:
-  aliases: ['Anopheles halophylus']
+  aliases: []
   parents:
   - 44543
 3163323:
-  aliases: ['Anopheles hargreavesi']
+  aliases: []
   parents:
   - 44534
 486634:
-  aliases: ['Anopheles harrisoni']
+  aliases: []
   parents:
   - 44534
 369908:
-  aliases: ['Anopheles homunculus']
+  aliases: []
   parents:
   - 68877
 3031304:
-  aliases: ['Anopheles homunculus complex 1 YML-2023a']
+  aliases: []
   parents:
   - 68877
 3031305:
-  aliases: ['Anopheles homunculus complex 1BB']
+  aliases: []
   parents:
   - 68877
 190374:
-  aliases: ['Anopheles incertae sedis']
+  aliases: []
   parents:
   - 44482
 320069:
-  aliases: ['Anopheles indefinitus']
+  aliases: []
   parents:
   - 44534
 1678524:
-  aliases: ['Anopheles ininii']
+  aliases: []
   parents:
   - 44543
 1548502:
-  aliases: ['Anopheles introlatus']
+  aliases: []
   parents:
   - 44534
 2564024:
-  aliases: ['Anopheles jebudensis']
+  aliases: []
   parents:
   - 44534
 139048:
-  aliases: ['Anopheles kompi']
+  aliases: []
   parents:
   - 273456
 43180:
-  aliases: ['Anopheles konderi']
+  aliases: []
   parents:
   - 44543
 369909:
-  aliases: ['Anopheles laneanus']
+  aliases: []
   parents:
   - 68877
 596824:
-  aliases: ['Anopheles lanei']
+  aliases: []
   parents:
   - 44543
 1108002:
-  aliases: ['Anopheles lepidotus']
+  aliases: []
   parents:
   - 68877
 2793954:
-  aliases: ['Anopheles limosus']
+  aliases: []
   parents:
   - 44534
 2995624:
-  aliases: ['Anopheles ludlowae']
+  aliases: []
   parents:
   - 44534
 596825:
-  aliases: ['Anopheles lutzii']
+  aliases: []
   parents:
   - 44543
 1184682:
-  aliases: ['Anopheles lutzii s.l. 1 RS16']
+  aliases: []
   parents:
   - 44543
 1184683:
-  aliases: ['Anopheles lutzii s.l. 2 RS19']
+  aliases: []
   parents:
   - 44543
 1184684:
-  aliases: ['Anopheles lutzii s.l. 2 RS33']
+  aliases: []
   parents:
   - 44543
 2259328:
-  aliases: ['Anopheles mascarensis']
+  aliases: []
   parents:
   - 44534
 1194503:
-  aliases: ['Anopheles moghulensis']
+  aliases: []
   parents:
   - 44534
 139046:
-  aliases: ['Anopheles neivai']
+  aliases: []
   parents:
   - 68877
 3031306:
-  aliases: ['Anopheles neivai complex 2BB']
+  aliases: []
   parents:
   - 68877
 3031307:
-  aliases: ['Anopheles neivai complex 3BB']
+  aliases: []
   parents:
   - 68877
 3031308:
-  aliases: ['Anopheles neivai complex 4BB']
+  aliases: []
   parents:
   - 68877
 925982:
-  aliases: ['Anopheles nimbus']
+  aliases: []
   parents:
   - 273456
 632896:
-  aliases: ['Anopheles nr. antunesi MAMS-2009']
+  aliases: []
   parents:
   - 44543
 1406129:
-  aliases: ['Anopheles nr. dravidicus YML2012']
+  aliases: []
   parents:
   - 44534
 2138373:
-  aliases: ['Anopheles nr. konderi 39']
+  aliases: []
   parents:
   - 44543
 2138374:
-  aliases: ['Anopheles nr. konderi 40']
+  aliases: []
   parents:
   - 44543
 2138375:
-  aliases: ['Anopheles nr. konderi 42']
+  aliases: []
   parents:
   - 44543
 2049329:
-  aliases: ['Anopheles nr. konderi 424B']
+  aliases: []
   parents:
   - 44543
 2138376:
-  aliases: ['Anopheles nr. konderi 43']
+  aliases: []
   parents:
   - 44543
 2049330:
-  aliases: ['Anopheles nr. konderi 471B']
+  aliases: []
   parents:
   - 44543
 2049331:
-  aliases: ['Anopheles nr. konderi 479B']
+  aliases: []
   parents:
   - 44543
 2735825:
-  aliases: ['Anopheles nr. konderi Do B38']
+  aliases: []
   parents:
   - 44543
 2735826:
-  aliases: ['Anopheles nr. konderi Do B40']
+  aliases: []
   parents:
   - 44543
 1326108:
-  aliases: ['Anopheles nr. konderi FRL-2013']
+  aliases: []
   parents:
   - 44543
 2419676:
-  aliases: ['Anopheles nr. konderi MAMS-2018']
+  aliases: []
   parents:
   - 44543
 1280485:
-  aliases: ['Anopheles ovengensis']
+  aliases: []
   parents:
   - 44534
 596827:
-  aliases: ['Anopheles parvus']
+  aliases: []
   parents:
   - 44543
 1620269:
-  aliases: ['Anopheles pauliani']
+  aliases: []
   parents:
   - 44534
 221566:
-  aliases: ['Anopheles pharoensis']
+  aliases: []
   parents:
   - 44534
 319534:
-  aliases: ['Anopheles philippinensis']
+  aliases: []
   parents:
   - 44534
 1108003:
-  aliases: ['Anopheles pholidotus']
+  aliases: []
   parents:
   - 68877
 3031309:
-  aliases: ['Anopheles pholidotus complex 1BB']
+  aliases: []
   parents:
   - 68877
 3031310:
-  aliases: ['Anopheles pholidotus complex 2BB']
+  aliases: []
   parents:
   - 68877
 1141471:
-  aliases: ['Anopheles pretoriensis']
+  aliases: []
   parents:
   - 44534
 516961:
-  aliases: ['Anopheles pseudojamesi']
+  aliases: []
   parents:
   - 44534
 2171670:
-  aliases: ['Anopheles pseudotibiamaculatus']
+  aliases: []
   parents:
   - 273457
 1632207:
-  aliases: ['Anopheles rhodesiensis']
+  aliases: []
   parents:
   - 44534
 3031311:
-  aliases: ['Anopheles rollai complex 1BB']
+  aliases: []
   parents:
   - 68877
 3031312:
-  aliases: ['Anopheles rollai complex 2BB']
+  aliases: []
   parents:
   - 68877
 3031313:
-  aliases: ['Anopheles rollai complex 4BB']
+  aliases: []
   parents:
   - 68877
 3031314:
-  aliases: ['Anopheles rollai complex 5BB']
+  aliases: []
   parents:
   - 68877
 3424145:
-  aliases: ['Anopheles rondoniensis']
+  aliases: []
   parents:
   - 44543
 1141472:
-  aliases: ['Anopheles rufipes']
+  aliases: []
   parents:
   - 44534
 38782:
-  aliases: ['Anopheles sp.']
+  aliases: []
   parents:
   - 63365
 1496334:
-  aliases: ['Anopheles sp. 1 BSL-2014']
+  aliases: []
   parents:
   - 63365
 2609882:
-  aliases: ['Anopheles sp. 1 BSL-2014 cf1']
+  aliases: []
   parents:
   - 63365
 2731378:
-  aliases: ['Anopheles sp. 1 DZ-2020']
+  aliases: []
   parents:
   - 63365
 1293408:
-  aliases: ['Anopheles sp. 1 GW-2013']
+  aliases: []
   parents:
   - 63365
 2014930:
-  aliases: ['Anopheles sp. 1 YL-2017']
+  aliases: []
   parents:
   - 63365
 2510657:
-  aliases: ['Anopheles sp. 10FCM']
+  aliases: []
   parents:
   - 63365
 1496338:
-  aliases: ['Anopheles sp. 11 BSL-2014']
+  aliases: []
   parents:
   - 63365
 2499885:
-  aliases: ['Anopheles sp. 11 CMJ-2018']
+  aliases: []
   parents:
   - 63365
 2731379:
-  aliases: ['Anopheles sp. 11 DZ-2020']
+  aliases: []
   parents:
   - 63365
 2510658:
-  aliases: ['Anopheles sp. 11FCM']
+  aliases: []
   parents:
   - 63365
 2510659:
-  aliases: ['Anopheles sp. 12FCM']
+  aliases: []
   parents:
   - 63365
 1496339:
-  aliases: ['Anopheles sp. 14 BSL-2014']
+  aliases: []
   parents:
   - 63365
 2499886:
-  aliases: ['Anopheles sp. 14 CMJ-2018']
+  aliases: []
   parents:
   - 63365
 2731380:
-  aliases: ['Anopheles sp. 14 DZ-2020']
+  aliases: []
   parents:
   - 63365
 1496340:
-  aliases: ['Anopheles sp. 15 BSL-2014']
+  aliases: []
   parents:
   - 63365
 2499887:
-  aliases: ['Anopheles sp. 15 CMJ-2018']
+  aliases: []
   parents:
   - 63365
 2731381:
-  aliases: ['Anopheles sp. 15 DZ-2020']
+  aliases: []
   parents:
   - 63365
 2726198:
-  aliases: ['Anopheles sp. 15 JEF-2020']
+  aliases: []
   parents:
   - 63365
 1496341:
-  aliases: ['Anopheles sp. 16 BSL-2014']
+  aliases: []
   parents:
   - 63365
 2730096:
-  aliases: ['Anopheles sp. 17 DZ-2020']
+  aliases: []
   parents:
   - 63365
 2731382:
-  aliases: ['Anopheles sp. 18 DZ-2020']
+  aliases: []
   parents:
   - 63365
 3137592:
-  aliases: ['Anopheles sp. 18 EE-2024']
+  aliases: []
   parents:
   - 63365
 2731383:
-  aliases: ['Anopheles sp. 19 DZ-2020']
+  aliases: []
   parents:
   - 63365
 3137593:
-  aliases: ['Anopheles sp. 19 KHH1 EE-2024']
+  aliases: []
   parents:
   - 63365
 2510648:
-  aliases: ['Anopheles sp. 1FCM']
+  aliases: []
   parents:
   - 63365
 3137594:
-  aliases: ['Anopheles sp. 20 EE-2024']
+  aliases: []
   parents:
   - 63365
 3135066:
-  aliases: ['Anopheles sp. 2022ETH0173']
+  aliases: []
   parents:
   - 63365
 2510649:
-  aliases: ['Anopheles sp. 2FCM']
+  aliases: []
   parents:
   - 63365
 2510650:
-  aliases: ['Anopheles sp. 3FCM']
+  aliases: []
   parents:
   - 63365
 2304023:
-  aliases: ['Anopheles sp. 4 JV-2018']
+  aliases: []
   parents:
   - 63365
 2510651:
-  aliases: ['Anopheles sp. 4FCM']
+  aliases: []
   parents:
   - 63365
 2510652:
-  aliases: ['Anopheles sp. 5FCM']
+  aliases: []
   parents:
   - 63365
 1496335:
-  aliases: ['Anopheles sp. 6 BSL-2014']
+  aliases: []
   parents:
   - 63365
 2499888:
-  aliases: ['Anopheles sp. 6 CMJ-2018']
+  aliases: []
   parents:
   - 63365
 2730097:
-  aliases: ['Anopheles sp. 6 DZ-2020']
+  aliases: []
   parents:
   - 63365
 2510653:
-  aliases: ['Anopheles sp. 6FCM']
+  aliases: []
   parents:
   - 63365
 1496336:
-  aliases: ['Anopheles sp. 7 BSL-2014']
+  aliases: []
   parents:
   - 63365
 2731384:
-  aliases: ['Anopheles sp. 7 DZ-2020']
+  aliases: []
   parents:
   - 63365
 2304024:
-  aliases: ['Anopheles sp. 7 JV-2018']
+  aliases: []
   parents:
   - 63365
 2510654:
-  aliases: ['Anopheles sp. 7FCM']
+  aliases: []
   parents:
   - 63365
 2510655:
-  aliases: ['Anopheles sp. 8FCM']
+  aliases: []
   parents:
   - 63365
 1496337:
-  aliases: ['Anopheles sp. 9 BSL-2014']
+  aliases: []
   parents:
   - 63365
 2730098:
-  aliases: ['Anopheles sp. 9 DZ-2020']
+  aliases: []
   parents:
   - 63365
 2510656:
-  aliases: ['Anopheles sp. 9FCM']
+  aliases: []
   parents:
   - 63365
 2267823:
-  aliases: ['Anopheles sp. A/1']
+  aliases: []
   parents:
   - 63365
 2746495:
-  aliases: ['Anopheles sp. A113']
+  aliases: []
   parents:
   - 63365
 1833979:
-  aliases: ['Anopheles sp. AGB-2016']
+  aliases: []
   parents:
   - 63365
 2751541:
-  aliases: ['Anopheles sp. AN13']
+  aliases: []
   parents:
   - 63365
 2751542:
-  aliases: ['Anopheles sp. AN14']
+  aliases: []
   parents:
   - 63365
 2751543:
-  aliases: ['Anopheles sp. AN15']
+  aliases: []
   parents:
   - 63365
 2751544:
-  aliases: ['Anopheles sp. AN16']
+  aliases: []
   parents:
   - 63365
 2751545:
-  aliases: ['Anopheles sp. AN17']
+  aliases: []
   parents:
   - 63365
 2751546:
-  aliases: ['Anopheles sp. AN18']
+  aliases: []
   parents:
   - 63365
 2751540:
-  aliases: ['Anopheles sp. AN9']
+  aliases: []
   parents:
   - 63365
 465798:
-  aliases: ['Anopheles sp. Ah36']
+  aliases: []
   parents:
   - 63365
 2746496:
-  aliases: ['Anopheles sp. B242']
+  aliases: []
   parents:
   - 63365
 2746497:
-  aliases: ['Anopheles sp. B245']
+  aliases: []
   parents:
   - 63365
 2314999:
-  aliases: ['Anopheles sp. BIOUG25498-G06']
+  aliases: []
   parents:
   - 63365
 2207149:
-  aliases: ['Anopheles sp. BIOUG27392-B04']
+  aliases: []
   parents:
   - 63365
 2207150:
-  aliases: ['Anopheles sp. BIOUG27392-G12']
+  aliases: []
   parents:
   - 63365
 2315000:
-  aliases: ['Anopheles sp. BIOUG28195-H10']
+  aliases: []
   parents:
   - 63365
 1888154:
-  aliases: ['Anopheles sp. BOLD-2016']
+  aliases: []
   parents:
   - 63365
 2657478:
-  aliases: ['Anopheles sp. BOLD:AAA5103']
+  aliases: []
   parents:
   - 63365
 2657479:
-  aliases: ['Anopheles sp. BOLD:AAA5104']
+  aliases: []
   parents:
   - 63365
 1754996:
-  aliases: ['Anopheles sp. BOLD:AAC0584']
+  aliases: []
   parents:
   - 63365
 2657477:
-  aliases: ['Anopheles sp. BOLD:AAI4553']
+  aliases: []
   parents:
   - 63365
 1744827:
-  aliases: ['Anopheles sp. BOLD:ACB9644']
+  aliases: []
   parents:
   - 63365
 2746498:
-  aliases: ['Anopheles sp. C181']
+  aliases: []
   parents:
   - 63365
 2746499:
-  aliases: ['Anopheles sp. C194']
+  aliases: []
   parents:
   - 63365
 2746500:
-  aliases: ['Anopheles sp. C197']
+  aliases: []
   parents:
   - 63365
 2746501:
-  aliases: ['Anopheles sp. C203']
+  aliases: []
   parents:
   - 63365
 1866959:
-  aliases: ['Anopheles sp. CMJ-2016']
+  aliases: []
   parents:
   - 63365
 2569800:
-  aliases: ['Anopheles sp. GAB-1 43']
+  aliases: []
   parents:
   - 63365
 2569801:
-  aliases: ['Anopheles sp. GAB-1 45']
+  aliases: []
   parents:
   - 63365
 2569802:
-  aliases: ['Anopheles sp. GAB-1 46']
+  aliases: []
   parents:
   - 63365
 2569803:
-  aliases: ['Anopheles sp. GAB-1 47']
+  aliases: []
   parents:
   - 63365
 2569804:
-  aliases: ['Anopheles sp. GAB-1 48']
+  aliases: []
   parents:
   - 63365
 2569805:
-  aliases: ['Anopheles sp. GAB-1 49']
+  aliases: []
   parents:
   - 63365
 2569806:
-  aliases: ['Anopheles sp. GAB-1 71']
+  aliases: []
   parents:
   - 63365
 2569807:
-  aliases: ['Anopheles sp. GAB-1 72']
+  aliases: []
   parents:
   - 63365
 2569808:
-  aliases: ['Anopheles sp. GAB-2 BNG3373']
+  aliases: []
   parents:
   - 63365
 2569809:
-  aliases: ['Anopheles sp. GAB-2 BNG4103']
+  aliases: []
   parents:
   - 63365
 2569810:
-  aliases: ['Anopheles sp. GAB-2 BNG5460']
+  aliases: []
   parents:
   - 63365
 2569811:
-  aliases: ['Anopheles sp. GAB-2 BNG5479']
+  aliases: []
   parents:
   - 63365
 2569812:
-  aliases: ['Anopheles sp. GAB-2 MKB21']
+  aliases: []
   parents:
   - 63365
 2569813:
-  aliases: ['Anopheles sp. GAB-2 MKB24']
+  aliases: []
   parents:
   - 63365
 2569814:
-  aliases: ['Anopheles sp. GAB-2 MKB47']
+  aliases: []
   parents:
   - 63365
 2569815:
-  aliases: ['Anopheles sp. GAB-2 MKB48']
+  aliases: []
   parents:
   - 63365
 2569816:
-  aliases: ['Anopheles sp. GAB-3 BTK50']
+  aliases: []
   parents:
   - 63365
 2267822:
-  aliases: ['Anopheles sp. GUI-KAN1']
+  aliases: []
   parents:
   - 63365
 296737:
-  aliases: ['Anopheles sp. JN03-1']
+  aliases: []
   parents:
   - 63365
 2609883:
-  aliases: ['Anopheles sp. KHH11']
+  aliases: []
   parents:
   - 63365
 2931889:
-  aliases: ['Anopheles sp. KV11']
+  aliases: []
   parents:
   - 63365
 2920257:
-  aliases: ['Anopheles sp. KV14']
+  aliases: []
   parents:
   - 63365
 2920258:
-  aliases: ['Anopheles sp. KV17']
+  aliases: []
   parents:
   - 63365
 2931890:
-  aliases: ['Anopheles sp. KV22']
+  aliases: []
   parents:
   - 63365
 2920259:
-  aliases: ['Anopheles sp. KV23']
+  aliases: []
   parents:
   - 63365
 2920262:
-  aliases: ['Anopheles sp. KV4']
+  aliases: []
   parents:
   - 63365
 2920261:
-  aliases: ['Anopheles sp. KV8']
+  aliases: []
   parents:
   - 63365
 1803712:
-  aliases: ['Anopheles sp. M36YA']
+  aliases: []
   parents:
   - 63365
 1551378:
-  aliases: ['Anopheles sp. MBI-14']
+  aliases: []
   parents:
   - 63365
 293436:
-  aliases: ['Anopheles sp. MYJ-1']
+  aliases: []
   parents:
   - 63365
 293437:
-  aliases: ['Anopheles sp. MYJ-2']
+  aliases: []
   parents:
   - 63365
 293438:
-  aliases: ['Anopheles sp. MYJ-3']
+  aliases: []
   parents:
   - 63365
 2654948:
-  aliases: ['Anopheles sp. Mali 1']
+  aliases: []
   parents:
   - 63365
 2665661:
-  aliases: ['Anopheles sp. Mm-47']
+  aliases: []
   parents:
   - 63365
 2665662:
-  aliases: ['Anopheles sp. Mm-9']
+  aliases: []
   parents:
   - 63365
 1712672:
-  aliases: ['Anopheles sp. NFL-2015']
+  aliases: []
   parents:
   - 63365
 2920260:
-  aliases: ['Anopheles sp. NG1']
+  aliases: []
   parents:
   - 63365
 2654949:
-  aliases: ['Anopheles sp. NMNH 2017-026-E05']
+  aliases: []
   parents:
   - 63365
 2267821:
-  aliases: ['Anopheles sp. O/15']
+  aliases: []
   parents:
   - 63365
 356795:
-  aliases: ['Anopheles sp. P40']
+  aliases: []
   parents:
   - 63365
 98337:
-  aliases: ['Anopheles sp. RGS-1']
+  aliases: []
   parents:
   - 63365
 98338:
-  aliases: ['Anopheles sp. RGS-2']
+  aliases: []
   parents:
   - 63365
 98339:
-  aliases: ['Anopheles sp. RGS-3']
+  aliases: []
   parents:
   - 63365
 98340:
-  aliases: ['Anopheles sp. RGS-4']
+  aliases: []
   parents:
   - 63365
 2588643:
-  aliases: ['Anopheles sp. RP-2019-1']
+  aliases: []
   parents:
   - 63365
 2588644:
-  aliases: ['Anopheles sp. RP-2019-2']
+  aliases: []
   parents:
   - 63365
 696724:
-  aliases: ['Anopheles sp. SMMU-f3']
+  aliases: []
   parents:
   - 63365
 696722:
-  aliases: ['Anopheles sp. SMMU-flp1']
+  aliases: []
   parents:
   - 63365
 696723:
-  aliases: ['Anopheles sp. SMMU-jp3']
+  aliases: []
   parents:
   - 63365
 2500423:
-  aliases: ['Anopheles sp. SMRU:METF 54758']
+  aliases: []
   parents:
   - 63365
 2500180:
-  aliases: ['Anopheles sp. SMRU:METF 54764']
+  aliases: []
   parents:
   - 63365
 2500181:
-  aliases: ['Anopheles sp. SMRU:METF 54766']
+  aliases: []
   parents:
   - 63365
 2500182:
-  aliases: ['Anopheles sp. SMRU:METF 54819']
+  aliases: []
   parents:
   - 63365
 2500183:
-  aliases: ['Anopheles sp. SMRU:METF 54825']
+  aliases: []
   parents:
   - 63365
 2500424:
-  aliases: ['Anopheles sp. SMRU:METF 54828']
+  aliases: []
   parents:
   - 63365
 2500184:
-  aliases: ['Anopheles sp. SMRU:METF 54830']
+  aliases: []
   parents:
   - 63365
 2500185:
-  aliases: ['Anopheles sp. SMRU:METF 54924']
+  aliases: []
   parents:
   - 63365
 2500186:
-  aliases: ['Anopheles sp. SMRU:METF 54960']
+  aliases: []
   parents:
   - 63365
 2500187:
-  aliases: ['Anopheles sp. SMRU:METF 54978']
+  aliases: []
   parents:
   - 63365
 2500188:
-  aliases: ['Anopheles sp. SMRU:METF 54995']
+  aliases: []
   parents:
   - 63365
 2500189:
-  aliases: ['Anopheles sp. SMRU:METF 55018']
+  aliases: []
   parents:
   - 63365
 2500190:
-  aliases: ['Anopheles sp. SMRU:METF 55128']
+  aliases: []
   parents:
   - 63365
 2500191:
-  aliases: ['Anopheles sp. SMRU:METF 55157']
+  aliases: []
   parents:
   - 63365
 2500192:
-  aliases: ['Anopheles sp. SMRU:METF 55260']
+  aliases: []
   parents:
   - 63365
 2500193:
-  aliases: ['Anopheles sp. SMRU:METF 55284']
+  aliases: []
   parents:
   - 63365
 2500194:
-  aliases: ['Anopheles sp. SMRU:METF 55341']
+  aliases: []
   parents:
   - 63365
 2500195:
-  aliases: ['Anopheles sp. SMRU:METF 55344']
+  aliases: []
   parents:
   - 63365
 2500425:
-  aliases: ['Anopheles sp. SMRU:METF 55366']
+  aliases: []
   parents:
   - 63365
 2500426:
-  aliases: ['Anopheles sp. SMRU:METF 55375']
+  aliases: []
   parents:
   - 63365
 2500444:
-  aliases: ['Anopheles sp. SMRU:METF 55378']
+  aliases: []
   parents:
   - 63365
 2500196:
-  aliases: ['Anopheles sp. SMRU:METF 55384']
+  aliases: []
   parents:
   - 63365
 2500197:
-  aliases: ['Anopheles sp. SMRU:METF 55386']
+  aliases: []
   parents:
   - 63365
 2500445:
-  aliases: ['Anopheles sp. SMRU:METF 55418']
+  aliases: []
   parents:
   - 63365
 2500198:
-  aliases: ['Anopheles sp. SMRU:METF 55454']
+  aliases: []
   parents:
   - 63365
 2500199:
-  aliases: ['Anopheles sp. SMRU:METF 55457']
+  aliases: []
   parents:
   - 63365
 2500427:
-  aliases: ['Anopheles sp. SMRU:METF 55669']
+  aliases: []
   parents:
   - 63365
 2500200:
-  aliases: ['Anopheles sp. SMRU:METF 55753']
+  aliases: []
   parents:
   - 63365
 2500201:
-  aliases: ['Anopheles sp. SMRU:METF 55800']
+  aliases: []
   parents:
   - 63365
 2500202:
-  aliases: ['Anopheles sp. SMRU:METF 55803']
+  aliases: []
   parents:
   - 63365
 2500203:
-  aliases: ['Anopheles sp. SMRU:METF 55805']
+  aliases: []
   parents:
   - 63365
 2500446:
-  aliases: ['Anopheles sp. SMRU:METF 55816']
+  aliases: []
   parents:
   - 63365
 2500428:
-  aliases: ['Anopheles sp. SMRU:METF 55819']
+  aliases: []
   parents:
   - 63365
 2500204:
-  aliases: ['Anopheles sp. SMRU:METF 55824']
+  aliases: []
   parents:
   - 63365
 2500447:
-  aliases: ['Anopheles sp. SMRU:METF 55900']
+  aliases: []
   parents:
   - 63365
 2500448:
-  aliases: ['Anopheles sp. SMRU:METF 56034']
+  aliases: []
   parents:
   - 63365
 2500429:
-  aliases: ['Anopheles sp. SMRU:METF 56038']
+  aliases: []
   parents:
   - 63365
 2500205:
-  aliases: ['Anopheles sp. SMRU:METF 56041']
+  aliases: []
   parents:
   - 63365
 2500206:
-  aliases: ['Anopheles sp. SMRU:METF 56149']
+  aliases: []
   parents:
   - 63365
 2500207:
-  aliases: ['Anopheles sp. SMRU:METF 56175']
+  aliases: []
   parents:
   - 63365
 2500449:
-  aliases: ['Anopheles sp. SMRU:METF 56276']
+  aliases: []
   parents:
   - 63365
 2500208:
-  aliases: ['Anopheles sp. SMRU:METF 56283']
+  aliases: []
   parents:
   - 63365
 2500209:
-  aliases: ['Anopheles sp. SMRU:METF 56301']
+  aliases: []
   parents:
   - 63365
 2500210:
-  aliases: ['Anopheles sp. SMRU:METF 56302']
+  aliases: []
   parents:
   - 63365
 2500211:
-  aliases: ['Anopheles sp. SMRU:METF 56303']
+  aliases: []
   parents:
   - 63365
 2500212:
-  aliases: ['Anopheles sp. SMRU:METF 56305']
+  aliases: []
   parents:
   - 63365
 2500213:
-  aliases: ['Anopheles sp. SMRU:METF 56308']
+  aliases: []
   parents:
   - 63365
 2500214:
-  aliases: ['Anopheles sp. SMRU:METF 56311']
+  aliases: []
   parents:
   - 63365
 2500450:
-  aliases: ['Anopheles sp. SMRU:METF 56329']
+  aliases: []
   parents:
   - 63365
 2500215:
-  aliases: ['Anopheles sp. SMRU:METF 56345']
+  aliases: []
   parents:
   - 63365
 2500216:
-  aliases: ['Anopheles sp. SMRU:METF 56586']
+  aliases: []
   parents:
   - 63365
 2500451:
-  aliases: ['Anopheles sp. SMRU:METF 56604']
+  aliases: []
   parents:
   - 63365
 2500217:
-  aliases: ['Anopheles sp. SMRU:METF 56608']
+  aliases: []
   parents:
   - 63365
 2500218:
-  aliases: ['Anopheles sp. SMRU:METF 56617']
+  aliases: []
   parents:
   - 63365
 2500430:
-  aliases: ['Anopheles sp. SMRU:METF 56631']
+  aliases: []
   parents:
   - 63365
 2500452:
-  aliases: ['Anopheles sp. SMRU:METF 56977']
+  aliases: []
   parents:
   - 63365
 2500219:
-  aliases: ['Anopheles sp. SMRU:METF 56981']
+  aliases: []
   parents:
   - 63365
 2500220:
-  aliases: ['Anopheles sp. SMRU:METF 56990']
+  aliases: []
   parents:
   - 63365
 2500453:
-  aliases: ['Anopheles sp. SMRU:METF 56991']
+  aliases: []
   parents:
   - 63365
 2500221:
-  aliases: ['Anopheles sp. SMRU:METF 56993']
+  aliases: []
   parents:
   - 63365
 2500222:
-  aliases: ['Anopheles sp. SMRU:METF 56996']
+  aliases: []
   parents:
   - 63365
 2500454:
-  aliases: ['Anopheles sp. SMRU:METF 57029']
+  aliases: []
   parents:
   - 63365
 2500223:
-  aliases: ['Anopheles sp. SMRU:METF 57051']
+  aliases: []
   parents:
   - 63365
 2500455:
-  aliases: ['Anopheles sp. SMRU:METF 57055']
+  aliases: []
   parents:
   - 63365
 2500456:
-  aliases: ['Anopheles sp. SMRU:METF 57058']
+  aliases: []
   parents:
   - 63365
 2500224:
-  aliases: ['Anopheles sp. SMRU:METF 57223']
+  aliases: []
   parents:
   - 63365
 2500225:
-  aliases: ['Anopheles sp. SMRU:METF 57227']
+  aliases: []
   parents:
   - 63365
 2500226:
-  aliases: ['Anopheles sp. SMRU:METF 57234']
+  aliases: []
   parents:
   - 63365
 2500457:
-  aliases: ['Anopheles sp. SMRU:METF 57272']
+  aliases: []
   parents:
   - 63365
 2500227:
-  aliases: ['Anopheles sp. SMRU:METF 57427']
+  aliases: []
   parents:
   - 63365
 2500228:
-  aliases: ['Anopheles sp. SMRU:METF 57439']
+  aliases: []
   parents:
   - 63365
 2500229:
-  aliases: ['Anopheles sp. SMRU:METF 57480']
+  aliases: []
   parents:
   - 63365
 2500458:
-  aliases: ['Anopheles sp. SMRU:METF 57488']
+  aliases: []
   parents:
   - 63365
 2500230:
-  aliases: ['Anopheles sp. SMRU:METF 57492']
+  aliases: []
   parents:
   - 63365
 2500459:
-  aliases: ['Anopheles sp. SMRU:METF 57597']
+  aliases: []
   parents:
   - 63365
 2500231:
-  aliases: ['Anopheles sp. SMRU:METF 57604']
+  aliases: []
   parents:
   - 63365
 2500232:
-  aliases: ['Anopheles sp. SMRU:METF 57607']
+  aliases: []
   parents:
   - 63365
 2500233:
-  aliases: ['Anopheles sp. SMRU:METF 57642']
+  aliases: []
   parents:
   - 63365
 2500234:
-  aliases: ['Anopheles sp. SMRU:METF 57655']
+  aliases: []
   parents:
   - 63365
 2500460:
-  aliases: ['Anopheles sp. SMRU:METF 57703']
+  aliases: []
   parents:
   - 63365
 2500235:
-  aliases: ['Anopheles sp. SMRU:METF 57704']
+  aliases: []
   parents:
   - 63365
 2500236:
-  aliases: ['Anopheles sp. SMRU:METF 57710']
+  aliases: []
   parents:
   - 63365
 2500237:
-  aliases: ['Anopheles sp. SMRU:METF 57713']
+  aliases: []
   parents:
   - 63365
 2500238:
-  aliases: ['Anopheles sp. SMRU:METF 57714']
+  aliases: []
   parents:
   - 63365
 2500461:
-  aliases: ['Anopheles sp. SMRU:METF 57717']
+  aliases: []
   parents:
   - 63365
 2500462:
-  aliases: ['Anopheles sp. SMRU:METF 57718']
+  aliases: []
   parents:
   - 63365
 2500463:
-  aliases: ['Anopheles sp. SMRU:METF 57719']
+  aliases: []
   parents:
   - 63365
 2500239:
-  aliases: ['Anopheles sp. SMRU:METF 57720']
+  aliases: []
   parents:
   - 63365
 2500240:
-  aliases: ['Anopheles sp. SMRU:METF 57731']
+  aliases: []
   parents:
   - 63365
 2500464:
-  aliases: ['Anopheles sp. SMRU:METF 57737']
+  aliases: []
   parents:
   - 63365
 2500241:
-  aliases: ['Anopheles sp. SMRU:METF 57738']
+  aliases: []
   parents:
   - 63365
 2500465:
-  aliases: ['Anopheles sp. SMRU:METF 57949']
+  aliases: []
   parents:
   - 63365
 2500242:
-  aliases: ['Anopheles sp. SMRU:METF 57950']
+  aliases: []
   parents:
   - 63365
 2500243:
-  aliases: ['Anopheles sp. SMRU:METF 57952']
+  aliases: []
   parents:
   - 63365
 2500244:
-  aliases: ['Anopheles sp. SMRU:METF 57953']
+  aliases: []
   parents:
   - 63365
 2500245:
-  aliases: ['Anopheles sp. SMRU:METF 57955']
+  aliases: []
   parents:
   - 63365
 2500246:
-  aliases: ['Anopheles sp. SMRU:METF 57963']
+  aliases: []
   parents:
   - 63365
 2500247:
-  aliases: ['Anopheles sp. SMRU:METF 57964']
+  aliases: []
   parents:
   - 63365
 2500248:
-  aliases: ['Anopheles sp. SMRU:METF 57970']
+  aliases: []
   parents:
   - 63365
 2500249:
-  aliases: ['Anopheles sp. SMRU:METF 57975']
+  aliases: []
   parents:
   - 63365
 2500250:
-  aliases: ['Anopheles sp. SMRU:METF 58254']
+  aliases: []
   parents:
   - 63365
 2500251:
-  aliases: ['Anopheles sp. SMRU:METF 58255']
+  aliases: []
   parents:
   - 63365
 2500252:
-  aliases: ['Anopheles sp. SMRU:METF 58256']
+  aliases: []
   parents:
   - 63365
 2500466:
-  aliases: ['Anopheles sp. SMRU:METF 58261']
+  aliases: []
   parents:
   - 63365
 2500253:
-  aliases: ['Anopheles sp. SMRU:METF 58264']
+  aliases: []
   parents:
   - 63365
 2500467:
-  aliases: ['Anopheles sp. SMRU:METF 58265']
+  aliases: []
   parents:
   - 63365
 2500254:
-  aliases: ['Anopheles sp. SMRU:METF 58266']
+  aliases: []
   parents:
   - 63365
 2500255:
-  aliases: ['Anopheles sp. SMRU:METF 58267']
+  aliases: []
   parents:
   - 63365
 2500256:
-  aliases: ['Anopheles sp. SMRU:METF 58268']
+  aliases: []
   parents:
   - 63365
 2500468:
-  aliases: ['Anopheles sp. SMRU:METF 58270']
+  aliases: []
   parents:
   - 63365
 2500257:
-  aliases: ['Anopheles sp. SMRU:METF 58273']
+  aliases: []
   parents:
   - 63365
 2500258:
-  aliases: ['Anopheles sp. SMRU:METF 58274']
+  aliases: []
   parents:
   - 63365
 2500469:
-  aliases: ['Anopheles sp. SMRU:METF 58278']
+  aliases: []
   parents:
   - 63365
 2500259:
-  aliases: ['Anopheles sp. SMRU:METF 58279']
+  aliases: []
   parents:
   - 63365
 2500260:
-  aliases: ['Anopheles sp. SMRU:METF 58280']
+  aliases: []
   parents:
   - 63365
 2500261:
-  aliases: ['Anopheles sp. SMRU:METF 58466']
+  aliases: []
   parents:
   - 63365
 2500470:
-  aliases: ['Anopheles sp. SMRU:METF 58473']
+  aliases: []
   parents:
   - 63365
 2500471:
-  aliases: ['Anopheles sp. SMRU:METF 58474']
+  aliases: []
   parents:
   - 63365
 2500262:
-  aliases: ['Anopheles sp. SMRU:METF 58478']
+  aliases: []
   parents:
   - 63365
 2500263:
-  aliases: ['Anopheles sp. SMRU:METF 58483']
+  aliases: []
   parents:
   - 63365
 2500431:
-  aliases: ['Anopheles sp. SMRU:METF 58511']
+  aliases: []
   parents:
   - 63365
 2500472:
-  aliases: ['Anopheles sp. SMRU:METF 58513']
+  aliases: []
   parents:
   - 63365
 2500473:
-  aliases: ['Anopheles sp. SMRU:METF 58514']
+  aliases: []
   parents:
   - 63365
 2500264:
-  aliases: ['Anopheles sp. SMRU:METF 58519']
+  aliases: []
   parents:
   - 63365
 2500474:
-  aliases: ['Anopheles sp. SMRU:METF 58527']
+  aliases: []
   parents:
   - 63365
 2500265:
-  aliases: ['Anopheles sp. SMRU:METF 58611']
+  aliases: []
   parents:
   - 63365
 2500432:
-  aliases: ['Anopheles sp. SMRU:METF 58614']
+  aliases: []
   parents:
   - 63365
 2500266:
-  aliases: ['Anopheles sp. SMRU:METF 58625']
+  aliases: []
   parents:
   - 63365
 2500475:
-  aliases: ['Anopheles sp. SMRU:METF 58632']
+  aliases: []
   parents:
   - 63365
 2500476:
-  aliases: ['Anopheles sp. SMRU:METF 58642']
+  aliases: []
   parents:
   - 63365
 2500477:
-  aliases: ['Anopheles sp. SMRU:METF 58643']
+  aliases: []
   parents:
   - 63365
 2500478:
-  aliases: ['Anopheles sp. SMRU:METF 58644']
+  aliases: []
   parents:
   - 63365
 2500479:
-  aliases: ['Anopheles sp. SMRU:METF 58653']
+  aliases: []
   parents:
   - 63365
 2500267:
-  aliases: ['Anopheles sp. SMRU:METF 58668']
+  aliases: []
   parents:
   - 63365
 2500433:
-  aliases: ['Anopheles sp. SMRU:METF 58819']
+  aliases: []
   parents:
   - 63365
 2500480:
-  aliases: ['Anopheles sp. SMRU:METF 58837']
+  aliases: []
   parents:
   - 63365
 2500481:
-  aliases: ['Anopheles sp. SMRU:METF 58846']
+  aliases: []
   parents:
   - 63365
 2500482:
-  aliases: ['Anopheles sp. SMRU:METF 58854']
+  aliases: []
   parents:
   - 63365
 2500483:
-  aliases: ['Anopheles sp. SMRU:METF 58859']
+  aliases: []
   parents:
   - 63365
 2500268:
-  aliases: ['Anopheles sp. SMRU:METF 58961']
+  aliases: []
   parents:
   - 63365
 2500269:
-  aliases: ['Anopheles sp. SMRU:METF 58966']
+  aliases: []
   parents:
   - 63365
 2500270:
-  aliases: ['Anopheles sp. SMRU:METF 58985']
+  aliases: []
   parents:
   - 63365
 2500271:
-  aliases: ['Anopheles sp. SMRU:METF 58986']
+  aliases: []
   parents:
   - 63365
 2500272:
-  aliases: ['Anopheles sp. SMRU:METF 59015']
+  aliases: []
   parents:
   - 63365
 2500273:
-  aliases: ['Anopheles sp. SMRU:METF 59017']
+  aliases: []
   parents:
   - 63365
 2500274:
-  aliases: ['Anopheles sp. SMRU:METF 59020']
+  aliases: []
   parents:
   - 63365
 2500275:
-  aliases: ['Anopheles sp. SMRU:METF 59026']
+  aliases: []
   parents:
   - 63365
 2500276:
-  aliases: ['Anopheles sp. SMRU:METF 59028']
+  aliases: []
   parents:
   - 63365
 2500277:
-  aliases: ['Anopheles sp. SMRU:METF 59038']
+  aliases: []
   parents:
   - 63365
 2500278:
-  aliases: ['Anopheles sp. SMRU:METF 59046']
+  aliases: []
   parents:
   - 63365
 2500279:
-  aliases: ['Anopheles sp. SMRU:METF 59048']
+  aliases: []
   parents:
   - 63365
 2500280:
-  aliases: ['Anopheles sp. SMRU:METF 59106']
+  aliases: []
   parents:
   - 63365
 2500281:
-  aliases: ['Anopheles sp. SMRU:METF 59130']
+  aliases: []
   parents:
   - 63365
 2500282:
-  aliases: ['Anopheles sp. SMRU:METF 59154']
+  aliases: []
   parents:
   - 63365
 2500283:
-  aliases: ['Anopheles sp. SMRU:METF 59156']
+  aliases: []
   parents:
   - 63365
 2500284:
-  aliases: ['Anopheles sp. SMRU:METF 59161']
+  aliases: []
   parents:
   - 63365
 2500285:
-  aliases: ['Anopheles sp. SMRU:METF 59164']
+  aliases: []
   parents:
   - 63365
 2500286:
-  aliases: ['Anopheles sp. SMRU:METF 59264']
+  aliases: []
   parents:
   - 63365
 2500287:
-  aliases: ['Anopheles sp. SMRU:METF 59266']
+  aliases: []
   parents:
   - 63365
 2500288:
-  aliases: ['Anopheles sp. SMRU:METF 59270']
+  aliases: []
   parents:
   - 63365
 2500289:
-  aliases: ['Anopheles sp. SMRU:METF 59272']
+  aliases: []
   parents:
   - 63365
 2500290:
-  aliases: ['Anopheles sp. SMRU:METF 59288']
+  aliases: []
   parents:
   - 63365
 2500484:
-  aliases: ['Anopheles sp. SMRU:METF 59319']
+  aliases: []
   parents:
   - 63365
 2500291:
-  aliases: ['Anopheles sp. SMRU:METF 59378']
+  aliases: []
   parents:
   - 63365
 2500292:
-  aliases: ['Anopheles sp. SMRU:METF 59380']
+  aliases: []
   parents:
   - 63365
 2500293:
-  aliases: ['Anopheles sp. SMRU:METF 59395']
+  aliases: []
   parents:
   - 63365
 2500485:
-  aliases: ['Anopheles sp. SMRU:METF 59398']
+  aliases: []
   parents:
   - 63365
 2500294:
-  aliases: ['Anopheles sp. SMRU:METF 59406']
+  aliases: []
   parents:
   - 63365
 2500295:
-  aliases: ['Anopheles sp. SMRU:METF 59426']
+  aliases: []
   parents:
   - 63365
 2500296:
-  aliases: ['Anopheles sp. SMRU:METF 59429']
+  aliases: []
   parents:
   - 63365
 2500297:
-  aliases: ['Anopheles sp. SMRU:METF 59432']
+  aliases: []
   parents:
   - 63365
 2500298:
-  aliases: ['Anopheles sp. SMRU:METF 59535']
+  aliases: []
   parents:
   - 63365
 2500299:
-  aliases: ['Anopheles sp. SMRU:METF 59542']
+  aliases: []
   parents:
   - 63365
 2500300:
-  aliases: ['Anopheles sp. SMRU:METF 59556']
+  aliases: []
   parents:
   - 63365
 2500301:
-  aliases: ['Anopheles sp. SMRU:METF 59567']
+  aliases: []
   parents:
   - 63365
 2500302:
-  aliases: ['Anopheles sp. SMRU:METF 59570']
+  aliases: []
   parents:
   - 63365
 2500303:
-  aliases: ['Anopheles sp. SMRU:METF 59674']
+  aliases: []
   parents:
   - 63365
 2500304:
-  aliases: ['Anopheles sp. SMRU:METF 59675']
+  aliases: []
   parents:
   - 63365
 2500305:
-  aliases: ['Anopheles sp. SMRU:METF 59683']
+  aliases: []
   parents:
   - 63365
 2500306:
-  aliases: ['Anopheles sp. SMRU:METF 59684']
+  aliases: []
   parents:
   - 63365
 2500307:
-  aliases: ['Anopheles sp. SMRU:METF 59685']
+  aliases: []
   parents:
   - 63365
 2500308:
-  aliases: ['Anopheles sp. SMRU:METF 59686']
+  aliases: []
   parents:
   - 63365
 2500309:
-  aliases: ['Anopheles sp. SMRU:METF 59706']
+  aliases: []
   parents:
   - 63365
 2500310:
-  aliases: ['Anopheles sp. SMRU:METF 59707']
+  aliases: []
   parents:
   - 63365
 2500434:
-  aliases: ['Anopheles sp. SMRU:METF 59838']
+  aliases: []
   parents:
   - 63365
 2500311:
-  aliases: ['Anopheles sp. SMRU:METF 59846']
+  aliases: []
   parents:
   - 63365
 2500312:
-  aliases: ['Anopheles sp. SMRU:METF 59886']
+  aliases: []
   parents:
   - 63365
 2500313:
-  aliases: ['Anopheles sp. SMRU:METF 59896']
+  aliases: []
   parents:
   - 63365
 2500314:
-  aliases: ['Anopheles sp. SMRU:METF 59898']
+  aliases: []
   parents:
   - 63365
 2500315:
-  aliases: ['Anopheles sp. SMRU:METF 59899']
+  aliases: []
   parents:
   - 63365
 2500316:
-  aliases: ['Anopheles sp. SMRU:METF 59902']
+  aliases: []
   parents:
   - 63365
 2500317:
-  aliases: ['Anopheles sp. SMRU:METF 59904']
+  aliases: []
   parents:
   - 63365
 2500486:
-  aliases: ['Anopheles sp. SMRU:METF 60126']
+  aliases: []
   parents:
   - 63365
 2500318:
-  aliases: ['Anopheles sp. SMRU:METF 60135']
+  aliases: []
   parents:
   - 63365
 2500319:
-  aliases: ['Anopheles sp. SMRU:METF 60136']
+  aliases: []
   parents:
   - 63365
 2500320:
-  aliases: ['Anopheles sp. SMRU:METF 60139']
+  aliases: []
   parents:
   - 63365
 2500321:
-  aliases: ['Anopheles sp. SMRU:METF 60142']
+  aliases: []
   parents:
   - 63365
 2500322:
-  aliases: ['Anopheles sp. SMRU:METF 60201']
+  aliases: []
   parents:
   - 63365
 2500323:
-  aliases: ['Anopheles sp. SMRU:METF 60203']
+  aliases: []
   parents:
   - 63365
 2500324:
-  aliases: ['Anopheles sp. SMRU:METF 60210']
+  aliases: []
   parents:
   - 63365
 2500325:
-  aliases: ['Anopheles sp. SMRU:METF 60224']
+  aliases: []
   parents:
   - 63365
 2500326:
-  aliases: ['Anopheles sp. SMRU:METF 60654']
+  aliases: []
   parents:
   - 63365
 2500327:
-  aliases: ['Anopheles sp. SMRU:METF 60682']
+  aliases: []
   parents:
   - 63365
 2500487:
-  aliases: ['Anopheles sp. SMRU:METF 60710']
+  aliases: []
   parents:
   - 63365
 2500328:
-  aliases: ['Anopheles sp. SMRU:METF 60721']
+  aliases: []
   parents:
   - 63365
 2500329:
-  aliases: ['Anopheles sp. SMRU:METF 60723']
+  aliases: []
   parents:
   - 63365
 2500330:
-  aliases: ['Anopheles sp. SMRU:METF 60724']
+  aliases: []
   parents:
   - 63365
 2500331:
-  aliases: ['Anopheles sp. SMRU:METF 60761']
+  aliases: []
   parents:
   - 63365
 2500332:
-  aliases: ['Anopheles sp. SMRU:METF 60763']
+  aliases: []
   parents:
   - 63365
 2500488:
-  aliases: ['Anopheles sp. SMRU:METF 60958']
+  aliases: []
   parents:
   - 63365
 2500333:
-  aliases: ['Anopheles sp. SMRU:METF 61004']
+  aliases: []
   parents:
   - 63365
 2500334:
-  aliases: ['Anopheles sp. SMRU:METF 61013']
+  aliases: []
   parents:
   - 63365
 2500489:
-  aliases: ['Anopheles sp. SMRU:METF 61033']
+  aliases: []
   parents:
   - 63365
 2500335:
-  aliases: ['Anopheles sp. SMRU:METF 61240']
+  aliases: []
   parents:
   - 63365
 2500336:
-  aliases: ['Anopheles sp. SMRU:METF 61266']
+  aliases: []
   parents:
   - 63365
 2500337:
-  aliases: ['Anopheles sp. SMRU:METF 61284']
+  aliases: []
   parents:
   - 63365
 2500338:
-  aliases: ['Anopheles sp. SMRU:METF 61319']
+  aliases: []
   parents:
   - 63365
 2500339:
-  aliases: ['Anopheles sp. SMRU:METF 61320']
+  aliases: []
   parents:
   - 63365
 2500340:
-  aliases: ['Anopheles sp. SMRU:METF 61321']
+  aliases: []
   parents:
   - 63365
 2500490:
-  aliases: ['Anopheles sp. SMRU:METF 61322']
+  aliases: []
   parents:
   - 63365
 2500491:
-  aliases: ['Anopheles sp. SMRU:METF 61375']
+  aliases: []
   parents:
   - 63365
 2500341:
-  aliases: ['Anopheles sp. SMRU:METF 61387']
+  aliases: []
   parents:
   - 63365
 2500492:
-  aliases: ['Anopheles sp. SMRU:METF 61444']
+  aliases: []
   parents:
   - 63365
 2500493:
-  aliases: ['Anopheles sp. SMRU:METF 61561']
+  aliases: []
   parents:
   - 63365
 2500342:
-  aliases: ['Anopheles sp. SMRU:METF 61581']
+  aliases: []
   parents:
   - 63365
 2500435:
-  aliases: ['Anopheles sp. SMRU:METF 61588']
+  aliases: []
   parents:
   - 63365
 2500343:
-  aliases: ['Anopheles sp. SMRU:METF 61597']
+  aliases: []
   parents:
   - 63365
 2500494:
-  aliases: ['Anopheles sp. SMRU:METF 61891']
+  aliases: []
   parents:
   - 63365
 2500344:
-  aliases: ['Anopheles sp. SMRU:METF 61905']
+  aliases: []
   parents:
   - 63365
 2500345:
-  aliases: ['Anopheles sp. SMRU:METF 61954']
+  aliases: []
   parents:
   - 63365
 2500495:
-  aliases: ['Anopheles sp. SMRU:METF 62048']
+  aliases: []
   parents:
   - 63365
 2500346:
-  aliases: ['Anopheles sp. SMRU:METF 62103']
+  aliases: []
   parents:
   - 63365
 2500496:
-  aliases: ['Anopheles sp. SMRU:METF 62119']
+  aliases: []
   parents:
   - 63365
 2500436:
-  aliases: ['Anopheles sp. SMRU:METF 62213']
+  aliases: []
   parents:
   - 63365
 2500497:
-  aliases: ['Anopheles sp. SMRU:METF 62697']
+  aliases: []
   parents:
   - 63365
 2500437:
-  aliases: ['Anopheles sp. SMRU:METF 62741']
+  aliases: []
   parents:
   - 63365
 2500347:
-  aliases: ['Anopheles sp. SMRU:METF 62798']
+  aliases: []
   parents:
   - 63365
 2500498:
-  aliases: ['Anopheles sp. SMRU:METF 62819']
+  aliases: []
   parents:
   - 63365
 2500348:
-  aliases: ['Anopheles sp. SMRU:METF 63084']
+  aliases: []
   parents:
   - 63365
 2500349:
-  aliases: ['Anopheles sp. SMRU:METF 63092']
+  aliases: []
   parents:
   - 63365
 2500350:
-  aliases: ['Anopheles sp. SMRU:METF 63383']
+  aliases: []
   parents:
   - 63365
 2500351:
-  aliases: ['Anopheles sp. SMRU:METF 63384']
+  aliases: []
   parents:
   - 63365
 2500352:
-  aliases: ['Anopheles sp. SMRU:METF 63386']
+  aliases: []
   parents:
   - 63365
 2500353:
-  aliases: ['Anopheles sp. SMRU:METF 63392']
+  aliases: []
   parents:
   - 63365
 2500354:
-  aliases: ['Anopheles sp. SMRU:METF 63393']
+  aliases: []
   parents:
   - 63365
 2500355:
-  aliases: ['Anopheles sp. SMRU:METF 63399']
+  aliases: []
   parents:
   - 63365
 2500356:
-  aliases: ['Anopheles sp. SMRU:METF 63403']
+  aliases: []
   parents:
   - 63365
 2500499:
-  aliases: ['Anopheles sp. SMRU:METF 63411']
+  aliases: []
   parents:
   - 63365
 2500357:
-  aliases: ['Anopheles sp. SMRU:METF 63412']
+  aliases: []
   parents:
   - 63365
 2500358:
-  aliases: ['Anopheles sp. SMRU:METF 63414']
+  aliases: []
   parents:
   - 63365
 2500359:
-  aliases: ['Anopheles sp. SMRU:METF 63416']
+  aliases: []
   parents:
   - 63365
 2500360:
-  aliases: ['Anopheles sp. SMRU:METF 63423']
+  aliases: []
   parents:
   - 63365
 2500438:
-  aliases: ['Anopheles sp. SMRU:METF 63429']
+  aliases: []
   parents:
   - 63365
 2500500:
-  aliases: ['Anopheles sp. SMRU:METF 63440']
+  aliases: []
   parents:
   - 63365
 2500501:
-  aliases: ['Anopheles sp. SMRU:METF 63443']
+  aliases: []
   parents:
   - 63365
 2500361:
-  aliases: ['Anopheles sp. SMRU:METF 63464']
+  aliases: []
   parents:
   - 63365
 2500502:
-  aliases: ['Anopheles sp. SMRU:METF 63504']
+  aliases: []
   parents:
   - 63365
 2500362:
-  aliases: ['Anopheles sp. SMRU:METF 63511']
+  aliases: []
   parents:
   - 63365
 2500363:
-  aliases: ['Anopheles sp. SMRU:METF 63516']
+  aliases: []
   parents:
   - 63365
 2500503:
-  aliases: ['Anopheles sp. SMRU:METF 63522']
+  aliases: []
   parents:
   - 63365
 2500364:
-  aliases: ['Anopheles sp. SMRU:METF 63642']
+  aliases: []
   parents:
   - 63365
 2500365:
-  aliases: ['Anopheles sp. SMRU:METF 63654']
+  aliases: []
   parents:
   - 63365
 2500366:
-  aliases: ['Anopheles sp. SMRU:METF 63655']
+  aliases: []
   parents:
   - 63365
 2500367:
-  aliases: ['Anopheles sp. SMRU:METF 63657']
+  aliases: []
   parents:
   - 63365
 2500368:
-  aliases: ['Anopheles sp. SMRU:METF 63658']
+  aliases: []
   parents:
   - 63365
 2500369:
-  aliases: ['Anopheles sp. SMRU:METF 63659']
+  aliases: []
   parents:
   - 63365
 2500370:
-  aliases: ['Anopheles sp. SMRU:METF 63660']
+  aliases: []
   parents:
   - 63365
 2500439:
-  aliases: ['Anopheles sp. SMRU:METF 63671']
+  aliases: []
   parents:
   - 63365
 2500504:
-  aliases: ['Anopheles sp. SMRU:METF 63691']
+  aliases: []
   parents:
   - 63365
 2500505:
-  aliases: ['Anopheles sp. SMRU:METF 63694']
+  aliases: []
   parents:
   - 63365
 2500506:
-  aliases: ['Anopheles sp. SMRU:METF 63709']
+  aliases: []
   parents:
   - 63365
 2500371:
-  aliases: ['Anopheles sp. SMRU:METF 63722']
+  aliases: []
   parents:
   - 63365
 2500372:
-  aliases: ['Anopheles sp. SMRU:METF 63925']
+  aliases: []
   parents:
   - 63365
 2500373:
-  aliases: ['Anopheles sp. SMRU:METF 63926']
+  aliases: []
   parents:
   - 63365
 2500374:
-  aliases: ['Anopheles sp. SMRU:METF 63927']
+  aliases: []
   parents:
   - 63365
 2500375:
-  aliases: ['Anopheles sp. SMRU:METF 63928']
+  aliases: []
   parents:
   - 63365
 2500376:
-  aliases: ['Anopheles sp. SMRU:METF 63929']
+  aliases: []
   parents:
   - 63365
 2500377:
-  aliases: ['Anopheles sp. SMRU:METF 63932']
+  aliases: []
   parents:
   - 63365
 2500378:
-  aliases: ['Anopheles sp. SMRU:METF 63933']
+  aliases: []
   parents:
   - 63365
 2500379:
-  aliases: ['Anopheles sp. SMRU:METF 63934']
+  aliases: []
   parents:
   - 63365
 2500380:
-  aliases: ['Anopheles sp. SMRU:METF 63938']
+  aliases: []
   parents:
   - 63365
 2500381:
-  aliases: ['Anopheles sp. SMRU:METF 63949']
+  aliases: []
   parents:
   - 63365
 2500507:
-  aliases: ['Anopheles sp. SMRU:METF 63950']
+  aliases: []
   parents:
   - 63365
 2500382:
-  aliases: ['Anopheles sp. SMRU:METF 63970']
+  aliases: []
   parents:
   - 63365
 2500383:
-  aliases: ['Anopheles sp. SMRU:METF 63972']
+  aliases: []
   parents:
   - 63365
 2500384:
-  aliases: ['Anopheles sp. SMRU:METF 63973']
+  aliases: []
   parents:
   - 63365
 2500385:
-  aliases: ['Anopheles sp. SMRU:METF 63975']
+  aliases: []
   parents:
   - 63365
 2500508:
-  aliases: ['Anopheles sp. SMRU:METF 63980']
+  aliases: []
   parents:
   - 63365
 2500386:
-  aliases: ['Anopheles sp. SMRU:METF 63992']
+  aliases: []
   parents:
   - 63365
 2500509:
-  aliases: ['Anopheles sp. SMRU:METF 64000']
+  aliases: []
   parents:
   - 63365
 2500387:
-  aliases: ['Anopheles sp. SMRU:METF 64298']
+  aliases: []
   parents:
   - 63365
 2500440:
-  aliases: ['Anopheles sp. SMRU:METF 64313']
+  aliases: []
   parents:
   - 63365
 2500510:
-  aliases: ['Anopheles sp. SMRU:METF 64315']
+  aliases: []
   parents:
   - 63365
 2500388:
-  aliases: ['Anopheles sp. SMRU:METF 64318']
+  aliases: []
   parents:
   - 63365
 2500389:
-  aliases: ['Anopheles sp. SMRU:METF 64319']
+  aliases: []
   parents:
   - 63365
 2500390:
-  aliases: ['Anopheles sp. SMRU:METF 64320']
+  aliases: []
   parents:
   - 63365
 2500391:
-  aliases: ['Anopheles sp. SMRU:METF 64321']
+  aliases: []
   parents:
   - 63365
 2500392:
-  aliases: ['Anopheles sp. SMRU:METF 64322']
+  aliases: []
   parents:
   - 63365
 2500393:
-  aliases: ['Anopheles sp. SMRU:METF 64329']
+  aliases: []
   parents:
   - 63365
 2500394:
-  aliases: ['Anopheles sp. SMRU:METF 64336']
+  aliases: []
   parents:
   - 63365
 2500511:
-  aliases: ['Anopheles sp. SMRU:METF 64471']
+  aliases: []
   parents:
   - 63365
 2500395:
-  aliases: ['Anopheles sp. SMRU:METF 64477']
+  aliases: []
   parents:
   - 63365
 2500512:
-  aliases: ['Anopheles sp. SMRU:METF 64502']
+  aliases: []
   parents:
   - 63365
 2500513:
-  aliases: ['Anopheles sp. SMRU:METF 64511']
+  aliases: []
   parents:
   - 63365
 2500396:
-  aliases: ['Anopheles sp. SMRU:METF 64541']
+  aliases: []
   parents:
   - 63365
 2500397:
-  aliases: ['Anopheles sp. SMRU:METF 64546']
+  aliases: []
   parents:
   - 63365
 2500398:
-  aliases: ['Anopheles sp. SMRU:METF 64547']
+  aliases: []
   parents:
   - 63365
 2500399:
-  aliases: ['Anopheles sp. SMRU:METF 64633']
+  aliases: []
   parents:
   - 63365
 2500400:
-  aliases: ['Anopheles sp. SMRU:METF 64634']
+  aliases: []
   parents:
   - 63365
 2500401:
-  aliases: ['Anopheles sp. SMRU:METF 64636']
+  aliases: []
   parents:
   - 63365
 2500402:
-  aliases: ['Anopheles sp. SMRU:METF 64639']
+  aliases: []
   parents:
   - 63365
 2500403:
-  aliases: ['Anopheles sp. SMRU:METF 64882']
+  aliases: []
   parents:
   - 63365
 2500404:
-  aliases: ['Anopheles sp. SMRU:METF 64889']
+  aliases: []
   parents:
   - 63365
 2500405:
-  aliases: ['Anopheles sp. SMRU:METF 64890']
+  aliases: []
   parents:
   - 63365
 2500406:
-  aliases: ['Anopheles sp. SMRU:METF 64891']
+  aliases: []
   parents:
   - 63365
 2500407:
-  aliases: ['Anopheles sp. SMRU:METF 64892']
+  aliases: []
   parents:
   - 63365
 2500514:
-  aliases: ['Anopheles sp. SMRU:METF 64901']
+  aliases: []
   parents:
   - 63365
 2500441:
-  aliases: ['Anopheles sp. SMRU:METF 64905']
+  aliases: []
   parents:
   - 63365
 2500408:
-  aliases: ['Anopheles sp. SMRU:METF 65221']
+  aliases: []
   parents:
   - 63365
 2500409:
-  aliases: ['Anopheles sp. SMRU:METF 65222']
+  aliases: []
   parents:
   - 63365
 2500410:
-  aliases: ['Anopheles sp. SMRU:METF 65224']
+  aliases: []
   parents:
   - 63365
 2500411:
-  aliases: ['Anopheles sp. SMRU:METF 65256']
+  aliases: []
   parents:
   - 63365
 2500412:
-  aliases: ['Anopheles sp. SMRU:METF 65643']
+  aliases: []
   parents:
   - 63365
 2500413:
-  aliases: ['Anopheles sp. SMRU:METF 65644']
+  aliases: []
   parents:
   - 63365
 2500414:
-  aliases: ['Anopheles sp. SMRU:METF 65646']
+  aliases: []
   parents:
   - 63365
 2500415:
-  aliases: ['Anopheles sp. SMRU:METF 65650']
+  aliases: []
   parents:
   - 63365
 2500515:
-  aliases: ['Anopheles sp. SMRU:METF 65651']
+  aliases: []
   parents:
   - 63365
 2500416:
-  aliases: ['Anopheles sp. SMRU:METF 65666']
+  aliases: []
   parents:
   - 63365
 2500417:
-  aliases: ['Anopheles sp. SMRU:METF 65944']
+  aliases: []
   parents:
   - 63365
 2500442:
-  aliases: ['Anopheles sp. SMRU:METF 65949']
+  aliases: []
   parents:
   - 63365
 2500516:
-  aliases: ['Anopheles sp. SMRU:METF 66153']
+  aliases: []
   parents:
   - 63365
 2500418:
-  aliases: ['Anopheles sp. SMRU:METF 66155']
+  aliases: []
   parents:
   - 63365
 2500419:
-  aliases: ['Anopheles sp. SMRU:METF 66157']
+  aliases: []
   parents:
   - 63365
 2500420:
-  aliases: ['Anopheles sp. SMRU:METF 66158']
+  aliases: []
   parents:
   - 63365
 2500421:
-  aliases: ['Anopheles sp. SMRU:METF 66164']
+  aliases: []
   parents:
   - 63365
 2500443:
-  aliases: ['Anopheles sp. SMRU:METF 66177']
+  aliases: []
   parents:
   - 63365
 2500422:
-  aliases: ['Anopheles sp. SMRU:METF 66199']
+  aliases: []
   parents:
   - 63365
 1576576:
-  aliases: ['Anopheles sp. SOKN050']
+  aliases: []
   parents:
   - 63365
 2746494:
-  aliases: ['Anopheles sp. TENGRELA']
+  aliases: []
   parents:
   - 63365
 1426909:
-  aliases: ['Anopheles sp. TIP1']
+  aliases: []
   parents:
   - 63365
 2326595:
-  aliases: ['Anopheles sp. TTMDJ373-10']
+  aliases: []
   parents:
   - 63365
 2499882:
-  aliases: ['Anopheles sp. UG1']
+  aliases: []
   parents:
   - 63365
 2499883:
-  aliases: ['Anopheles sp. UG2']
+  aliases: []
   parents:
   - 63365
 2499884:
-  aliases: ['Anopheles sp. UG3']
+  aliases: []
   parents:
   - 63365
 2781778:
-  aliases: ['Anopheles sp. X CLJ-2020']
+  aliases: []
   parents:
   - 63365
 2079318:
-  aliases: ['Anopheles sp. YL-2017']
+  aliases: []
   parents:
   - 63365
 234803:
-  aliases: ['Anopheles sp. YM-2003a']
+  aliases: []
   parents:
   - 63365
 283719:
-  aliases: ['Anopheles sp. YM-2003b']
+  aliases: []
   parents:
   - 63365
 283721:
-  aliases: ['Anopheles sp. YM-2003c']
+  aliases: []
   parents:
   - 63365
 2892205:
-  aliases: ['Anopheles sp. ZMUO 001712']
+  aliases: []
   parents:
   - 63365
 1199415:
-  aliases: ['Anopheles sp. clade C JRL-2012']
+  aliases: []
   parents:
   - 63365
 1199416:
-  aliases: ['Anopheles sp. clade D JRL-2012']
+  aliases: []
   parents:
   - 63365
 1199417:
-  aliases: ['Anopheles sp. clade E JRL-2012']
+  aliases: []
   parents:
   - 63365
 337524:
-  aliases: ['Anopheles sp. dg19']
+  aliases: []
   parents:
   - 63365
 337525:
-  aliases: ['Anopheles sp. dg20']
+  aliases: []
   parents:
   - 63365
 139050:
-  aliases: ['Anopheles squamifemur']
+  aliases: []
   parents:
   - 273457
 911292:
-  aliases: ['Anopheles squamosus']
+  aliases: []
   parents:
   - 44534
 2847163:
-  aliases: ['Anopheles tadei']
+  aliases: []
   parents:
   - 44543
 1141473:
-  aliases: ['Anopheles theileri']
+  aliases: []
   parents:
   - 44534
 43182:
-  aliases: ['Anopheles trinkae']
+  aliases: []
   parents:
   - 44543
 317811:
-  aliases: ['Armigeres']
+  aliases: []
   parents:
   - 124916
 346054:
-  aliases: ['Aztecaedes']
+  aliases: []
   parents:
   - 7158
 53528:
-  aliases: ['Barraudius']
+  aliases: []
   parents:
   - 7174
 2756214:
-  aliases: ['Bironella derooki']
+  aliases: []
   parents:
   - 53565
 53566:
-  aliases: ['Bironella gracilis']
+  aliases: []
   parents:
   - 53563
 59138:
-  aliases: ['Bironella hollandi']
+  aliases: []
   parents:
   - 53564
 425231:
-  aliases: ['Borichinda cavernicola']
+  aliases: []
   parents:
   - 425230
 346052:
-  aliases: ['Bothaella']
+  aliases: []
   parents:
   - 7158
 1245277:
-  aliases: ['Bruceharrisonius']
+  aliases: []
   parents:
   - 7158
 300146:
-  aliases: ['Cancraedes']
+  aliases: []
   parents:
   - 7158
 794814:
-  aliases: ['Carrollia']
+  aliases: []
   parents:
   - 7174
 2067444:
-  aliases: ['Catageiomyia argenteopunctata']
+  aliases: []
   parents:
   - 2067443
 2761508:
-  aliases: ['Catageiomyia microsticta']
+  aliases: []
   parents:
   - 2067443
 346055:
-  aliases: ['Chaetocruiomyia']
+  aliases: []
   parents:
   - 190765
 2767512:
-  aliases: ['Chagasia sp. 1 SJ-2020']
+  aliases: []
   parents:
   - 2629023
 2171937:
-  aliases: ['Chagasia sp. SP54_C']
+  aliases: []
   parents:
   - 2629023
 1285601:
-  aliases: ['Chrysoconops']
+  aliases: []
   parents:
   - 190765
 2339219:
-  aliases: ['Coetzeemyia']
+  aliases: []
   parents:
   - 7158
 706477:
-  aliases: ['Collessius hatorii']
+  aliases: []
   parents:
   - 1245380
 2900299:
-  aliases: ['Collessius macfarlanei']
+  aliases: []
   parents:
   - 1245380
 1529933:
-  aliases: ['Collessius pseudotaeniatus']
+  aliases: []
   parents:
   - 1245380
 1245336:
-  aliases: ['Collessius tonkinensis']
+  aliases: []
   parents:
   - 1245380
 464955:
-  aliases: ['Conopostegus']
+  aliases: []
   parents:
   - 7180
 1273083:
-  aliases: ['Coquillettidia albicosta']
+  aliases: []
   parents:
   - 329110
 2993644:
-  aliases: ['Coquillettidia arribalzagae']
+  aliases: []
   parents:
   - 329110
 667557:
-  aliases: ['Coquillettidia aurea']
+  aliases: []
   parents:
   - 329110
 653291:
-  aliases: ['Coquillettidia aurites']
+  aliases: []
   parents:
   - 329110
 2547966:
-  aliases: ['Coquillettidia buxtoni']
+  aliases: []
   parents:
   - 329110
 2597061:
-  aliases: ['Coquillettidia chrysonotum']
+  aliases: []
   parents:
   - 329110
 1799669:
-  aliases: ['Coquillettidia chrysosoma']
+  aliases: []
   parents:
   - 329110
 1245327:
-  aliases: ['Coquillettidia crassipes']
+  aliases: []
   parents:
   - 329110
 667558:
-  aliases: ['Coquillettidia fuscopennata']
+  aliases: []
   parents:
   - 329110
 2719870:
-  aliases: ['Coquillettidia hermanoi']
+  aliases: []
   parents:
   - 329110
 2292400:
-  aliases: ['Coquillettidia iracunda']
+  aliases: []
   parents:
   - 329110
 2719871:
-  aliases: ['Coquillettidia juxtamansonia']
+  aliases: []
   parents:
   - 329110
 1806174:
-  aliases: ['Coquillettidia linealis']
+  aliases: []
   parents:
   - 329110
 2689571:
-  aliases: ['Coquillettidia lynchi']
+  aliases: []
   parents:
   - 329110
 667559:
-  aliases: ['Coquillettidia maculipennis']
+  aliases: []
   parents:
   - 329110
 653292:
-  aliases: ['Coquillettidia metallica']
+  aliases: []
   parents:
   - 329110
 1799670:
-  aliases: ['Coquillettidia microannulata']
+  aliases: []
   parents:
   - 329110
 1257098:
-  aliases: ['Coquillettidia nigricans']
+  aliases: []
   parents:
   - 329110
 1424508:
-  aliases: ['Coquillettidia nigrosignata']
+  aliases: []
   parents:
   - 329110
 3687341:
-  aliases: ['Coquillettidia nr. linealis']
+  aliases: []
   parents:
   - 329110
 1771330:
-  aliases: ['Coquillettidia ochracea']
+  aliases: []
   parents:
   - 329110
 329111:
-  aliases: ['Coquillettidia perturbans']
+  aliases: []
   parents:
   - 329110
 1245328:
-  aliases: ['Coquillettidia richiardii']
+  aliases: []
   parents:
   - 329110
 2795833:
-  aliases: ['Coquillettidia shannoni']
+  aliases: []
   parents:
   - 329110
 2292401:
-  aliases: ['Coquillettidia tenuipalpis']
+  aliases: []
   parents:
   - 329110
 3073409:
-  aliases: ['Coquillettidia variegata']
+  aliases: []
   parents:
   - 329110
 2488822:
-  aliases: ['Coquillettidia venezuelensis']
+  aliases: []
   parents:
   - 329110
 1799671:
-  aliases: ['Coquillettidia versicolor']
+  aliases: []
   parents:
   - 329110
 569586:
-  aliases: ['Coquillettidia xanthogaster']
+  aliases: []
   parents:
   - 329110
 53527:
-  aliases: ['Culex']
+  aliases: []
   parents:
   - 7174
 2007271:
-  aliases: ['Culex incertae sedis']
+  aliases: []
   parents:
   - 7174
 53530:
-  aliases: ['Culiciomyia']
+  aliases: []
   parents:
   - 7174
 1788509:
-  aliases: ['Culiseta alaskaensis']
+  aliases: []
   parents:
   - 174825
 332058:
-  aliases: ['Culiseta annulata']
+  aliases: []
   parents:
   - 174825
 3114447:
-  aliases: ['Culiseta atra']
+  aliases: []
   parents:
   - 174825
 866104:
-  aliases: ['Culiseta bergrothi']
+  aliases: []
   parents:
   - 174825
 2517338:
-  aliases: ['Culiseta cf. subochrea/annulata Cs.s/a093LR']
+  aliases: []
   parents:
   - 174825
 2517337:
-  aliases: ['Culiseta cf. subochrea/annulata Cs.s/a93LR']
+  aliases: []
   parents:
   - 174825
 2517340:
-  aliases: ['Culiseta cf. subochrea/annulata mb30']
+  aliases: []
   parents:
   - 174825
 2517339:
-  aliases: ['Culiseta cf. subochrea/annulata mb5']
+  aliases: []
   parents:
   - 174825
 2517341:
-  aliases: ['Culiseta cf. subochrea/annulata mb58']
+  aliases: []
   parents:
   - 174825
 1538645:
-  aliases: ['Culiseta fumipennis']
+  aliases: []
   parents:
   - 174825
 2025599:
-  aliases: ['Culiseta glaphyroptera']
+  aliases: []
   parents:
   - 174825
 174826:
-  aliases: ['Culiseta impatiens']
+  aliases: []
   parents:
   - 174825
 1582038:
-  aliases: ['Culiseta incidens']
+  aliases: []
   parents:
   - 174825
 1806175:
-  aliases: ['Culiseta inconspicua']
+  aliases: []
   parents:
   - 174825
 704160:
-  aliases: ['Culiseta inornata']
+  aliases: []
   parents:
   - 174825
 2579876:
-  aliases: ['Culiseta litorea']
+  aliases: []
   parents:
   - 174825
 1206072:
-  aliases: ['Culiseta longiareolata']
+  aliases: []
   parents:
   - 174825
 329109:
-  aliases: ['Culiseta melanura']
+  aliases: []
   parents:
   - 174825
 329108:
-  aliases: ['Culiseta minnesotae']
+  aliases: []
   parents:
   - 174825
 329107:
-  aliases: ['Culiseta morsitans']
+  aliases: []
   parents:
   - 174825
 1245330:
-  aliases: ['Culiseta nipponica']
+  aliases: []
   parents:
   - 174825
 2292402:
-  aliases: ['Culiseta novaezealandiae']
+  aliases: []
   parents:
   - 174825
 1904329:
-  aliases: ['Culiseta nr. morsitans APHA-8-2015A12']
+  aliases: []
   parents:
   - 174825
 1904330:
-  aliases: ['Culiseta nr. morsitans APHA-8-2015B01']
+  aliases: []
   parents:
   - 174825
 1904328:
-  aliases: ['Culiseta nr. subochrea APHA-2-2015C11']
+  aliases: []
   parents:
   - 174825
 866105:
-  aliases: ['Culiseta ochroptera']
+  aliases: []
   parents:
   - 174825
 1206282:
-  aliases: ['Culiseta particeps']
+  aliases: []
   parents:
   - 174825
 1788510:
-  aliases: ['Culiseta subochrea']
+  aliases: []
   parents:
   - 174825
 2292403:
-  aliases: ['Culiseta tonnoiri']
+  aliases: []
   parents:
   - 174825
 2575618:
-  aliases: ['Dahliana']
+  aliases: []
   parents:
   - 7158
 1245381:
-  aliases: ['Danielsia']
+  aliases: []
   parents:
   - 7158
 1631187:
-  aliases: ['Deinocerites atlanticus']
+  aliases: []
   parents:
   - 53524
 53525:
-  aliases: ['Deinocerites cancer']
+  aliases: []
   parents:
   - 53524
 2487799:
-  aliases: ['Deinocerites magnus']
+  aliases: []
   parents:
   - 53524
 2863125:
-  aliases: ['Deinocerites pseudes']
+  aliases: []
   parents:
   - 53524
 53539:
-  aliases: ['Diceromyia']
+  aliases: []
   parents:
   - 7158
 1806171:
-  aliases: ['Dobrotworskyius']
+  aliases: []
   parents:
   - 7158
 1245382:
-  aliases: ['Downsiomyia']
+  aliases: []
   parents:
   - 7158
 300148:
-  aliases: ['Edwardsaedes']
+  aliases: []
   parents:
   - 7158
 2665659:
-  aliases: ['Eretmapodites chrysogaster']
+  aliases: []
   parents:
   - 317801
 667560:
-  aliases: ['Eretmapodites intermedius']
+  aliases: []
   parents:
   - 317801
 864620:
-  aliases: ['Eretmapodites leucopous']
+  aliases: []
   parents:
   - 317801
 2989693:
-  aliases: ['Eretmapodites plioleucus']
+  aliases: []
   parents:
   - 317801
 503352:
-  aliases: ['Eretmapodites quinquevittatus']
+  aliases: []
   parents:
   - 317801
 2907952:
-  aliases: ['Eretmapodites subsimplicipes']
+  aliases: []
   parents:
   - 317801
 308739:
-  aliases: ['Etorletiomyia']
+  aliases: []
   parents:
   - 308736
 53531:
-  aliases: ['Eumelanomyia']
+  aliases: []
   parents:
   - 7174
 308731:
-  aliases: ['Ficalbia minima']
+  aliases: []
   parents:
   - 308730
 2918766:
-  aliases: ['Ficalbia uniformis']
+  aliases: []
   parents:
   - 308730
 53542:
-  aliases: ['Finlaya']
+  aliases: []
   parents:
   - 7158
 300149:
-  aliases: ['Fredwardsius']
+  aliases: []
   parents:
   - 7158
 1866276:
-  aliases: ['Georgecraigius']
+  aliases: []
   parents:
   - 7158
 346056:
-  aliases: ['Geoskusea']
+  aliases: []
   parents:
   - 190765
 2773400:
-  aliases: ['Gilesius pulchriventer']
+  aliases: []
   parents:
   - 2773402
 346057:
-  aliases: ['Gymnometopa']
+  aliases: []
   parents:
   - 190765
 464954:
-  aliases: ['Haemagogus']
+  aliases: []
   parents:
   - 7180
 71821:
-  aliases: ['Halaedes']
+  aliases: []
   parents:
   - 190765
 317809:
-  aliases: ['Harbachius']
+  aliases: []
   parents:
   - 317805
 325437:
-  aliases: ['Heizmannia']
+  aliases: []
   parents:
   - 317799
 1245383:
-  aliases: ['Himalaius']
+  aliases: []
   parents:
   - 7158
 498391:
-  aliases: ['Hodgesia bailyi']
+  aliases: []
   parents:
   - 425228
 190766:
-  aliases: ['Howardina']
+  aliases: []
   parents:
   - 7158
 1245384:
-  aliases: ['Hulecoeteomyia']
+  aliases: []
   parents:
   - 7158
 2007254:
-  aliases: ['Johnbelkinia longipes']
+  aliases: []
   parents:
   - 2007253
 2007255:
-  aliases: ['Johnbelkinia ulopus']
+  aliases: []
   parents:
   - 2007253
 1289136:
-  aliases: ['Juppius']
+  aliases: []
   parents:
   - 190765
 346058:
-  aliases: ['Kenknightia']
+  aliases: []
   parents:
   - 190765
 2989691:
-  aliases: ['Kitzmilleria']
+  aliases: []
   parents:
   - 7174
 346059:
-  aliases: ['Kompia']
+  aliases: []
   parents:
   - 190765
 58247:
-  aliases: ['Laticorn']
+  aliases: []
   parents:
   - 44482
 317812:
-  aliases: ['Leicesteria']
+  aliases: []
   parents:
   - 124916
 3014974:
-  aliases: ['Lewnielsenius']
+  aliases: []
   parents:
   - 7158
 2872817:
-  aliases: ['Limatus asulleptus']
+  aliases: []
   parents:
   - 704164
 704165:
-  aliases: ['Limatus durhamii']
+  aliases: []
   parents:
   - 704164
 1426897:
-  aliases: ['Limatus flavisetosus']
+  aliases: []
   parents:
   - 704164
 3468594:
-  aliases: ['Limatus paraensis']
+  aliases: []
   parents:
   - 704164
 308715:
-  aliases: ['Lophoceraomyia']
+  aliases: []
   parents:
   - 7174
 300153:
-  aliases: ['Lorrainea']
+  aliases: []
   parents:
   - 7158
 1245385:
-  aliases: ['Luius']
+  aliases: []
   parents:
   - 7158
 1426898:
-  aliases: ['Lutzia allostigma']
+  aliases: []
   parents:
   - 53533
 707284:
-  aliases: ['Lutzia bigoti']
+  aliases: []
   parents:
   - 53533
 2502097:
-  aliases: ['Lutzia chiangmaiensis']
+  aliases: []
   parents:
   - 53533
 308712:
-  aliases: ['Lutzia fuscana']
+  aliases: []
   parents:
   - 53533
 1245329:
-  aliases: ['Lutzia halifaxii']
+  aliases: []
   parents:
   - 53533
 2730086:
-  aliases: ['Lutzia shinonagai']
+  aliases: []
   parents:
   - 53533
 42432:
-  aliases: ['Lutzia tigripes']
+  aliases: []
   parents:
   - 53533
 1652497:
-  aliases: ['Lutzia vorax']
+  aliases: []
   parents:
   - 53533
 346061:
-  aliases: ['Macleaya']
+  aliases: []
   parents:
   - 7158
 53534:
-  aliases: ['Maillotia']
+  aliases: []
   parents:
   - 7174
 325434:
-  aliases: ['Malaya genurostris']
+  aliases: []
   parents:
   - 149618
 149619:
-  aliases: ['Malaya jacobsoni']
+  aliases: []
   parents:
   - 149618
 308734:
-  aliases: ['Mansonia']
+  aliases: []
   parents:
   - 149459
 308733:
-  aliases: ['Mansonioides']
+  aliases: []
   parents:
   - 149459
 704167:
-  aliases: ['Maorigoeldia argyropus']
+  aliases: []
   parents:
   - 704166
 317802:
-  aliases: ['Mattinglyia']
+  aliases: []
   parents:
   - 317799
 53535:
-  aliases: ['Melanoconion']
+  aliases: []
   parents:
   - 7174
 2891964:
-  aliases: ['Micraedes']
+  aliases: []
   parents:
   - 7174
 707272:
-  aliases: ['Microculex']
+  aliases: []
   parents:
   - 7174
 308737:
-  aliases: ['Mimomyia']
+  aliases: []
   parents:
   - 308736
 53536:
-  aliases: ['Mochlostyrax']
+  aliases: []
   parents:
   - 7174
 53543:
-  aliases: ['Mucidus']
+  aliases: []
   parents:
   - 7158
 59140:
-  aliases: ['Myzomyia']
+  aliases: []
   parents:
   - 44534
 44535:
-  aliases: ['Neocellia']
+  aliases: []
   parents:
   - 44534
 53537:
-  aliases: ['Neoculex']
+  aliases: []
   parents:
   - 7174
 317806:
-  aliases: ['Neomacleaya']
+  aliases: []
   parents:
   - 317805
 53544:
-  aliases: ['Neomelaniconion']
+  aliases: []
   parents:
   - 7158
 44536:
-  aliases: ['Neomyzomyia']
+  aliases: []
   parents:
   - 44534
 1346164:
-  aliases: ['Nyctomyia pholeocola']
+  aliases: []
   parents:
   - 1367702
 53545:
-  aliases: ['Ochlerotatus']
+  aliases: []
   parents:
   - 190765
 767021:
-  aliases: ['Ochlerotatus incertae sedis']
+  aliases: []
   parents:
   - 190765
 667565:
-  aliases: ['Oculeomyia']
+  aliases: []
   parents:
   - 7174
 2292399:
-  aliases: ['Opifex chathamicus']
+  aliases: []
   parents:
   - 317800
 704161:
-  aliases: ['Opifex fuscus']
+  aliases: []
   parents:
   - 317800
 139054:
-  aliases: ['Orthopodomyia alba']
+  aliases: []
   parents:
   - 139053
 3569222:
-  aliases: ['Orthopodomyia andamanensis']
+  aliases: []
   parents:
   - 139053
 325430:
-  aliases: ['Orthopodomyia anopheloides']
+  aliases: []
   parents:
   - 139053
 2007214:
-  aliases: ['Orthopodomyia fascipes']
+  aliases: []
   parents:
   - 139053
 665337:
-  aliases: ['Orthopodomyia kummi']
+  aliases: []
   parents:
   - 139053
 665338:
-  aliases: ['Orthopodomyia pulcripalpis']
+  aliases: []
   parents:
   - 139053
 3569223:
-  aliases: ['Orthopodomyia siamensis']
+  aliases: []
   parents:
   - 139053
 665339:
-  aliases: ['Orthopodomyia signifera']
+  aliases: []
   parents:
   - 139053
 300154:
-  aliases: ['Paraedes']
+  aliases: []
   parents:
   - 7158
 262669:
-  aliases: ['Paramyzomyia']
+  aliases: []
   parents:
   - 44534
 1245346:
-  aliases: ['Phagomyia assamensis']
+  aliases: []
   parents:
   - 1245386
 1529942:
-  aliases: ['Phagomyia cogilli']
+  aliases: []
   parents:
   - 1245386
 1245347:
-  aliases: ['Phagomyia khazani']
+  aliases: []
   parents:
   - 1245386
 1245348:
-  aliases: ['Phagomyia prominens']
+  aliases: []
   parents:
   - 1245386
 707270:
-  aliases: ['Phenacomyia']
+  aliases: []
   parents:
   - 7174
 1091057:
-  aliases: ['Phytotelmatomyia']
+  aliases: []
   parents:
   - 7174
 1806189:
-  aliases: ['Polylepidomyia']
+  aliases: []
   parents:
   - 53567
 1379452:
-  aliases: ['Protoculex']
+  aliases: []
   parents:
   - 190765
 119225:
-  aliases: ['Protomacleaya']
+  aliases: []
   parents:
   - 190765
 325427:
-  aliases: ['Pseudoficalbia']
+  aliases: []
   parents:
   - 139055
 346065:
-  aliases: ['Pseudoskusea']
+  aliases: []
   parents:
   - 190765
 1631548:
-  aliases: ['Psorophora (Grabhamia) sp. RHL-2015']
+  aliases: []
   parents:
   - 7182
 1916147:
-  aliases: ['Psorophora albigenu']
+  aliases: []
   parents:
   - 7182
 869069:
-  aliases: ['Psorophora albipes']
+  aliases: []
   parents:
   - 7182
 329106:
-  aliases: ['Psorophora ciliata']
+  aliases: []
   parents:
   - 7182
 549315:
-  aliases: ['Psorophora cingulata']
+  aliases: []
   parents:
   - 7182
 869070:
-  aliases: ['Psorophora columbiae']
+  aliases: []
   parents:
   - 7182
 869071:
-  aliases: ['Psorophora confinnis']
+  aliases: []
   parents:
   - 7182
 869072:
-  aliases: ['Psorophora cyanescens']
+  aliases: []
   parents:
   - 7182
 1206287:
-  aliases: ['Psorophora discolor']
+  aliases: []
   parents:
   - 7182
 1921085:
-  aliases: ['Psorophora discrucians']
+  aliases: []
   parents:
   - 7182
 7183:
-  aliases: ['Psorophora ferox']
+  aliases: []
   parents:
   - 7182
 3153700:
-  aliases: ['Psorophora forceps']
+  aliases: []
   parents:
   - 7182
 2689572:
-  aliases: ['Psorophora funiculus']
+  aliases: []
   parents:
   - 7182
 2067438:
-  aliases: ['Psorophora horrida']
+  aliases: []
   parents:
   - 7182
 869073:
-  aliases: ['Psorophora howardii']
+  aliases: []
   parents:
   - 7182
 1206012:
-  aliases: ['Psorophora insularia']
+  aliases: []
   parents:
   - 7182
 3014949:
-  aliases: ['Psorophora jamaicensis']
+  aliases: []
   parents:
   - 7182
 1206013:
-  aliases: ['Psorophora longipalpus']
+  aliases: []
   parents:
   - 7182
 3014950:
-  aliases: ['Psorophora mathesoni']
+  aliases: []
   parents:
   - 7182
 2795834:
-  aliases: ['Psorophora paulli']
+  aliases: []
   parents:
   - 7182
 1206014:
-  aliases: ['Psorophora pygmaea']
+  aliases: []
   parents:
   - 7182
 2597062:
-  aliases: ['Psorophora saeva']
+  aliases: []
   parents:
   - 7182
 1206015:
-  aliases: ['Psorophora signipennis']
+  aliases: []
   parents:
   - 7182
 3014948:
-  aliases: ['Psorophora tolteca']
+  aliases: []
   parents:
   - 7182
 933869:
-  aliases: ['Psorophora varinervis']
+  aliases: []
   parents:
   - 7182
 2488823:
-  aliases: ['Psorophora varipes']
+  aliases: []
   parents:
   - 7182
 44537:
-  aliases: ['Pyretophorus']
+  aliases: []
   parents:
   - 44534
 325440:
-  aliases: ['Rachionotomyia']
+  aliases: []
   parents:
   - 53567
 3014975:
-  aliases: ['Rachisoura']
+  aliases: []
   parents:
   - 53567
 1919242:
-  aliases: ['Rampamyia']
+  aliases: []
   parents:
   - 7158
 345925:
-  aliases: ['Rhinoskusea']
+  aliases: []
   parents:
   - 190765
 2007259:
-  aliases: ['Runchomyia magna']
+  aliases: []
   parents:
   - 2007258
 2597063:
-  aliases: ['Runchomyia reversa']
+  aliases: []
   parents:
   - 2007258
 190767:
-  aliases: ['Rusticoidus']
+  aliases: []
   parents:
   - 190765
 518694:
-  aliases: ['Sabethes albiprivus']
+  aliases: []
   parents:
   - 53551
 464956:
-  aliases: ['Sabethes belisarioi']
+  aliases: []
   parents:
   - 53551
 2984125:
-  aliases: ['Sabethes bipartipes']
+  aliases: []
   parents:
   - 53551
 521044:
-  aliases: ['Sabethes cf. albiprivus B PMP-2008']
+  aliases: []
   parents:
   - 53551
 865939:
-  aliases: ['Sabethes chloropterus']
+  aliases: []
   parents:
   - 53551
 3153701:
-  aliases: ['Sabethes conditus']
+  aliases: []
   parents:
   - 53551
 53552:
-  aliases: ['Sabethes cyaneus']
+  aliases: []
   parents:
   - 53551
 2153043:
-  aliases: ['Sabethes glaucodaemon']
+  aliases: []
   parents:
   - 53551
 2007215:
-  aliases: ['Sabethes hadrognathus']
+  aliases: []
   parents:
   - 53551
 3381344:
-  aliases: ['Sabethes identicus']
+  aliases: []
   parents:
   - 53551
 2007216:
-  aliases: ['Sabethes idiogenes']
+  aliases: []
   parents:
   - 53551
 758603:
-  aliases: ['Sabethes intermedius']
+  aliases: []
   parents:
   - 53551
 2007217:
-  aliases: ['Sabethes paradoxus']
+  aliases: []
   parents:
   - 53551
 3029984:
-  aliases: ['Sabethes quasicyaneus']
+  aliases: []
   parents:
   - 53551
 2007218:
-  aliases: ['Sabethes soperi']
+  aliases: []
   parents:
   - 53551
 2984126:
-  aliases: ['Sabethes tarsopus']
+  aliases: []
   parents:
   - 53551
 2007222:
-  aliases: ['Sabethes undosus']
+  aliases: []
   parents:
   - 53551
 3153702:
-  aliases: ['Sallumia']
+  aliases: []
   parents:
   - 190765
 300155:
-  aliases: ['Scutomyia']
+  aliases: []
   parents:
   - 7158
 704169:
-  aliases: ['Shannoniana fluviatilis']
+  aliases: []
   parents:
   - 704168
 2872816:
-  aliases: ['Shannoniana moralesi']
+  aliases: []
   parents:
   - 704168
 2007223:
-  aliases: ['Shannoniana schedocyclia']
+  aliases: []
   parents:
   - 704168
 2730084:
-  aliases: ['Sirivanakarnius']
+  aliases: []
   parents:
   - 7174
 53547:
-  aliases: ['Skusea']
+  aliases: []
   parents:
   - 7158
 53541:
-  aliases: ['Stegomyia']
+  aliases: []
   parents:
   - 7158
 1608559:
-  aliases: ['Tanakaius savoryi']
+  aliases: []
   parents:
   - 1608558
 3453668:
-  aliases: ['Tinolestes']
+  aliases: []
   parents:
   - 7174
 1245370:
-  aliases: ['Topomyia houghtoni']
+  aliases: []
   parents:
   - 1245394
 2498891:
-  aliases: ['Topomyia yanbarensis']
+  aliases: []
   parents:
   - 1245394
 3122450:
-  aliases: ['Toxorhynchites (Lynchiella) sp.']
+  aliases: []
   parents:
   - 2624694
 2007226:
-  aliases: ['Toxorhynchites haemorrhoidalis haemorrhoidalis']
+  aliases: []
   parents:
   - 2007225
 2007227:
-  aliases: ['Toxorhynchites haemorrhoidalis superbus']
+  aliases: []
   parents:
   - 2007225
 2498890:
-  aliases: ['Toxorhynchites manicatus yaeyamae']
+  aliases: []
   parents:
   - 2498889
 329112:
-  aliases: ['Toxorhynchites rutilus septentrionalis']
+  aliases: []
   parents:
   - 53553
 2665171:
-  aliases: ['Toxorhynchites sp. 16GH 18-5']
+  aliases: []
   parents:
   - 2624694
 174824:
-  aliases: ['Toxorhynchites sp. AM-2001']
+  aliases: []
   parents:
   - 2624694
 743695:
-  aliases: ['Toxorhynchites sp. BOLD:AAC7484']
+  aliases: []
   parents:
   - 2624694
 2597067:
-  aliases: ['Toxorhynchites sp. CL-2019']
+  aliases: []
   parents:
   - 2624694
 1426900:
-  aliases: ['Toxorhynchites sp. TIP1']
+  aliases: []
   parents:
   - 2624694
 2108401:
-  aliases: ['Toxorhynchites sp. TOC']
+  aliases: []
   parents:
   - 2624694
 2038295:
-  aliases: ['Toxorhynchites sp. Toxo']
+  aliases: []
   parents:
   - 2624694
 2007229:
-  aliases: ['Trichoprosopon compressum']
+  aliases: []
   parents:
   - 704162
 704163:
-  aliases: ['Trichoprosopon digitatum']
+  aliases: []
   parents:
   - 704162
 1677683:
-  aliases: ['Trichoprosopon evansae']
+  aliases: []
   parents:
   - 704162
 2872824:
-  aliases: ['Trichoprosopon nr. brevipes BOLD:ADE5656']
+  aliases: []
   parents:
   - 704162
 2007230:
-  aliases: ['Trichoprosopon pallidiventer']
+  aliases: []
   parents:
   - 704162
 3458803:
-  aliases: ['Trichoprosopon soaresi']
+  aliases: []
   parents:
   - 704162
 2725259:
-  aliases: ['Trichoprosopon sp. 1 DJS-2020']
+  aliases: []
   parents:
   - 704162
 2725260:
-  aliases: ['Trichoprosopon sp. 2 DJS-2020']
+  aliases: []
   parents:
   - 704162
 2725261:
-  aliases: ['Trichoprosopon sp. 3 DJS-2020']
+  aliases: []
   parents:
   - 704162
 2725262:
-  aliases: ['Trichoprosopon sp. 5 DJS-2020']
+  aliases: []
   parents:
   - 704162
 3458804:
-  aliases: ['Trichoprosopon vonplesseni']
+  aliases: []
   parents:
   - 704162
 325442:
-  aliases: ['Tripteroides']
+  aliases: []
   parents:
   - 53567
 2587271:
-  aliases: ['Udaya argyrurus']
+  aliases: []
   parents:
   - 1245387
 1245355:
-  aliases: ['Udaya subsimilis']
+  aliases: []
   parents:
   - 1245387
 325429:
-  aliases: ['Uranotaenia']
+  aliases: []
   parents:
   - 139055
 317810:
-  aliases: ['Verrallina']
+  aliases: []
   parents:
   - 317805
 2872819:
-  aliases: ['Wyeomyia abebela']
+  aliases: []
   parents:
   - 174620
 2007233:
-  aliases: ['Wyeomyia albosquamata']
+  aliases: []
   parents:
   - 174620
 2793202:
-  aliases: ['Wyeomyia anthica']
+  aliases: []
   parents:
   - 174620
 1426843:
-  aliases: ['Wyeomyia aphobema']
+  aliases: []
   parents:
   - 174620
 2007234:
-  aliases: ['Wyeomyia aporonoma']
+  aliases: []
   parents:
   - 174620
 2007235:
-  aliases: ['Wyeomyia argenteorostris']
+  aliases: []
   parents:
   - 174620
 2007236:
-  aliases: ['Wyeomyia arthrostigma']
+  aliases: []
   parents:
   - 174620
 2007237:
-  aliases: ['Wyeomyia bourrouli']
+  aliases: []
   parents:
   - 174620
 2903343:
-  aliases: ['Wyeomyia celaenocephala']
+  aliases: []
   parents:
   - 174620
 2007238:
-  aliases: ['Wyeomyia complosa']
+  aliases: []
   parents:
   - 174620
 2007239:
-  aliases: ['Wyeomyia compta']
+  aliases: []
   parents:
   - 174620
 2597064:
-  aliases: ['Wyeomyia confusa']
+  aliases: []
   parents:
   - 174620
 2007240:
-  aliases: ['Wyeomyia forattinii']
+  aliases: []
   parents:
   - 174620
 2007241:
-  aliases: ['Wyeomyia lamellata']
+  aliases: []
   parents:
   - 174620
 1677684:
-  aliases: ['Wyeomyia luteoventralis']
+  aliases: []
   parents:
   - 174620
 629757:
-  aliases: ['Wyeomyia melanocephala']
+  aliases: []
   parents:
   - 174620
 2872820:
-  aliases: ['Wyeomyia melanopus']
+  aliases: []
   parents:
   - 174620
 2785384:
-  aliases: ['Wyeomyia mitchelli']
+  aliases: []
   parents:
   - 174620
 857316:
-  aliases: ['Wyeomyia mitchellii']
+  aliases: []
   parents:
   - 174620
 1426902:
-  aliases: ['Wyeomyia nr. aphobema BOLD:AAW1141']
+  aliases: []
   parents:
   - 174620
 2007242:
-  aliases: ['Wyeomyia oblita']
+  aliases: []
   parents:
   - 174620
 2007243:
-  aliases: ['Wyeomyia occulta']
+  aliases: []
   parents:
   - 174620
 2007244:
-  aliases: ['Wyeomyia pertinans']
+  aliases: []
   parents:
   - 174620
 2007245:
-  aliases: ['Wyeomyia pseudopecten']
+  aliases: []
   parents:
   - 174620
 2007246:
-  aliases: ['Wyeomyia robusta']
+  aliases: []
   parents:
   - 174620
 2706870:
-  aliases: ['Wyeomyia rorotai']
+  aliases: []
   parents:
   - 174620
 174621:
-  aliases: ['Wyeomyia smithii']
+  aliases: []
   parents:
   - 174620
 2007249:
-  aliases: ['Wyeomyia splendida']
+  aliases: []
   parents:
   - 174620
 2007250:
-  aliases: ['Wyeomyia surinamensis']
+  aliases: []
   parents:
   - 174620
 2007251:
-  aliases: ['Wyeomyia testei']
+  aliases: []
   parents:
   - 174620
 1426899:
-  aliases: ['Wyeomyia ulocoma']
+  aliases: []
   parents:
   - 174620
 857315:
-  aliases: ['Wyeomyia vanduzeei']
+  aliases: []
   parents:
   - 174620
 2007252:
-  aliases: ['Wyeomyia ypsipola']
+  aliases: []
   parents:
   - 174620
 346066:
-  aliases: ['Zavortinkius']
+  aliases: []
   parents:
   - 7158
 1424510:
-  aliases: ['Zeugnomyia gracilis']
+  aliases: []
   parents:
   - 1424509
 44544:
-  aliases: ['albimanus section']
+  aliases: []
   parents:
   - 44543
 44545:
-  aliases: ['argyritarsis section']
+  aliases: []
   parents:
   - 44543
 333811:
-  aliases: ['environmental samples']
+  aliases: []
   parents:
   - 7174
 1629145:
-  aliases: ['environmental samples']
+  aliases: []
   parents:
   - 7158
 874512:
-  aliases: ['myzorhynchella section']
+  aliases: []
   parents:
   - 44543
 53548:
-  aliases: ['unclassified Aedes (in: mosquitos)']
+  aliases: []
   parents:
   - 7158
 2853149:
-  aliases: ['unclassified Armigeres (in: mosquitos)']
+  aliases: []
   parents:
   - 124916
 2637621:
-  aliases: ['unclassified Coquillettidia']
+  aliases: []
   parents:
   - 329110
 3406907:
-  aliases: ['unclassified Culex (in: mosquitos)']
+  aliases: []
   parents:
   - 7174
 2619201:
-  aliases: ['unclassified Culiseta']
+  aliases: []
   parents:
   - 174825
 3406951:
-  aliases: ['unclassified Haemagogus (in: mosquitos)']
+  aliases: []
   parents:
   - 7180
 3406956:
-  aliases: ['unclassified Heizmannia (in: mosquitos)']
+  aliases: []
   parents:
   - 317799
 1147728:
-  aliases: ['unclassified Mansonia (in: mosquitos)']
+  aliases: []
   parents:
   - 149459
 3407012:
-  aliases: ['unclassified Mimomyia (in: mosquitos)']
+  aliases: []
   parents:
   - 308736
 54114:
-  aliases: ['unclassified Nyssorhynchus']
+  aliases: []
   parents:
   - 44543
 1125803:
-  aliases: ['unclassified Ochlerotatus (in: mosquitos, genus)']
+  aliases: []
   parents:
   - 190765
 2622204:
-  aliases: ['unclassified Onirion']
+  aliases: []
   parents:
   - 2007256
 2853112:
-  aliases: ['unclassified Orthopodomyia']
+  aliases: []
   parents:
   - 139053
 3122448:
-  aliases: ['unclassified Psorophora']
+  aliases: []
   parents:
   - 7182
 2647614:
-  aliases: ['unclassified Runchomyia']
+  aliases: []
   parents:
   - 2007258
 2646388:
-  aliases: ['unclassified Sabethes']
+  aliases: []
   parents:
   - 53551
 3123417:
-  aliases: ['unclassified Shannoniana']
+  aliases: []
   parents:
   - 704168
 2630085:
-  aliases: ['unclassified Trichoprosopon']
+  aliases: []
   parents:
   - 704162
 3407135:
-  aliases: ['unclassified Tripteroides (in: mosquitos)']
+  aliases: []
   parents:
   - 53567
 3407139:
-  aliases: ['unclassified Uranotaenia (in: mosquitos)']
+  aliases: []
   parents:
   - 139055
 3407142:
-  aliases: ['unclassified Verrallina (in: mosquitos)']
+  aliases: []
   parents:
   - 317805
 2631130:
-  aliases: ['unclassified Wyeomyia']
+  aliases: []
   parents:
   - 174620
 1803707:
-  aliases: ['Aedes (Aedimorphus) sp. 20974_AedimB11']
+  aliases: []
   parents:
   - 53540
 1803708:
-  aliases: ['Aedes (Aedimorphus) sp. 20974_AedimB12']
+  aliases: []
   parents:
   - 53540
 1803709:
-  aliases: ['Aedes (Aedimorphus) sp. 20974_AedimC02']
+  aliases: []
   parents:
   - 53540
 2014629:
-  aliases: ['Aedes (Diceromyia) sp. 1 PK-2017']
+  aliases: []
   parents:
   - 53539
 1263929:
-  aliases: ['Aedes abnormalis']
+  aliases: []
   parents:
   - 53540
 7159:
-  aliases: ['Aedes aegypti']
+  aliases: []
   parents:
   - 53541
 3095915:
-  aliases: ['Aedes aegypti x Aedes mascarensis']
+  aliases: []
   parents:
   - 53541
 1629146:
-  aliases: ['Aedes aff. notoscriptus environmental sample']
+  aliases: []
   parents:
   - 1629145
 667568:
-  aliases: ['Aedes africanus']
+  aliases: []
   parents:
   - 53541
 561254:
-  aliases: ['Aedes albiradius']
+  aliases: []
   parents:
   - 53544
 1806178:
-  aliases: ['Aedes alboannulatus']
+  aliases: []
   parents:
   - 1806171
 1234363:
-  aliases: ['Aedes albocephalus']
+  aliases: []
   parents:
   - 53540
 1245338:
-  aliases: ['Aedes albolateralis']
+  aliases: []
   parents:
   - 1245382
 1245349:
-  aliases: ['Aedes albolineatus']
+  aliases: []
   parents:
   - 300155
 7160:
-  aliases: ['Aedes albopictus']
+  aliases: []
   parents:
   - 53541
 1245337:
-  aliases: ['Aedes albotaeniatus']
+  aliases: []
   parents:
   - 1245381
 2563463:
-  aliases: ['Aedes alboventralis']
+  aliases: []
   parents:
   - 53540
 2873521:
-  aliases: ['Aedes allotecnon']
+  aliases: []
   parents:
   - 190766
 569587:
-  aliases: ['Aedes alternans']
+  aliases: []
   parents:
   - 53543
 1424563:
-  aliases: ['Aedes amesii']
+  aliases: []
   parents:
   - 300153
 1245350:
-  aliases: ['Aedes annandalei']
+  aliases: []
   parents:
   - 53541
 3402264:
-  aliases: ['Aedes antuensis']
+  aliases: []
   parents:
   - 300148
 2007260:
-  aliases: ['Aedes arborealis']
+  aliases: []
   parents:
   - 190766
 28624:
-  aliases: ['Aedes atropalpus']
+  aliases: []
   parents:
   - 1866276
 1424564:
-  aliases: ['Aedes aurantius']
+  aliases: []
   parents:
   - 53543
 1214259:
-  aliases: ['Aedes aureostriatus']
+  aliases: []
   parents:
   - 1245277
 2761509:
-  aliases: ['Aedes aurovenatus']
+  aliases: []
   parents:
   - 53544
 188699:
-  aliases: ['Aedes bahamensis']
+  aliases: []
   parents:
   - 190766
 498394:
-  aliases: ['Aedes barraudi']
+  aliases: []
   parents:
   - 300154
 1451302:
-  aliases: ['Aedes bekkui']
+  aliases: []
   parents:
   - 300148
 561250:
-  aliases: ['Aedes belleci']
+  aliases: []
   parents:
   - 53544
 2748776:
-  aliases: ['Aedes bhutanensis']
+  aliases: []
   parents:
   - 1245384
 1397682:
-  aliases: ['Aedes bromeliae']
+  aliases: []
   parents:
   - 53541
 2696053:
-  aliases: ['Aedes busckii']
+  aliases: []
   parents:
   - 190766
 2918770:
-  aliases: ['Aedes capensis']
+  aliases: []
   parents:
   - 300144
 2067445:
-  aliases: ['Aedes centropunctatus']
+  aliases: []
   parents:
   - 53540
 2722874:
-  aliases: ['Aedes cf. denderensis FANP37.H11']
+  aliases: []
   parents:
   - 53541
 2722875:
-  aliases: ['Aedes cf. luteocephalus SENP19.A2']
+  aliases: []
   parents:
   - 53541
 2722876:
-  aliases: ['Aedes cf. simpsoni MAFP6.G8']
+  aliases: []
   parents:
   - 53541
 3076078:
-  aliases: ['Aedes chemulpoensis']
+  aliases: []
   parents:
   - 53541
 498395:
-  aliases: ['Aedes chrysolineatus']
+  aliases: []
   parents:
   - 53542
 120872:
-  aliases: ['Aedes cinereus']
+  aliases: []
   parents:
   - 149531
 503349:
-  aliases: ['Aedes circumluteolus']
+  aliases: []
   parents:
   - 53544
 1424566:
-  aliases: ['Aedes collessi']
+  aliases: []
   parents:
   - 300154
 2989690:
-  aliases: ['Aedes contiguus']
+  aliases: []
   parents:
   - 53541
 2014625:
-  aliases: ['Aedes coulangesi']
+  aliases: []
   parents:
   - 53539
 2067446:
-  aliases: ['Aedes cozi']
+  aliases: []
   parents:
   - 53541
 2903341:
-  aliases: ['Aedes cozumelensis']
+  aliases: []
   parents:
   - 190766
 1245351:
-  aliases: ['Aedes craggi']
+  aliases: []
   parents:
   - 53541
 240003:
-  aliases: ['Aedes cretinus']
+  aliases: []
   parents:
   - 53541
 503354:
-  aliases: ['Aedes cumminsii']
+  aliases: []
   parents:
   - 53540
 1263930:
-  aliases: ['Aedes curtipes']
+  aliases: []
   parents:
   - 300146
 742472:
-  aliases: ['Aedes daitensis']
+  aliases: []
   parents:
   - 53541
 3114448:
-  aliases: ['Aedes daliensis']
+  aliases: []
   parents:
   - 1806188
 503350:
-  aliases: ['Aedes dalzieli']
+  aliases: []
   parents:
   - 53540
 667561:
-  aliases: ['Aedes denderensis']
+  aliases: []
   parents:
   - 53541
 1799673:
-  aliases: ['Aedes dentatus']
+  aliases: []
   parents:
   - 53540
 2806239:
-  aliases: ['Aedes dentatus group sp.']
+  aliases: []
   parents:
   - 53540
 1245352:
-  aliases: ['Aedes desmotes']
+  aliases: []
   parents:
   - 53541
 2761504:
-  aliases: ['Aedes durbanensis']
+  aliases: []
   parents:
   - 53540
 373847:
-  aliases: ['Aedes dybasi']
+  aliases: []
   parents:
   - 53541
 2575619:
-  aliases: ['Aedes echinus']
+  aliases: []
   parents:
   - 2575618
 159648:
-  aliases: ['Aedes elsiae']
+  aliases: []
   parents:
   - 53542
 3461570:
-  aliases: ['Aedes embuensis']
+  aliases: []
   parents:
   - 53542
 2761505:
-  aliases: ['Aedes eritreae']
+  aliases: []
   parents:
   - 53540
 373843:
-  aliases: ['Aedes esoensis']
+  aliases: []
   parents:
   - 149531
 2563464:
-  aliases: ['Aedes fascipalpis']
+  aliases: []
   parents:
   - 53539
 1245345:
-  aliases: ['Aedes fengi']
+  aliases: []
   parents:
   - 1245385
 3043750:
-  aliases: ['Aedes flavipennis']
+  aliases: []
   parents:
   - 53542
 166586:
-  aliases: ['Aedes flavopictus']
+  aliases: []
   parents:
   - 53541
 561256:
-  aliases: ['Aedes fontenillei']
+  aliases: []
   parents:
   - 53544
 1245343:
-  aliases: ['Aedes formosensis']
+  aliases: []
   parents:
   - 1245384
 2067448:
-  aliases: ['Aedes fowleri']
+  aliases: []
   parents:
   - 53540
 2339220:
-  aliases: ['Aedes fryeri']
+  aliases: []
   parents:
   - 2339219
 1828538:
-  aliases: ['Aedes fulvithorax']
+  aliases: []
   parents:
   - 190766
 308709:
-  aliases: ['Aedes fumidus']
+  aliases: []
   parents:
   - 300153
 299627:
-  aliases: ['Aedes furcifer']
+  aliases: []
   parents:
   - 53539
 2814731:
-  aliases: ['Aedes futunae']
+  aliases: []
   parents:
   - 53541
 373852:
-  aliases: ['Aedes galloisi']
+  aliases: []
   parents:
   - 53541
 2587272:
-  aliases: ['Aedes ganapathi']
+  aliases: []
   parents:
   - 1245382
 2603928:
-  aliases: ['Aedes gardnerii']
+  aliases: []
   parents:
   - 53541
 401424:
-  aliases: ['Aedes geminus']
+  aliases: []
   parents:
   - 149531
 120874:
-  aliases: ['Aedes geniculatus']
+  aliases: []
   parents:
   - 53542
 1245342:
-  aliases: ['Aedes gilli']
+  aliases: []
   parents:
   - 1245383
 1245278:
-  aliases: ['Aedes greenii']
+  aliases: []
   parents:
   - 1245277
 2872823:
-  aliases: ['Aedes guatemala']
+  aliases: []
   parents:
   - 190766
 2785374:
-  aliases: ['Aedes guerrero']
+  aliases: []
   parents:
   - 190766
 2126761:
-  aliases: ['Aedes hansfordi']
+  aliases: []
   parents:
   - 53541
 498396:
-  aliases: ['Aedes harveyi']
+  aliases: []
   parents:
   - 53542
 2761507:
-  aliases: ['Aedes haworthi']
+  aliases: []
   parents:
   - 300144
 569588:
-  aliases: ['Aedes hebrideus']
+  aliases: []
   parents:
   - 53541
 1055893:
-  aliases: ['Aedes helenae']
+  aliases: []
   parents:
   - 346052
 373851:
-  aliases: ['Aedes hensilli']
+  aliases: []
   parents:
   - 53541
 1799674:
-  aliases: ['Aedes hirsutus']
+  aliases: []
   parents:
   - 53540
 376794:
-  aliases: ['Aedes iyengari']
+  aliases: []
   parents:
   - 53539
 140438:
-  aliases: ['Aedes japonicus']
+  aliases: []
   parents:
   - 53542
 508664:
-  aliases: ['Aedes katherinensis']
+  aliases: []
   parents:
   - 53541
 1055894:
-  aliases: ['Aedes kleini']
+  aliases: []
   parents:
   - 346052
 3014957:
-  aliases: ['Aedes kochi']
+  aliases: []
   parents:
   - 53542
 2865750:
-  aliases: ['Aedes koreicoides']
+  aliases: []
   parents:
   - 1806188
 586676:
-  aliases: ['Aedes koreicus']
+  aliases: []
   parents:
   - 1245384
 1579483:
-  aliases: ['Aedes krombeini']
+  aliases: []
   parents:
   - 53541
 3112733:
-  aliases: ['Aedes laniger']
+  aliases: []
   parents:
   - 53543
 2761511:
-  aliases: ['Aedes ledgeri']
+  aliases: []
   parents:
   - 53541
 3461571:
-  aliases: ['Aedes leesoni']
+  aliases: []
   parents:
   - 53540
 1769045:
-  aliases: ['Aedes lilii']
+  aliases: []
   parents:
   - 53541
 869251:
-  aliases: ['Aedes lineatopennis']
+  aliases: []
   parents:
   - 53544
 1328033:
-  aliases: ['Aedes longipalpis']
+  aliases: []
   parents:
   - 346066
 2891960:
-  aliases: ['Aedes lorraineae']
+  aliases: []
   parents:
   - 190766
 299629:
-  aliases: ['Aedes luteocephalus']
+  aliases: []
   parents:
   - 53541
 1806180:
-  aliases: ['Aedes macmillani']
+  aliases: []
   parents:
   - 346061
 2014626:
-  aliases: ['Aedes madagascarensis']
+  aliases: []
   parents:
   - 53539
 373846:
-  aliases: ['Aedes maehleri']
+  aliases: []
   parents:
   - 53541
 1424567:
-  aliases: ['Aedes malayensis']
+  aliases: []
   parents:
   - 53541
 1245353:
-  aliases: ['Aedes malikuli']
+  aliases: []
   parents:
   - 53541
 1806183:
-  aliases: ['Aedes mallochi']
+  aliases: []
   parents:
   - 1806188
 1055895:
-  aliases: ['Aedes manhi']
+  aliases: []
   parents:
   - 346052
 590165:
-  aliases: ['Aedes mascarensis']
+  aliases: []
   parents:
   - 53541
 503348:
-  aliases: ['Aedes mcintoshi']
+  aliases: []
   parents:
   - 53544
 1245335:
-  aliases: ['Aedes mediolineatus']
+  aliases: []
   parents:
   - 53540
 686388:
-  aliases: ['Aedes metallicus']
+  aliases: []
   parents:
   - 53541
 3014958:
-  aliases: ['Aedes milsoni']
+  aliases: []
   parents:
   - 1806171
 3014959:
-  aliases: ['Aedes monocellatus']
+  aliases: []
   parents:
   - 1806188
 3402265:
-  aliases: ['Aedes mubiensis']
+  aliases: []
   parents:
   - 149531
 3014976:
-  aliases: ['Aedes muelleri']
+  aliases: []
   parents:
   - 3014974
 3367304:
-  aliases: ['Aedes natronius']
+  aliases: []
   parents:
   - 53540
 2943528:
-  aliases: ['Aedes nigricephalus']
+  aliases: []
   parents:
   - 53540
 561251:
-  aliases: ['Aedes nigropterum']
+  aliases: []
   parents:
   - 53544
 373844:
-  aliases: ['Aedes nipponicus']
+  aliases: []
   parents:
   - 53542
 1214261:
-  aliases: ['Aedes nishikawai']
+  aliases: []
   parents:
   - 53542
 1245339:
-  aliases: ['Aedes niveoides']
+  aliases: []
   parents:
   - 1245382
 2022598:
-  aliases: ['Aedes niveus']
+  aliases: []
   parents:
   - 1245382
 508665:
-  aliases: ['Aedes notoscriptus']
+  aliases: []
   parents:
   - 1919242
 1579489:
-  aliases: ['Aedes novalbopictus']
+  aliases: []
   parents:
   - 53541
 1245340:
-  aliases: ['Aedes novoniveus']
+  aliases: []
   parents:
   - 1245382
 2686120:
-  aliases: ['Aedes nr. cinereus APHA-10-2015E05']
+  aliases: []
   parents:
   - 149531
 2686118:
-  aliases: ['Aedes nr. cinereus APHA-10-2015E06']
+  aliases: []
   parents:
   - 149531
 2686119:
-  aliases: ['Aedes nr. cinereus APHA-11-2015A09']
+  aliases: []
   parents:
   - 149531
 2793865:
-  aliases: ['Aedes nr. fumidus S49_101']
+  aliases: []
   parents:
   - 300153
 2793867:
-  aliases: ['Aedes nr. fumidus S50_103A']
+  aliases: []
   parents:
   - 300153
 2793866:
-  aliases: ['Aedes nr. fumidus S50_104A']
+  aliases: []
   parents:
   - 300153
 450822:
-  aliases: ['Aedes ochraceus']
+  aliases: []
   parents:
   - 53540
 1245341:
-  aliases: ['Aedes omorii']
+  aliases: []
   parents:
   - 1245382
 2761506:
-  aliases: ['Aedes pachyurus']
+  aliases: []
   parents:
   - 53540
 373848:
-  aliases: ['Aedes palauensis']
+  aliases: []
   parents:
   - 53541
 1929008:
-  aliases: ['Aedes pallidostriatus']
+  aliases: []
   parents:
   - 53540
 508666:
-  aliases: ['Aedes palmarum']
+  aliases: []
   parents:
   - 53542
 561253:
-  aliases: ['Aedes palpalae']
+  aliases: []
   parents:
   - 53544
 3114450:
-  aliases: ['Aedes pecuniosus']
+  aliases: []
   parents:
   - 53542
 1914964:
-  aliases: ['Aedes pembaensis']
+  aliases: []
   parents:
   - 53547
 3137930:
-  aliases: ['Aedes penghuensis']
+  aliases: []
   parents:
   - 300146
 2793098:
-  aliases: ['Aedes pexus']
+  aliases: []
   parents:
   - 1245382
 1397683:
-  aliases: ['Aedes pia']
+  aliases: []
   parents:
   - 53541
 2773399:
-  aliases: ['Aedes poicilius']
+  aliases: []
   parents:
   - 53542
 188700:
-  aliases: ['Aedes polynesiensis']
+  aliases: []
   parents:
   - 53541
 1245354:
-  aliases: ['Aedes pseudalbopictus']
+  aliases: []
   parents:
   - 53541
 2793099:
-  aliases: ['Aedes pseudoniveus']
+  aliases: []
   parents:
   - 1245382
 316597:
-  aliases: ['Aedes pseudoscutellaris']
+  aliases: []
   parents:
   - 53541
 2321093:
-  aliases: ['Aedes quadrivittatus']
+  aliases: []
   parents:
   - 190766
 2563465:
-  aliases: ['Aedes quasiunivittatus']
+  aliases: []
   parents:
   - 53540
 3014960:
-  aliases: ['Aedes quinquelineatus']
+  aliases: []
   parents:
   - 1919242
 2785375:
-  aliases: ['Aedes ramirezi']
+  aliases: []
   parents:
   - 346054
 373849:
-  aliases: ['Aedes riversi']
+  aliases: []
   parents:
   - 53541
 761982:
-  aliases: ['Aedes rossicus']
+  aliases: []
   parents:
   - 149531
 1806179:
-  aliases: ['Aedes rubrithorax']
+  aliases: []
   parents:
   - 1806171
 3014961:
-  aliases: ['Aedes rupestris']
+  aliases: []
   parents:
   - 1806171
 3402266:
-  aliases: ['Aedes sasai']
+  aliases: []
   parents:
   - 149531
 2587273:
-  aliases: ['Aedes saxicola']
+  aliases: []
   parents:
   - 1245384
 2563466:
-  aliases: ['Aedes scatophagoides']
+  aliases: []
   parents:
   - 53543
 373850:
-  aliases: ['Aedes scutellaris']
+  aliases: []
   parents:
   - 53541
 3383095:
-  aliases: ['Aedes sexlineatus']
+  aliases: []
   parents:
   - 190766
 7161:
-  aliases: ['Aedes simpsoni']
+  aliases: []
   parents:
   - 53541
 2879502:
-  aliases: ['Aedes simpsoni sensu lato KV_BF4']
+  aliases: []
   parents:
   - 53541
 2879503:
-  aliases: ['Aedes simpsoni sensu lato KV_BF6']
+  aliases: []
   parents:
   - 53541
 2879501:
-  aliases: ['Aedes simpsoni sensu lato KV_BF7']
+  aliases: []
   parents:
   - 53541
 2879500:
-  aliases: ['Aedes simpsoni sensu lato RAB_BF11']
+  aliases: []
   parents:
   - 53541
 2879499:
-  aliases: ['Aedes simpsoni sensu lato RAB_BF13']
+  aliases: []
   parents:
   - 53541
 2879497:
-  aliases: ['Aedes simpsoni sensu lato RAB_BF14']
+  aliases: []
   parents:
   - 53541
 2879498:
-  aliases: ['Aedes simpsoni sensu lato RAB_BF18']
+  aliases: []
   parents:
   - 53541
 37951:
-  aliases: ['Aedes sp.']
+  aliases: []
   parents:
   - 53548
 2314892:
-  aliases: ['Aedes sp. 07PROBE-04097']
+  aliases: []
   parents:
   - 53548
 507997:
-  aliases: ['Aedes sp. 1 NDD-2008']
+  aliases: []
   parents:
   - 53548
 2972445:
-  aliases: ['Aedes sp. 1 NPK-2022a']
+  aliases: []
   parents:
   - 53548
 1406126:
-  aliases: ['Aedes sp. 1 pk']
+  aliases: []
   parents:
   - 53548
 1406127:
-  aliases: ['Aedes sp. 2 pk']
+  aliases: []
   parents:
   - 53548
 1406128:
-  aliases: ['Aedes sp. 3 pk']
+  aliases: []
   parents:
   - 53548
 2022599:
-  aliases: ['Aedes sp. A KIY-2017']
+  aliases: []
   parents:
   - 53548
 2314948:
-  aliases: ['Aedes sp. AS-02-03']
+  aliases: []
   parents:
   - 53548
 2022600:
-  aliases: ['Aedes sp. B KIY-2017']
+  aliases: []
   parents:
   - 53548
 2314960:
-  aliases: ['Aedes sp. BARS_2015_34_077']
+  aliases: []
   parents:
   - 53548
 2326390:
-  aliases: ['Aedes sp. BBDCN128-10']
+  aliases: []
   parents:
   - 53548
 2326391:
-  aliases: ['Aedes sp. BBDCN544-10']
+  aliases: []
   parents:
   - 53548
 2326392:
-  aliases: ['Aedes sp. BBDCP552-10']
+  aliases: []
   parents:
   - 53548
 2326393:
-  aliases: ['Aedes sp. BBDCP557-10']
+  aliases: []
   parents:
   - 53548
 2326394:
-  aliases: ['Aedes sp. BBDCP565-10']
+  aliases: []
   parents:
   - 53548
 2326395:
-  aliases: ['Aedes sp. BBDCP566-10']
+  aliases: []
   parents:
   - 53548
 2326396:
-  aliases: ['Aedes sp. BBDCP567-10']
+  aliases: []
   parents:
   - 53548
 2326397:
-  aliases: ['Aedes sp. BBDCP568-10']
+  aliases: []
   parents:
   - 53548
 2326398:
-  aliases: ['Aedes sp. BBDCP578-10']
+  aliases: []
   parents:
   - 53548
 2326399:
-  aliases: ['Aedes sp. BBDCP584-10']
+  aliases: []
   parents:
   - 53548
 2326400:
-  aliases: ['Aedes sp. BBDCP587-10']
+  aliases: []
   parents:
   - 53548
 2326401:
-  aliases: ['Aedes sp. BBDCP588-10']
+  aliases: []
   parents:
   - 53548
 2326402:
-  aliases: ['Aedes sp. BBDCP597-10']
+  aliases: []
   parents:
   - 53548
 2326403:
-  aliases: ['Aedes sp. BBDCP603-10']
+  aliases: []
   parents:
   - 53548
 2314915:
-  aliases: ['Aedes sp. BIOUG01408-B05']
+  aliases: []
   parents:
   - 53548
 2314990:
-  aliases: ['Aedes sp. BIOUG01408-D12']
+  aliases: []
   parents:
   - 53548
 2314891:
-  aliases: ['Aedes sp. BIOUG01475-H07']
+  aliases: []
   parents:
   - 53548
 2206921:
-  aliases: ['Aedes sp. BIOUG03120-A05']
+  aliases: []
   parents:
   - 53548
 2206922:
-  aliases: ['Aedes sp. BIOUG03120-C06']
+  aliases: []
   parents:
   - 53548
 2206923:
-  aliases: ['Aedes sp. BIOUG06197-H09']
+  aliases: []
   parents:
   - 53548
 2206924:
-  aliases: ['Aedes sp. BIOUG06197-H11']
+  aliases: []
   parents:
   - 53548
 2206925:
-  aliases: ['Aedes sp. BIOUG06330-D06']
+  aliases: []
   parents:
   - 53548
 2206926:
-  aliases: ['Aedes sp. BIOUG06334-H02']
+  aliases: []
   parents:
   - 53548
 2206927:
-  aliases: ['Aedes sp. BIOUG08455-C11']
+  aliases: []
   parents:
   - 53548
 2206928:
-  aliases: ['Aedes sp. BIOUG08614-H02']
+  aliases: []
   parents:
   - 53548
 2206929:
-  aliases: ['Aedes sp. BIOUG11231-H06']
+  aliases: []
   parents:
   - 53548
 2557251:
-  aliases: ['Aedes sp. BIOUG11377-C03']
+  aliases: []
   parents:
   - 53548
 2557252:
-  aliases: ['Aedes sp. BIOUG11377-D10']
+  aliases: []
   parents:
   - 53548
 2206930:
-  aliases: ['Aedes sp. BIOUG11989-C10']
+  aliases: []
   parents:
   - 53548
 2206931:
-  aliases: ['Aedes sp. BIOUG14847-C09']
+  aliases: []
   parents:
   - 53548
 2206932:
-  aliases: ['Aedes sp. BIOUG14847-C11']
+  aliases: []
   parents:
   - 53548
 2206933:
-  aliases: ['Aedes sp. BIOUG14847-C12']
+  aliases: []
   parents:
   - 53548
 2206934:
-  aliases: ['Aedes sp. BIOUG14847-D01']
+  aliases: []
   parents:
   - 53548
 2206935:
-  aliases: ['Aedes sp. BIOUG14847-D02']
+  aliases: []
   parents:
   - 53548
 2206936:
-  aliases: ['Aedes sp. BIOUG14847-D09']
+  aliases: []
   parents:
   - 53548
 2206937:
-  aliases: ['Aedes sp. BIOUG14847-D10']
+  aliases: []
   parents:
   - 53548
 2206938:
-  aliases: ['Aedes sp. BIOUG14847-D11']
+  aliases: []
   parents:
   - 53548
 2206939:
-  aliases: ['Aedes sp. BIOUG14847-D12']
+  aliases: []
   parents:
   - 53548
 2206940:
-  aliases: ['Aedes sp. BIOUG14847-E02']
+  aliases: []
   parents:
   - 53548
 2206941:
-  aliases: ['Aedes sp. BIOUG14848-G02']
+  aliases: []
   parents:
   - 53548
 2206942:
-  aliases: ['Aedes sp. BIOUG14848-G06']
+  aliases: []
   parents:
   - 53548
 2206943:
-  aliases: ['Aedes sp. BIOUG14848-G10']
+  aliases: []
   parents:
   - 53548
 2206944:
-  aliases: ['Aedes sp. BIOUG14848-G11']
+  aliases: []
   parents:
   - 53548
 2206945:
-  aliases: ['Aedes sp. BIOUG14917-C05']
+  aliases: []
   parents:
   - 53548
 2206946:
-  aliases: ['Aedes sp. BIOUG14917-C06']
+  aliases: []
   parents:
   - 53548
 2206947:
-  aliases: ['Aedes sp. BIOUG14917-C07']
+  aliases: []
   parents:
   - 53548
 2206948:
-  aliases: ['Aedes sp. BIOUG14917-C10']
+  aliases: []
   parents:
   - 53548
 2206949:
-  aliases: ['Aedes sp. BIOUG14917-D01']
+  aliases: []
   parents:
   - 53548
 2206950:
-  aliases: ['Aedes sp. BIOUG14917-D03']
+  aliases: []
   parents:
   - 53548
 2206951:
-  aliases: ['Aedes sp. BIOUG14917-D04']
+  aliases: []
   parents:
   - 53548
 2206952:
-  aliases: ['Aedes sp. BIOUG14917-D05']
+  aliases: []
   parents:
   - 53548
 2206953:
-  aliases: ['Aedes sp. BIOUG14917-D06']
+  aliases: []
   parents:
   - 53548
 2206954:
-  aliases: ['Aedes sp. BIOUG14917-D07']
+  aliases: []
   parents:
   - 53548
 2206955:
-  aliases: ['Aedes sp. BIOUG15689-F04']
+  aliases: []
   parents:
   - 53548
 2206956:
-  aliases: ['Aedes sp. BIOUG15986-E12']
+  aliases: []
   parents:
   - 53548
 2206957:
-  aliases: ['Aedes sp. BIOUG15989-A02']
+  aliases: []
   parents:
   - 53548
 2206958:
-  aliases: ['Aedes sp. BIOUG16992-G12']
+  aliases: []
   parents:
   - 53548
 2206959:
-  aliases: ['Aedes sp. BIOUG17185-D06']
+  aliases: []
   parents:
   - 53548
 2206960:
-  aliases: ['Aedes sp. BIOUG17326-H10']
+  aliases: []
   parents:
   - 53548
 2206961:
-  aliases: ['Aedes sp. BIOUG17581-B12']
+  aliases: []
   parents:
   - 53548
 2206962:
-  aliases: ['Aedes sp. BIOUG17655-G11']
+  aliases: []
   parents:
   - 53548
 2206963:
-  aliases: ['Aedes sp. BIOUG17774-F01']
+  aliases: []
   parents:
   - 53548
 2557253:
-  aliases: ['Aedes sp. BIOUG17782-E07']
+  aliases: []
   parents:
   - 53548
 2206964:
-  aliases: ['Aedes sp. BIOUG18930-B01']
+  aliases: []
   parents:
   - 53548
 2206965:
-  aliases: ['Aedes sp. BIOUG18930-C07']
+  aliases: []
   parents:
   - 53548
 2206966:
-  aliases: ['Aedes sp. BIOUG18930-C09']
+  aliases: []
   parents:
   - 53548
 2206967:
-  aliases: ['Aedes sp. BIOUG18930-E05']
+  aliases: []
   parents:
   - 53548
 2206968:
-  aliases: ['Aedes sp. BIOUG18930-E06']
+  aliases: []
   parents:
   - 53548
 2206969:
-  aliases: ['Aedes sp. BIOUG19675-E04']
+  aliases: []
   parents:
   - 53548
 2206970:
-  aliases: ['Aedes sp. BIOUG19689-A04']
+  aliases: []
   parents:
   - 53548
 2206971:
-  aliases: ['Aedes sp. BIOUG20086-G12']
+  aliases: []
   parents:
   - 53548
 2206972:
-  aliases: ['Aedes sp. BIOUG20086-H01']
+  aliases: []
   parents:
   - 53548
 2206973:
-  aliases: ['Aedes sp. BIOUG20086-H05']
+  aliases: []
   parents:
   - 53548
 2206974:
-  aliases: ['Aedes sp. BIOUG20086-H09']
+  aliases: []
   parents:
   - 53548
 2206975:
-  aliases: ['Aedes sp. BIOUG20257-C10']
+  aliases: []
   parents:
   - 53548
 2206976:
-  aliases: ['Aedes sp. BIOUG20323-A05']
+  aliases: []
   parents:
   - 53548
 2206977:
-  aliases: ['Aedes sp. BIOUG20323-A06']
+  aliases: []
   parents:
   - 53548
 2206978:
-  aliases: ['Aedes sp. BIOUG20323-A07']
+  aliases: []
   parents:
   - 53548
 2206979:
-  aliases: ['Aedes sp. BIOUG20323-A11']
+  aliases: []
   parents:
   - 53548
 2206980:
-  aliases: ['Aedes sp. BIOUG20494-D02']
+  aliases: []
   parents:
   - 53548
 2206981:
-  aliases: ['Aedes sp. BIOUG20494-F03']
+  aliases: []
   parents:
   - 53548
 2206982:
-  aliases: ['Aedes sp. BIOUG20506-B02']
+  aliases: []
   parents:
   - 53548
 2206983:
-  aliases: ['Aedes sp. BIOUG20506-D11']
+  aliases: []
   parents:
   - 53548
 2206984:
-  aliases: ['Aedes sp. BIOUG20509-E11']
+  aliases: []
   parents:
   - 53548
 2206985:
-  aliases: ['Aedes sp. BIOUG20509-F05']
+  aliases: []
   parents:
   - 53548
 2206986:
-  aliases: ['Aedes sp. BIOUG20510-A05']
+  aliases: []
   parents:
   - 53548
 2206987:
-  aliases: ['Aedes sp. BIOUG20512-F07']
+  aliases: []
   parents:
   - 53548
 2206988:
-  aliases: ['Aedes sp. BIOUG20513-C07']
+  aliases: []
   parents:
   - 53548
 2206989:
-  aliases: ['Aedes sp. BIOUG20532-A07']
+  aliases: []
   parents:
   - 53548
 2206990:
-  aliases: ['Aedes sp. BIOUG20533-A12']
+  aliases: []
   parents:
   - 53548
 2206991:
-  aliases: ['Aedes sp. BIOUG20533-G05']
+  aliases: []
   parents:
   - 53548
 2206992:
-  aliases: ['Aedes sp. BIOUG20540-A02']
+  aliases: []
   parents:
   - 53548
 2206993:
-  aliases: ['Aedes sp. BIOUG20540-D11']
+  aliases: []
   parents:
   - 53548
 2206994:
-  aliases: ['Aedes sp. BIOUG20540-D12']
+  aliases: []
   parents:
   - 53548
 2206995:
-  aliases: ['Aedes sp. BIOUG20628-H09']
+  aliases: []
   parents:
   - 53548
 2206996:
-  aliases: ['Aedes sp. BIOUG20666-F05']
+  aliases: []
   parents:
   - 53548
 2206997:
-  aliases: ['Aedes sp. BIOUG20666-F06']
+  aliases: []
   parents:
   - 53548
 2206998:
-  aliases: ['Aedes sp. BIOUG20728-A04']
+  aliases: []
   parents:
   - 53548
 2206999:
-  aliases: ['Aedes sp. BIOUG20732-H08']
+  aliases: []
   parents:
   - 53548
 2207000:
-  aliases: ['Aedes sp. BIOUG20763-C01']
+  aliases: []
   parents:
   - 53548
 2207001:
-  aliases: ['Aedes sp. BIOUG20768-H05']
+  aliases: []
   parents:
   - 53548
 2207002:
-  aliases: ['Aedes sp. BIOUG20769-E12']
+  aliases: []
   parents:
   - 53548
 2207003:
-  aliases: ['Aedes sp. BIOUG20771-H10']
+  aliases: []
   parents:
   - 53548
 2207004:
-  aliases: ['Aedes sp. BIOUG20798-C10']
+  aliases: []
   parents:
   - 53548
 2207005:
-  aliases: ['Aedes sp. BIOUG20798-D03']
+  aliases: []
   parents:
   - 53548
 2207006:
-  aliases: ['Aedes sp. BIOUG20798-D12']
+  aliases: []
   parents:
   - 53548
 2207007:
-  aliases: ['Aedes sp. BIOUG20810-C02']
+  aliases: []
   parents:
   - 53548
 2207008:
-  aliases: ['Aedes sp. BIOUG20812-E07']
+  aliases: []
   parents:
   - 53548
 2207009:
-  aliases: ['Aedes sp. BIOUG20842-F04']
+  aliases: []
   parents:
   - 53548
 2207010:
-  aliases: ['Aedes sp. BIOUG20867-F11']
+  aliases: []
   parents:
   - 53548
 2207011:
-  aliases: ['Aedes sp. BIOUG20935-D03']
+  aliases: []
   parents:
   - 53548
 2207012:
-  aliases: ['Aedes sp. BIOUG21104-D11']
+  aliases: []
   parents:
   - 53548
 2207013:
-  aliases: ['Aedes sp. BIOUG21162-C03']
+  aliases: []
   parents:
   - 53548
 2207014:
-  aliases: ['Aedes sp. BIOUG21404-A05']
+  aliases: []
   parents:
   - 53548
 2207015:
-  aliases: ['Aedes sp. BIOUG21450-A09']
+  aliases: []
   parents:
   - 53548
 2207016:
-  aliases: ['Aedes sp. BIOUG21513-F03']
+  aliases: []
   parents:
   - 53548
 2207017:
-  aliases: ['Aedes sp. BIOUG21637-D04']
+  aliases: []
   parents:
   - 53548
 2207018:
-  aliases: ['Aedes sp. BIOUG21637-G06']
+  aliases: []
   parents:
   - 53548
 2314932:
-  aliases: ['Aedes sp. BIOUG21924-E02']
+  aliases: []
   parents:
   - 53548
 2314995:
-  aliases: ['Aedes sp. BIOUG22016-E06']
+  aliases: []
   parents:
   - 53548
 2314890:
-  aliases: ['Aedes sp. BIOUG22112-B02']
+  aliases: []
   parents:
   - 53548
 2314878:
-  aliases: ['Aedes sp. BIOUG22112-B11']
+  aliases: []
   parents:
   - 53548
 2314899:
-  aliases: ['Aedes sp. BIOUG22112-C05']
+  aliases: []
   parents:
   - 53548
 2314993:
-  aliases: ['Aedes sp. BIOUG22112-D01']
+  aliases: []
   parents:
   - 53548
 2314923:
-  aliases: ['Aedes sp. BIOUG22112-F06']
+  aliases: []
   parents:
   - 53548
 2314992:
-  aliases: ['Aedes sp. BIOUG22112-G01']
+  aliases: []
   parents:
   - 53548
 2314882:
-  aliases: ['Aedes sp. BIOUG22116-A04']
+  aliases: []
   parents:
   - 53548
 2314986:
-  aliases: ['Aedes sp. BIOUG22116-A12']
+  aliases: []
   parents:
   - 53548
 2314908:
-  aliases: ['Aedes sp. BIOUG22116-B01']
+  aliases: []
   parents:
   - 53548
 2314920:
-  aliases: ['Aedes sp. BIOUG22116-D11']
+  aliases: []
   parents:
   - 53548
 2314953:
-  aliases: ['Aedes sp. BIOUG22116-E06']
+  aliases: []
   parents:
   - 53548
 2314981:
-  aliases: ['Aedes sp. BIOUG22116-E12']
+  aliases: []
   parents:
   - 53548
 2314938:
-  aliases: ['Aedes sp. BIOUG22116-F05']
+  aliases: []
   parents:
   - 53548
 2314904:
-  aliases: ['Aedes sp. BIOUG22116-H03']
+  aliases: []
   parents:
   - 53548
 2314954:
-  aliases: ['Aedes sp. BIOUG22117-A09']
+  aliases: []
   parents:
   - 53548
 2314918:
-  aliases: ['Aedes sp. BIOUG22117-A11']
+  aliases: []
   parents:
   - 53548
 2314974:
-  aliases: ['Aedes sp. BIOUG22117-C04']
+  aliases: []
   parents:
   - 53548
 2314897:
-  aliases: ['Aedes sp. BIOUG22117-C06']
+  aliases: []
   parents:
   - 53548
 2314944:
-  aliases: ['Aedes sp. BIOUG22117-F02']
+  aliases: []
   parents:
   - 53548
 2314927:
-  aliases: ['Aedes sp. BIOUG22117-G10']
+  aliases: []
   parents:
   - 53548
 2314926:
-  aliases: ['Aedes sp. BIOUG22117-H04']
+  aliases: []
   parents:
   - 53548
 2314909:
-  aliases: ['Aedes sp. BIOUG22119-A02']
+  aliases: []
   parents:
   - 53548
 2314895:
-  aliases: ['Aedes sp. BIOUG22119-A06']
+  aliases: []
   parents:
   - 53548
 2314901:
-  aliases: ['Aedes sp. BIOUG22119-A07']
+  aliases: []
   parents:
   - 53548
 2314872:
-  aliases: ['Aedes sp. BIOUG22119-C05']
+  aliases: []
   parents:
   - 53548
 2314911:
-  aliases: ['Aedes sp. BIOUG22119-D05']
+  aliases: []
   parents:
   - 53548
 2314955:
-  aliases: ['Aedes sp. BIOUG22119-G02']
+  aliases: []
   parents:
   - 53548
 2314921:
-  aliases: ['Aedes sp. BIOUG22119-G04']
+  aliases: []
   parents:
   - 53548
 2314984:
-  aliases: ['Aedes sp. BIOUG22119-H03']
+  aliases: []
   parents:
   - 53548
 2314913:
-  aliases: ['Aedes sp. BIOUG22119-H11']
+  aliases: []
   parents:
   - 53548
 2314903:
-  aliases: ['Aedes sp. BIOUG22283-D12']
+  aliases: []
   parents:
   - 53548
 2314874:
-  aliases: ['Aedes sp. BIOUG22386-A01']
+  aliases: []
   parents:
   - 53548
 2314869:
-  aliases: ['Aedes sp. BIOUG22386-A08']
+  aliases: []
   parents:
   - 53548
 2314893:
-  aliases: ['Aedes sp. BIOUG22386-A10']
+  aliases: []
   parents:
   - 53548
 2314951:
-  aliases: ['Aedes sp. BIOUG22386-B07']
+  aliases: []
   parents:
   - 53548
 2314967:
-  aliases: ['Aedes sp. BIOUG22386-C03']
+  aliases: []
   parents:
   - 53548
 2314945:
-  aliases: ['Aedes sp. BIOUG22386-C09']
+  aliases: []
   parents:
   - 53548
 2314979:
-  aliases: ['Aedes sp. BIOUG22386-D03']
+  aliases: []
   parents:
   - 53548
 2314916:
-  aliases: ['Aedes sp. BIOUG22432-C12']
+  aliases: []
   parents:
   - 53548
 2314902:
-  aliases: ['Aedes sp. BIOUG22432-D09']
+  aliases: []
   parents:
   - 53548
 2314933:
-  aliases: ['Aedes sp. BIOUG22432-D10']
+  aliases: []
   parents:
   - 53548
 2314870:
-  aliases: ['Aedes sp. BIOUG22432-E04']
+  aliases: []
   parents:
   - 53548
 2314985:
-  aliases: ['Aedes sp. BIOUG22432-E07']
+  aliases: []
   parents:
   - 53548
 2314896:
-  aliases: ['Aedes sp. BIOUG22432-E12']
+  aliases: []
   parents:
   - 53548
 2314940:
-  aliases: ['Aedes sp. BIOUG22432-H03']
+  aliases: []
   parents:
   - 53548
 2314930:
-  aliases: ['Aedes sp. BIOUG22438-D08']
+  aliases: []
   parents:
   - 53548
 2314867:
-  aliases: ['Aedes sp. BIOUG22438-E03']
+  aliases: []
   parents:
   - 53548
 2314887:
-  aliases: ['Aedes sp. BIOUG22438-E06']
+  aliases: []
   parents:
   - 53548
 2314965:
-  aliases: ['Aedes sp. BIOUG22438-G07']
+  aliases: []
   parents:
   - 53548
 2314905:
-  aliases: ['Aedes sp. BIOUG22440-A12']
+  aliases: []
   parents:
   - 53548
 2314910:
-  aliases: ['Aedes sp. BIOUG22440-C05']
+  aliases: []
   parents:
   - 53548
 2314912:
-  aliases: ['Aedes sp. BIOUG22440-C09']
+  aliases: []
   parents:
   - 53548
 2314983:
-  aliases: ['Aedes sp. BIOUG22440-D03']
+  aliases: []
   parents:
   - 53548
 2314943:
-  aliases: ['Aedes sp. BIOUG22440-E01']
+  aliases: []
   parents:
   - 53548
 2314889:
-  aliases: ['Aedes sp. BIOUG22440-E06']
+  aliases: []
   parents:
   - 53548
 2314956:
-  aliases: ['Aedes sp. BIOUG22440-G12']
+  aliases: []
   parents:
   - 53548
 2314866:
-  aliases: ['Aedes sp. BIOUG22440-H10']
+  aliases: []
   parents:
   - 53548
 2314975:
-  aliases: ['Aedes sp. BIOUG22515-C04']
+  aliases: []
   parents:
   - 53548
 2314977:
-  aliases: ['Aedes sp. BIOUG22515-E03']
+  aliases: []
   parents:
   - 53548
 2314994:
-  aliases: ['Aedes sp. BIOUG22515-E05']
+  aliases: []
   parents:
   - 53548
 2314972:
-  aliases: ['Aedes sp. BIOUG22515-F01']
+  aliases: []
   parents:
   - 53548
 2314976:
-  aliases: ['Aedes sp. BIOUG22515-G05']
+  aliases: []
   parents:
   - 53548
 2314917:
-  aliases: ['Aedes sp. BIOUG22518-A03']
+  aliases: []
   parents:
   - 53548
 2314879:
-  aliases: ['Aedes sp. BIOUG22518-F05']
+  aliases: []
   parents:
   - 53548
 2314888:
-  aliases: ['Aedes sp. BIOUG22518-F11']
+  aliases: []
   parents:
   - 53548
 2314961:
-  aliases: ['Aedes sp. BIOUG22519-A05']
+  aliases: []
   parents:
   - 53548
 2314941:
-  aliases: ['Aedes sp. BIOUG22519-C03']
+  aliases: []
   parents:
   - 53548
 2314883:
-  aliases: ['Aedes sp. BIOUG22519-E09']
+  aliases: []
   parents:
   - 53548
 2314894:
-  aliases: ['Aedes sp. BIOUG22519-G04']
+  aliases: []
   parents:
   - 53548
 2314868:
-  aliases: ['Aedes sp. BIOUG22521-B04']
+  aliases: []
   parents:
   - 53548
 2314924:
-  aliases: ['Aedes sp. BIOUG22521-B08']
+  aliases: []
   parents:
   - 53548
 2314996:
-  aliases: ['Aedes sp. BIOUG22521-B10']
+  aliases: []
   parents:
   - 53548
 2314959:
-  aliases: ['Aedes sp. BIOUG22653-H07']
+  aliases: []
   parents:
   - 53548
 2314971:
-  aliases: ['Aedes sp. BIOUG22653-H10']
+  aliases: []
   parents:
   - 53548
 2314907:
-  aliases: ['Aedes sp. BIOUG22656-E12']
+  aliases: []
   parents:
   - 53548
 2314968:
-  aliases: ['Aedes sp. BIOUG22658-B12']
+  aliases: []
   parents:
   - 53548
 2314973:
-  aliases: ['Aedes sp. BIOUG22658-C07']
+  aliases: []
   parents:
   - 53548
 2314937:
-  aliases: ['Aedes sp. BIOUG22658-C10']
+  aliases: []
   parents:
   - 53548
 2314884:
-  aliases: ['Aedes sp. BIOUG22658-D03']
+  aliases: []
   parents:
   - 53548
 2314877:
-  aliases: ['Aedes sp. BIOUG22658-D10']
+  aliases: []
   parents:
   - 53548
 2314881:
-  aliases: ['Aedes sp. BIOUG22658-F09']
+  aliases: []
   parents:
   - 53548
 2314871:
-  aliases: ['Aedes sp. BIOUG22658-H05']
+  aliases: []
   parents:
   - 53548
 2314898:
-  aliases: ['Aedes sp. BIOUG22660-A02']
+  aliases: []
   parents:
   - 53548
 2314922:
-  aliases: ['Aedes sp. BIOUG22660-A05']
+  aliases: []
   parents:
   - 53548
 2314980:
-  aliases: ['Aedes sp. BIOUG22660-D11']
+  aliases: []
   parents:
   - 53548
 2314885:
-  aliases: ['Aedes sp. BIOUG22660-F12']
+  aliases: []
   parents:
   - 53548
 2314950:
-  aliases: ['Aedes sp. BIOUG22708-B11']
+  aliases: []
   parents:
   - 53548
 2314880:
-  aliases: ['Aedes sp. BIOUG22708-D10']
+  aliases: []
   parents:
   - 53548
 2314942:
-  aliases: ['Aedes sp. BIOUG22708-F10']
+  aliases: []
   parents:
   - 53548
 2314991:
-  aliases: ['Aedes sp. BIOUG22708-G08']
+  aliases: []
   parents:
   - 53548
 2314970:
-  aliases: ['Aedes sp. BIOUG22709-A08']
+  aliases: []
   parents:
   - 53548
 2314966:
-  aliases: ['Aedes sp. BIOUG22709-A11']
+  aliases: []
   parents:
   - 53548
 2314947:
-  aliases: ['Aedes sp. BIOUG22709-B03']
+  aliases: []
   parents:
   - 53548
 2314919:
-  aliases: ['Aedes sp. BIOUG22709-C11']
+  aliases: []
   parents:
   - 53548
 2314929:
-  aliases: ['Aedes sp. BIOUG22709-H09']
+  aliases: []
   parents:
   - 53548
 2314998:
-  aliases: ['Aedes sp. BIOUG22764-D12']
+  aliases: []
   parents:
   - 53548
 2314957:
-  aliases: ['Aedes sp. BIOUG22929-D08']
+  aliases: []
   parents:
   - 53548
 2314876:
-  aliases: ['Aedes sp. BIOUG22938-G09']
+  aliases: []
   parents:
   - 53548
 2314931:
-  aliases: ['Aedes sp. BIOUG22961-E01']
+  aliases: []
   parents:
   - 53548
 2314873:
-  aliases: ['Aedes sp. BIOUG23190-C07']
+  aliases: []
   parents:
   - 53548
 2314906:
-  aliases: ['Aedes sp. BIOUG23198-F10']
+  aliases: []
   parents:
   - 53548
 2314949:
-  aliases: ['Aedes sp. BIOUG23204-G07']
+  aliases: []
   parents:
   - 53548
 2314988:
-  aliases: ['Aedes sp. BIOUG23305-A07']
+  aliases: []
   parents:
   - 53548
 2314958:
-  aliases: ['Aedes sp. BIOUG23682-G01']
+  aliases: []
   parents:
   - 53548
 2314875:
-  aliases: ['Aedes sp. BIOUG24298-H09']
+  aliases: []
   parents:
   - 53548
 2314969:
-  aliases: ['Aedes sp. BIOUG24511-F11']
+  aliases: []
   parents:
   - 53548
 2314963:
-  aliases: ['Aedes sp. BIOUG24556-C01']
+  aliases: []
   parents:
   - 53548
 2314886:
-  aliases: ['Aedes sp. BIOUG24556-C02']
+  aliases: []
   parents:
   - 53548
 2314934:
-  aliases: ['Aedes sp. BIOUG24556-C03']
+  aliases: []
   parents:
   - 53548
 2207019:
-  aliases: ['Aedes sp. BIOUG24582-F05']
+  aliases: []
   parents:
   - 53548
 2207020:
-  aliases: ['Aedes sp. BIOUG24639-G06']
+  aliases: []
   parents:
   - 53548
 2207021:
-  aliases: ['Aedes sp. BIOUG24722-F10']
+  aliases: []
   parents:
   - 53548
 2207022:
-  aliases: ['Aedes sp. BIOUG24729-H01']
+  aliases: []
   parents:
   - 53548
 2207023:
-  aliases: ['Aedes sp. BIOUG24729-H03']
+  aliases: []
   parents:
   - 53548
 2207024:
-  aliases: ['Aedes sp. BIOUG24729-H05']
+  aliases: []
   parents:
   - 53548
 2207025:
-  aliases: ['Aedes sp. BIOUG24729-H07']
+  aliases: []
   parents:
   - 53548
 2207026:
-  aliases: ['Aedes sp. BIOUG24729-H09']
+  aliases: []
   parents:
   - 53548
 2207027:
-  aliases: ['Aedes sp. BIOUG24729-H10']
+  aliases: []
   parents:
   - 53548
 2314936:
-  aliases: ['Aedes sp. BIOUG25044-D07']
+  aliases: []
   parents:
   - 53548
 2314928:
-  aliases: ['Aedes sp. BIOUG25044-D08']
+  aliases: []
   parents:
   - 53548
 2314900:
-  aliases: ['Aedes sp. BIOUG25044-G02']
+  aliases: []
   parents:
   - 53548
 2314925:
-  aliases: ['Aedes sp. BIOUG25044-G11']
+  aliases: []
   parents:
   - 53548
 2314978:
-  aliases: ['Aedes sp. BIOUG25128-G10']
+  aliases: []
   parents:
   - 53548
 2314946:
-  aliases: ['Aedes sp. BIOUG25294-E08']
+  aliases: []
   parents:
   - 53548
 2207028:
-  aliases: ['Aedes sp. BIOUG25382-C03']
+  aliases: []
   parents:
   - 53548
 2314997:
-  aliases: ['Aedes sp. BIOUG25546-E02']
+  aliases: []
   parents:
   - 53548
 2314964:
-  aliases: ['Aedes sp. BIOUG25708-A11']
+  aliases: []
   parents:
   - 53548
 2207029:
-  aliases: ['Aedes sp. BIOUG26184-D09']
+  aliases: []
   parents:
   - 53548
 2207030:
-  aliases: ['Aedes sp. BIOUG26185-A02']
+  aliases: []
   parents:
   - 53548
 2207031:
-  aliases: ['Aedes sp. BIOUG26185-A03']
+  aliases: []
   parents:
   - 53548
 2207032:
-  aliases: ['Aedes sp. BIOUG26185-A04']
+  aliases: []
   parents:
   - 53548
 2207033:
-  aliases: ['Aedes sp. BIOUG26185-A05']
+  aliases: []
   parents:
   - 53548
 2207034:
-  aliases: ['Aedes sp. BIOUG26185-A10']
+  aliases: []
   parents:
   - 53548
 2207035:
-  aliases: ['Aedes sp. BIOUG26185-B02']
+  aliases: []
   parents:
   - 53548
 2207036:
-  aliases: ['Aedes sp. BIOUG26185-B07']
+  aliases: []
   parents:
   - 53548
 2207037:
-  aliases: ['Aedes sp. BIOUG26185-B09']
+  aliases: []
   parents:
   - 53548
 2207038:
-  aliases: ['Aedes sp. BIOUG26185-B11']
+  aliases: []
   parents:
   - 53548
 2207039:
-  aliases: ['Aedes sp. BIOUG26185-C01']
+  aliases: []
   parents:
   - 53548
 2207040:
-  aliases: ['Aedes sp. BIOUG26185-C03']
+  aliases: []
   parents:
   - 53548
 2207041:
-  aliases: ['Aedes sp. BIOUG26185-D09']
+  aliases: []
   parents:
   - 53548
 2207042:
-  aliases: ['Aedes sp. BIOUG26185-D11']
+  aliases: []
   parents:
   - 53548
 2207043:
-  aliases: ['Aedes sp. BIOUG26185-D12']
+  aliases: []
   parents:
   - 53548
 2207044:
-  aliases: ['Aedes sp. BIOUG26185-E01']
+  aliases: []
   parents:
   - 53548
 2207045:
-  aliases: ['Aedes sp. BIOUG26185-E02']
+  aliases: []
   parents:
   - 53548
 2207046:
-  aliases: ['Aedes sp. BIOUG26185-E03']
+  aliases: []
   parents:
   - 53548
 2207047:
-  aliases: ['Aedes sp. BIOUG26185-E04']
+  aliases: []
   parents:
   - 53548
 2207048:
-  aliases: ['Aedes sp. BIOUG26185-E10']
+  aliases: []
   parents:
   - 53548
 2207049:
-  aliases: ['Aedes sp. BIOUG26185-G05']
+  aliases: []
   parents:
   - 53548
 2207050:
-  aliases: ['Aedes sp. BIOUG26185-G06']
+  aliases: []
   parents:
   - 53548
 2207051:
-  aliases: ['Aedes sp. BIOUG26185-G10']
+  aliases: []
   parents:
   - 53548
 2207052:
-  aliases: ['Aedes sp. BIOUG26185-H01']
+  aliases: []
   parents:
   - 53548
 2207053:
-  aliases: ['Aedes sp. BIOUG26185-H02']
+  aliases: []
   parents:
   - 53548
 2207054:
-  aliases: ['Aedes sp. BIOUG26185-H03']
+  aliases: []
   parents:
   - 53548
 2207055:
-  aliases: ['Aedes sp. BIOUG26185-H05']
+  aliases: []
   parents:
   - 53548
 2207056:
-  aliases: ['Aedes sp. BIOUG26185-H09']
+  aliases: []
   parents:
   - 53548
 2207057:
-  aliases: ['Aedes sp. BIOUG26185-H11']
+  aliases: []
   parents:
   - 53548
 2207058:
-  aliases: ['Aedes sp. BIOUG26186-B10']
+  aliases: []
   parents:
   - 53548
 2207059:
-  aliases: ['Aedes sp. BIOUG26190-A01']
+  aliases: []
   parents:
   - 53548
 2207060:
-  aliases: ['Aedes sp. BIOUG26190-A02']
+  aliases: []
   parents:
   - 53548
 2207061:
-  aliases: ['Aedes sp. BIOUG26190-A03']
+  aliases: []
   parents:
   - 53548
 2207062:
-  aliases: ['Aedes sp. BIOUG26190-A04']
+  aliases: []
   parents:
   - 53548
 2207063:
-  aliases: ['Aedes sp. BIOUG26190-A05']
+  aliases: []
   parents:
   - 53548
 2207064:
-  aliases: ['Aedes sp. BIOUG26190-A07']
+  aliases: []
   parents:
   - 53548
 2207065:
-  aliases: ['Aedes sp. BIOUG26190-E01']
+  aliases: []
   parents:
   - 53548
 2207066:
-  aliases: ['Aedes sp. BIOUG26190-E09']
+  aliases: []
   parents:
   - 53548
 2207067:
-  aliases: ['Aedes sp. BIOUG26261-A01']
+  aliases: []
   parents:
   - 53548
 2207068:
-  aliases: ['Aedes sp. BIOUG26261-B10']
+  aliases: []
   parents:
   - 53548
 2207069:
-  aliases: ['Aedes sp. BIOUG26264-C05']
+  aliases: []
   parents:
   - 53548
 2207070:
-  aliases: ['Aedes sp. BIOUG26264-C06']
+  aliases: []
   parents:
   - 53548
 2207071:
-  aliases: ['Aedes sp. BIOUG26622-H08']
+  aliases: []
   parents:
   - 53548
 2207072:
-  aliases: ['Aedes sp. BIOUG26623-A05']
+  aliases: []
   parents:
   - 53548
 2207073:
-  aliases: ['Aedes sp. BIOUG26660-D11']
+  aliases: []
   parents:
   - 53548
 2207074:
-  aliases: ['Aedes sp. BIOUG26660-F01']
+  aliases: []
   parents:
   - 53548
 2207075:
-  aliases: ['Aedes sp. BIOUG26660-H03']
+  aliases: []
   parents:
   - 53548
 2207076:
-  aliases: ['Aedes sp. BIOUG26660-H06']
+  aliases: []
   parents:
   - 53548
 2207077:
-  aliases: ['Aedes sp. BIOUG26664-A08']
+  aliases: []
   parents:
   - 53548
 2207078:
-  aliases: ['Aedes sp. BIOUG26749-G02']
+  aliases: []
   parents:
   - 53548
 2207079:
-  aliases: ['Aedes sp. BIOUG26776-A03']
+  aliases: []
   parents:
   - 53548
 2207080:
-  aliases: ['Aedes sp. BIOUG26781-C10']
+  aliases: []
   parents:
   - 53548
 2207081:
-  aliases: ['Aedes sp. BIOUG26781-D07']
+  aliases: []
   parents:
   - 53548
 2207082:
-  aliases: ['Aedes sp. BIOUG26781-E12']
+  aliases: []
   parents:
   - 53548
 2207083:
-  aliases: ['Aedes sp. BIOUG26781-G06']
+  aliases: []
   parents:
   - 53548
 2207084:
-  aliases: ['Aedes sp. BIOUG26782-A07']
+  aliases: []
   parents:
   - 53548
 2207085:
-  aliases: ['Aedes sp. BIOUG26782-C01']
+  aliases: []
   parents:
   - 53548
 2207086:
-  aliases: ['Aedes sp. BIOUG26782-C04']
+  aliases: []
   parents:
   - 53548
 2207087:
-  aliases: ['Aedes sp. BIOUG26782-C07']
+  aliases: []
   parents:
   - 53548
 2207088:
-  aliases: ['Aedes sp. BIOUG26782-G03']
+  aliases: []
   parents:
   - 53548
 2207089:
-  aliases: ['Aedes sp. BIOUG26782-G10']
+  aliases: []
   parents:
   - 53548
 2207090:
-  aliases: ['Aedes sp. BIOUG26789-C02']
+  aliases: []
   parents:
   - 53548
 2207091:
-  aliases: ['Aedes sp. BIOUG26792-F04']
+  aliases: []
   parents:
   - 53548
 2207092:
-  aliases: ['Aedes sp. BIOUG26807-B01']
+  aliases: []
   parents:
   - 53548
 2207093:
-  aliases: ['Aedes sp. BIOUG26810-C02']
+  aliases: []
   parents:
   - 53548
 2207094:
-  aliases: ['Aedes sp. BIOUG26832-E05']
+  aliases: []
   parents:
   - 53548
 2207095:
-  aliases: ['Aedes sp. BIOUG26948-C09']
+  aliases: []
   parents:
   - 53548
 2207096:
-  aliases: ['Aedes sp. BIOUG26948-G05']
+  aliases: []
   parents:
   - 53548
 2207097:
-  aliases: ['Aedes sp. BIOUG26981-F09']
+  aliases: []
   parents:
   - 53548
 2207098:
-  aliases: ['Aedes sp. BIOUG26982-H03']
+  aliases: []
   parents:
   - 53548
 2207099:
-  aliases: ['Aedes sp. BIOUG26983-B06']
+  aliases: []
   parents:
   - 53548
 2207100:
-  aliases: ['Aedes sp. BIOUG26984-H10']
+  aliases: []
   parents:
   - 53548
 2207101:
-  aliases: ['Aedes sp. BIOUG26987-C08']
+  aliases: []
   parents:
   - 53548
 2207102:
-  aliases: ['Aedes sp. BIOUG26988-A03']
+  aliases: []
   parents:
   - 53548
 2207103:
-  aliases: ['Aedes sp. BIOUG27050-C08']
+  aliases: []
   parents:
   - 53548
 2207104:
-  aliases: ['Aedes sp. BIOUG27066-A12']
+  aliases: []
   parents:
   - 53548
 2207105:
-  aliases: ['Aedes sp. BIOUG27066-E12']
+  aliases: []
   parents:
   - 53548
 2207106:
-  aliases: ['Aedes sp. BIOUG27067-A11']
+  aliases: []
   parents:
   - 53548
 2207107:
-  aliases: ['Aedes sp. BIOUG27068-H07']
+  aliases: []
   parents:
   - 53548
 2207108:
-  aliases: ['Aedes sp. BIOUG27079-A10']
+  aliases: []
   parents:
   - 53548
 2207109:
-  aliases: ['Aedes sp. BIOUG27079-F01']
+  aliases: []
   parents:
   - 53548
 2207110:
-  aliases: ['Aedes sp. BIOUG27079-F08']
+  aliases: []
   parents:
   - 53548
 2207111:
-  aliases: ['Aedes sp. BIOUG27093-G03']
+  aliases: []
   parents:
   - 53548
 2207112:
-  aliases: ['Aedes sp. BIOUG27097-E10']
+  aliases: []
   parents:
   - 53548
 2207113:
-  aliases: ['Aedes sp. BIOUG27097-G10']
+  aliases: []
   parents:
   - 53548
 2207114:
-  aliases: ['Aedes sp. BIOUG27097-H09']
+  aliases: []
   parents:
   - 53548
 2207115:
-  aliases: ['Aedes sp. BIOUG27101-D02']
+  aliases: []
   parents:
   - 53548
 2207116:
-  aliases: ['Aedes sp. BIOUG27102-B05']
+  aliases: []
   parents:
   - 53548
 2207117:
-  aliases: ['Aedes sp. BIOUG27104-A07']
+  aliases: []
   parents:
   - 53548
 2207118:
-  aliases: ['Aedes sp. BIOUG27104-A10']
+  aliases: []
   parents:
   - 53548
 2207119:
-  aliases: ['Aedes sp. BIOUG27104-B10']
+  aliases: []
   parents:
   - 53548
 2207120:
-  aliases: ['Aedes sp. BIOUG27104-C04']
+  aliases: []
   parents:
   - 53548
 2207121:
-  aliases: ['Aedes sp. BIOUG27104-D03']
+  aliases: []
   parents:
   - 53548
 2207122:
-  aliases: ['Aedes sp. BIOUG27104-D09']
+  aliases: []
   parents:
   - 53548
 2207123:
-  aliases: ['Aedes sp. BIOUG27104-F02']
+  aliases: []
   parents:
   - 53548
 2207124:
-  aliases: ['Aedes sp. BIOUG27104-G10']
+  aliases: []
   parents:
   - 53548
 2207125:
-  aliases: ['Aedes sp. BIOUG27105-A10']
+  aliases: []
   parents:
   - 53548
 2207126:
-  aliases: ['Aedes sp. BIOUG27105-A11']
+  aliases: []
   parents:
   - 53548
 2207127:
-  aliases: ['Aedes sp. BIOUG27105-B01']
+  aliases: []
   parents:
   - 53548
 2207128:
-  aliases: ['Aedes sp. BIOUG27105-B06']
+  aliases: []
   parents:
   - 53548
 2207129:
-  aliases: ['Aedes sp. BIOUG27105-D03']
+  aliases: []
   parents:
   - 53548
 2207130:
-  aliases: ['Aedes sp. BIOUG27157-H11']
+  aliases: []
   parents:
   - 53548
 2207131:
-  aliases: ['Aedes sp. BIOUG27158-D07']
+  aliases: []
   parents:
   - 53548
 2207132:
-  aliases: ['Aedes sp. BIOUG27173-D12']
+  aliases: []
   parents:
   - 53548
 2207133:
-  aliases: ['Aedes sp. BIOUG27226-D10']
+  aliases: []
   parents:
   - 53548
 2207134:
-  aliases: ['Aedes sp. BIOUG27355-D10']
+  aliases: []
   parents:
   - 53548
 2207135:
-  aliases: ['Aedes sp. BIOUG27357-F02']
+  aliases: []
   parents:
   - 53548
 2207136:
-  aliases: ['Aedes sp. BIOUG27360-A07']
+  aliases: []
   parents:
   - 53548
 2207137:
-  aliases: ['Aedes sp. BIOUG27360-B08']
+  aliases: []
   parents:
   - 53548
 2207138:
-  aliases: ['Aedes sp. BIOUG27360-C07']
+  aliases: []
   parents:
   - 53548
 2207139:
-  aliases: ['Aedes sp. BIOUG27362-H01']
+  aliases: []
   parents:
   - 53548
 2207140:
-  aliases: ['Aedes sp. BIOUG27391-E04']
+  aliases: []
   parents:
   - 53548
 2207141:
-  aliases: ['Aedes sp. BIOUG27454-G03']
+  aliases: []
   parents:
   - 53548
 2207142:
-  aliases: ['Aedes sp. BIOUG27473-F08']
+  aliases: []
   parents:
   - 53548
 2207143:
-  aliases: ['Aedes sp. BIOUG27485-D03']
+  aliases: []
   parents:
   - 53548
 2207144:
-  aliases: ['Aedes sp. BIOUG27485-E11']
+  aliases: []
   parents:
   - 53548
 2207145:
-  aliases: ['Aedes sp. BIOUG27485-G07']
+  aliases: []
   parents:
   - 53548
 2207146:
-  aliases: ['Aedes sp. BIOUG27486-G12']
+  aliases: []
   parents:
   - 53548
 2207147:
-  aliases: ['Aedes sp. BIOUG27488-F10']
+  aliases: []
   parents:
   - 53548
 2207148:
-  aliases: ['Aedes sp. BIOUG27593-H01']
+  aliases: []
   parents:
   - 53548
 1887054:
-  aliases: ['Aedes sp. BOLD-2016']
+  aliases: []
   parents:
   - 53548
 1052690:
-  aliases: ['Aedes sp. BOLD:AAA3748']
+  aliases: []
   parents:
   - 53548
 1214559:
-  aliases: ['Aedes sp. BOLD:AAA3750']
+  aliases: []
   parents:
   - 53548
 1052688:
-  aliases: ['Aedes sp. BOLD:AAA3751']
+  aliases: []
   parents:
   - 53548
 1695049:
-  aliases: ['Aedes sp. BOLD:AAA7067']
+  aliases: []
   parents:
   - 53548
 1052687:
-  aliases: ['Aedes sp. BOLD:AAB1098']
+  aliases: []
   parents:
   - 53548
 1823607:
-  aliases: ['Aedes sp. BOLD:AAB5696']
+  aliases: []
   parents:
   - 53548
 1754994:
-  aliases: ['Aedes sp. BOLD:AAC1238']
+  aliases: []
   parents:
   - 53548
 1725037:
-  aliases: ['Aedes sp. BOLD:AAC5210']
+  aliases: []
   parents:
   - 53548
 1214558:
-  aliases: ['Aedes sp. BOLD:AAC9062']
+  aliases: []
   parents:
   - 53548
 1725038:
-  aliases: ['Aedes sp. BOLD:AAC9476']
+  aliases: []
   parents:
   - 53548
 1725039:
-  aliases: ['Aedes sp. BOLD:AAC9486']
+  aliases: []
   parents:
   - 53548
 1823608:
-  aliases: ['Aedes sp. BOLD:AAD4355']
+  aliases: []
   parents:
   - 53548
 1081110:
-  aliases: ['Aedes sp. BOLD:AAF2904']
+  aliases: []
   parents:
   - 53548
 1214560:
-  aliases: ['Aedes sp. BOLD:AAT9839']
+  aliases: []
   parents:
   - 53548
 2657465:
-  aliases: ['Aedes sp. BOLD:AAV4154']
+  aliases: []
   parents:
   - 53548
 1695050:
-  aliases: ['Aedes sp. BOLD:ABY6840']
+  aliases: []
   parents:
   - 53548
 1754995:
-  aliases: ['Aedes sp. BOLD:ACE3097']
+  aliases: []
   parents:
   - 53548
 1665014:
-  aliases: ['Aedes sp. BOLD:ACG8854']
+  aliases: []
   parents:
   - 53548
 1829911:
-  aliases: ['Aedes sp. BOLD:ACI4651']
+  aliases: []
   parents:
   - 53548
 1578835:
-  aliases: ['Aedes sp. BTLHVDV-2014']
+  aliases: []
   parents:
   - 53548
 2326404:
-  aliases: ['Aedes sp. DARC222-10']
+  aliases: []
   parents:
   - 53548
 2326405:
-  aliases: ['Aedes sp. DARC225-10']
+  aliases: []
   parents:
   - 53548
 2326406:
-  aliases: ['Aedes sp. DARC228-10']
+  aliases: []
   parents:
   - 53548
 2326407:
-  aliases: ['Aedes sp. DARC233-10']
+  aliases: []
   parents:
   - 53548
 2326408:
-  aliases: ['Aedes sp. DARC257-11']
+  aliases: []
   parents:
   - 53548
 681643:
-  aliases: ['Aedes sp. EH-2009']
+  aliases: []
   parents:
   - 53548
 1907893:
-  aliases: ['Aedes sp. GM-2016']
+  aliases: []
   parents:
   - 53548
 2596824:
-  aliases: ['Aedes sp. GW76']
+  aliases: []
   parents:
   - 53548
 2314914:
-  aliases: ['Aedes sp. HC-12-01']
+  aliases: []
   parents:
   - 53548
 2314935:
-  aliases: ['Aedes sp. HC-15-04']
+  aliases: []
   parents:
   - 53548
 2326409:
-  aliases: ['Aedes sp. JSDIP336-10']
+  aliases: []
   parents:
   - 53548
 2326410:
-  aliases: ['Aedes sp. JSDIP444-10']
+  aliases: []
   parents:
   - 53548
 2326411:
-  aliases: ['Aedes sp. JSDIP620-10']
+  aliases: []
   parents:
   - 53548
 2326412:
-  aliases: ['Aedes sp. JSDIP740-10']
+  aliases: []
   parents:
   - 53548
 2326413:
-  aliases: ['Aedes sp. JSDIP917-10']
+  aliases: []
   parents:
   - 53548
 2326414:
-  aliases: ['Aedes sp. JWDCA312-10']
+  aliases: []
   parents:
   - 53548
 2326415:
-  aliases: ['Aedes sp. JWDCA317-10']
+  aliases: []
   parents:
   - 53548
 2326416:
-  aliases: ['Aedes sp. JWDCB144-10']
+  aliases: []
   parents:
   - 53548
 2326417:
-  aliases: ['Aedes sp. JWDCB148-10']
+  aliases: []
   parents:
   - 53548
 2326418:
-  aliases: ['Aedes sp. JWDCC056-10']
+  aliases: []
   parents:
   - 53548
 2326419:
-  aliases: ['Aedes sp. JWDCC057-10']
+  aliases: []
   parents:
   - 53548
 2326420:
-  aliases: ['Aedes sp. JWDCC058-10']
+  aliases: []
   parents:
   - 53548
 2326421:
-  aliases: ['Aedes sp. JWDCC070-10']
+  aliases: []
   parents:
   - 53548
 2326422:
-  aliases: ['Aedes sp. JWDCC071-10']
+  aliases: []
   parents:
   - 53548
 2326423:
-  aliases: ['Aedes sp. JWDCC110-10']
+  aliases: []
   parents:
   - 53548
 2326424:
-  aliases: ['Aedes sp. JWDCC111-10']
+  aliases: []
   parents:
   - 53548
 2326425:
-  aliases: ['Aedes sp. JWDCC112-10']
+  aliases: []
   parents:
   - 53548
 2326426:
-  aliases: ['Aedes sp. JWDCC113-10']
+  aliases: []
   parents:
   - 53548
 2326427:
-  aliases: ['Aedes sp. JWDCC133-10']
+  aliases: []
   parents:
   - 53548
 2326428:
-  aliases: ['Aedes sp. JWDCC134-10']
+  aliases: []
   parents:
   - 53548
 2326429:
-  aliases: ['Aedes sp. JWDCC137-10']
+  aliases: []
   parents:
   - 53548
 2326430:
-  aliases: ['Aedes sp. JWDCC179-10']
+  aliases: []
   parents:
   - 53548
 2326431:
-  aliases: ['Aedes sp. JWDCC181-10']
+  aliases: []
   parents:
   - 53548
 2326432:
-  aliases: ['Aedes sp. JWDCC202-10']
+  aliases: []
   parents:
   - 53548
 2326433:
-  aliases: ['Aedes sp. JWDCC224-10']
+  aliases: []
   parents:
   - 53548
 2326434:
-  aliases: ['Aedes sp. JWDCC226-10']
+  aliases: []
   parents:
   - 53548
 2326435:
-  aliases: ['Aedes sp. JWDCC268-10']
+  aliases: []
   parents:
   - 53548
 2326436:
-  aliases: ['Aedes sp. JWDCC271-10']
+  aliases: []
   parents:
   - 53548
 2326437:
-  aliases: ['Aedes sp. JWDCC432-10']
+  aliases: []
   parents:
   - 53548
 2326438:
-  aliases: ['Aedes sp. JWDCC434-10']
+  aliases: []
   parents:
   - 53548
 2326439:
-  aliases: ['Aedes sp. JWDCC435-10']
+  aliases: []
   parents:
   - 53548
 2326440:
-  aliases: ['Aedes sp. JWDCC436-10']
+  aliases: []
   parents:
   - 53548
 2326441:
-  aliases: ['Aedes sp. JWDCC437-10']
+  aliases: []
   parents:
   - 53548
 2326442:
-  aliases: ['Aedes sp. JWDCC444-10']
+  aliases: []
   parents:
   - 53548
 2326443:
-  aliases: ['Aedes sp. JWDCC446-10']
+  aliases: []
   parents:
   - 53548
 2326444:
-  aliases: ['Aedes sp. JWDCC449-10']
+  aliases: []
   parents:
   - 53548
 2326445:
-  aliases: ['Aedes sp. JWDCC453-10']
+  aliases: []
   parents:
   - 53548
 2326446:
-  aliases: ['Aedes sp. JWDCC454-10']
+  aliases: []
   parents:
   - 53548
 2326447:
-  aliases: ['Aedes sp. JWDCC455-10']
+  aliases: []
   parents:
   - 53548
 2326448:
-  aliases: ['Aedes sp. JWDCC456-10']
+  aliases: []
   parents:
   - 53548
 2326449:
-  aliases: ['Aedes sp. JWDCC461-10']
+  aliases: []
   parents:
   - 53548
 2326450:
-  aliases: ['Aedes sp. JWDCC462-10']
+  aliases: []
   parents:
   - 53548
 2326451:
-  aliases: ['Aedes sp. JWDCC463-10']
+  aliases: []
   parents:
   - 53548
 2326452:
-  aliases: ['Aedes sp. JWDCC464-10']
+  aliases: []
   parents:
   - 53548
 2326453:
-  aliases: ['Aedes sp. JWDCC469-10']
+  aliases: []
   parents:
   - 53548
 2326454:
-  aliases: ['Aedes sp. JWDCC471-10']
+  aliases: []
   parents:
   - 53548
 2326455:
-  aliases: ['Aedes sp. JWDCC475-10']
+  aliases: []
   parents:
   - 53548
 2326456:
-  aliases: ['Aedes sp. JWDCC777-10']
+  aliases: []
   parents:
   - 53548
 2326457:
-  aliases: ['Aedes sp. JWDCC778-10']
+  aliases: []
   parents:
   - 53548
 2326458:
-  aliases: ['Aedes sp. JWDCC779-10']
+  aliases: []
   parents:
   - 53548
 2326459:
-  aliases: ['Aedes sp. JWDCC780-10']
+  aliases: []
   parents:
   - 53548
 2326460:
-  aliases: ['Aedes sp. JWDCC878-10']
+  aliases: []
   parents:
   - 53548
 2326461:
-  aliases: ['Aedes sp. JWDCC901-10']
+  aliases: []
   parents:
   - 53548
 2326462:
-  aliases: ['Aedes sp. JWDCD001-10']
+  aliases: []
   parents:
   - 53548
 2326463:
-  aliases: ['Aedes sp. JWDCD097-10']
+  aliases: []
   parents:
   - 53548
 2326464:
-  aliases: ['Aedes sp. JWDCD100-10']
+  aliases: []
   parents:
   - 53548
 2326465:
-  aliases: ['Aedes sp. JWDCD104-10']
+  aliases: []
   parents:
   - 53548
 2326466:
-  aliases: ['Aedes sp. JWDCD106-10']
+  aliases: []
   parents:
   - 53548
 2326467:
-  aliases: ['Aedes sp. JWDCD123-10']
+  aliases: []
   parents:
   - 53548
 2326468:
-  aliases: ['Aedes sp. JWDCD135-10']
+  aliases: []
   parents:
   - 53548
 2326469:
-  aliases: ['Aedes sp. JWDCD177-10']
+  aliases: []
   parents:
   - 53548
 2326470:
-  aliases: ['Aedes sp. JWDCE528-10']
+  aliases: []
   parents:
   - 53548
 2326471:
-  aliases: ['Aedes sp. JWDCE529-10']
+  aliases: []
   parents:
   - 53548
 2326472:
-  aliases: ['Aedes sp. JWDCE530-10']
+  aliases: []
   parents:
   - 53548
 2326473:
-  aliases: ['Aedes sp. JWDCE549-10']
+  aliases: []
   parents:
   - 53548
 2326474:
-  aliases: ['Aedes sp. JWDCE649-10']
+  aliases: []
   parents:
   - 53548
 2326475:
-  aliases: ['Aedes sp. JWDCE650-10']
+  aliases: []
   parents:
   - 53548
 2326476:
-  aliases: ['Aedes sp. JWDCE651-10']
+  aliases: []
   parents:
   - 53548
 2326477:
-  aliases: ['Aedes sp. JWDCE703-10']
+  aliases: []
   parents:
   - 53548
 2326478:
-  aliases: ['Aedes sp. JWDCE781-10']
+  aliases: []
   parents:
   - 53548
 2326479:
-  aliases: ['Aedes sp. JWDCE793-10']
+  aliases: []
   parents:
   - 53548
 2326480:
-  aliases: ['Aedes sp. JWDCE794-10']
+  aliases: []
   parents:
   - 53548
 2326481:
-  aliases: ['Aedes sp. JWDCE795-10']
+  aliases: []
   parents:
   - 53548
 2326482:
-  aliases: ['Aedes sp. JWDCE798-10']
+  aliases: []
   parents:
   - 53548
 2326483:
-  aliases: ['Aedes sp. JWDCE799-10']
+  aliases: []
   parents:
   - 53548
 2326484:
-  aliases: ['Aedes sp. JWDCE800-10']
+  aliases: []
   parents:
   - 53548
 2326485:
-  aliases: ['Aedes sp. JWDCE831-10']
+  aliases: []
   parents:
   - 53548
 2326486:
-  aliases: ['Aedes sp. JWDCE832-10']
+  aliases: []
   parents:
   - 53548
 2326487:
-  aliases: ['Aedes sp. JWDCE851-10']
+  aliases: []
   parents:
   - 53548
 2326488:
-  aliases: ['Aedes sp. JWDCE853-10']
+  aliases: []
   parents:
   - 53548
 2326489:
-  aliases: ['Aedes sp. JWDCE865-10']
+  aliases: []
   parents:
   - 53548
 2326490:
-  aliases: ['Aedes sp. JWDCE866-10']
+  aliases: []
   parents:
   - 53548
 2326491:
-  aliases: ['Aedes sp. JWDCE903-10']
+  aliases: []
   parents:
   - 53548
 2326492:
-  aliases: ['Aedes sp. JWDCE922-10']
+  aliases: []
   parents:
   - 53548
 2326493:
-  aliases: ['Aedes sp. JWDCE923-10']
+  aliases: []
   parents:
   - 53548
 2326494:
-  aliases: ['Aedes sp. JWDCE927-10']
+  aliases: []
   parents:
   - 53548
 2326495:
-  aliases: ['Aedes sp. JWDCE928-10']
+  aliases: []
   parents:
   - 53548
 2326496:
-  aliases: ['Aedes sp. JWDCE929-10']
+  aliases: []
   parents:
   - 53548
 2326497:
-  aliases: ['Aedes sp. JWDCF060-10']
+  aliases: []
   parents:
   - 53548
 2326498:
-  aliases: ['Aedes sp. JWDCF061-10']
+  aliases: []
   parents:
   - 53548
 2326499:
-  aliases: ['Aedes sp. JWDCF062-10']
+  aliases: []
   parents:
   - 53548
 2326500:
-  aliases: ['Aedes sp. JWDCF139-10']
+  aliases: []
   parents:
   - 53548
 2326501:
-  aliases: ['Aedes sp. JWDCF172-10']
+  aliases: []
   parents:
   - 53548
 2326502:
-  aliases: ['Aedes sp. JWDCF335-10']
+  aliases: []
   parents:
   - 53548
 2326503:
-  aliases: ['Aedes sp. JWDCF370-10']
+  aliases: []
   parents:
   - 53548
 2326504:
-  aliases: ['Aedes sp. JWDCF372-10']
+  aliases: []
   parents:
   - 53548
 2326505:
-  aliases: ['Aedes sp. JWDCF380-10']
+  aliases: []
   parents:
   - 53548
 2326506:
-  aliases: ['Aedes sp. JWDCF382-10']
+  aliases: []
   parents:
   - 53548
 2326507:
-  aliases: ['Aedes sp. JWDCF431-10']
+  aliases: []
   parents:
   - 53548
 2326508:
-  aliases: ['Aedes sp. JWDCF443-10']
+  aliases: []
   parents:
   - 53548
 2326509:
-  aliases: ['Aedes sp. JWDCF445-10']
+  aliases: []
   parents:
   - 53548
 2326510:
-  aliases: ['Aedes sp. JWDCF466-10']
+  aliases: []
   parents:
   - 53548
 2326511:
-  aliases: ['Aedes sp. JWDCF487-10']
+  aliases: []
   parents:
   - 53548
 2326512:
-  aliases: ['Aedes sp. JWDCF488-10']
+  aliases: []
   parents:
   - 53548
 2326513:
-  aliases: ['Aedes sp. JWDCF489-10']
+  aliases: []
   parents:
   - 53548
 2326514:
-  aliases: ['Aedes sp. JWDCF491-10']
+  aliases: []
   parents:
   - 53548
 2326515:
-  aliases: ['Aedes sp. JWDCF512-10']
+  aliases: []
   parents:
   - 53548
 2326516:
-  aliases: ['Aedes sp. JWDCF534-10']
+  aliases: []
   parents:
   - 53548
 2326517:
-  aliases: ['Aedes sp. JWDCF536-10']
+  aliases: []
   parents:
   - 53548
 2326518:
-  aliases: ['Aedes sp. JWDCF571-10']
+  aliases: []
   parents:
   - 53548
 2326519:
-  aliases: ['Aedes sp. JWDCF572-10']
+  aliases: []
   parents:
   - 53548
 2326520:
-  aliases: ['Aedes sp. JWDCF583-10']
+  aliases: []
   parents:
   - 53548
 2326521:
-  aliases: ['Aedes sp. JWDCF584-10']
+  aliases: []
   parents:
   - 53548
 2326522:
-  aliases: ['Aedes sp. JWDCF585-10']
+  aliases: []
   parents:
   - 53548
 2326523:
-  aliases: ['Aedes sp. JWDCF602-10']
+  aliases: []
   parents:
   - 53548
 2326524:
-  aliases: ['Aedes sp. JWDCF603-10']
+  aliases: []
   parents:
   - 53548
 2326525:
-  aliases: ['Aedes sp. JWDCF625-10']
+  aliases: []
   parents:
   - 53548
 2326526:
-  aliases: ['Aedes sp. JWDCF626-10']
+  aliases: []
   parents:
   - 53548
 2326527:
-  aliases: ['Aedes sp. JWDCF644-10']
+  aliases: []
   parents:
   - 53548
 2326528:
-  aliases: ['Aedes sp. JWDCF676-10']
+  aliases: []
   parents:
   - 53548
 2326529:
-  aliases: ['Aedes sp. JWDCF678-10']
+  aliases: []
   parents:
   - 53548
 2326530:
-  aliases: ['Aedes sp. JWDCF713-10']
+  aliases: []
   parents:
   - 53548
 2326531:
-  aliases: ['Aedes sp. JWDCG126-10']
+  aliases: []
   parents:
   - 53548
 2326532:
-  aliases: ['Aedes sp. JWDCG210-10']
+  aliases: []
   parents:
   - 53548
 2326533:
-  aliases: ['Aedes sp. JWDCG211-10']
+  aliases: []
   parents:
   - 53548
 2326534:
-  aliases: ['Aedes sp. JWDCG624-10']
+  aliases: []
   parents:
   - 53548
 2326535:
-  aliases: ['Aedes sp. JWDCG626-10']
+  aliases: []
   parents:
   - 53548
 2326536:
-  aliases: ['Aedes sp. JWDCG695-10']
+  aliases: []
   parents:
   - 53548
 2326537:
-  aliases: ['Aedes sp. JWDCH008-10']
+  aliases: []
   parents:
   - 53548
 2326538:
-  aliases: ['Aedes sp. JWDCH047-10']
+  aliases: []
   parents:
   - 53548
 2326539:
-  aliases: ['Aedes sp. JWDCH263-10']
+  aliases: []
   parents:
   - 53548
 2326540:
-  aliases: ['Aedes sp. JWDCH389-10']
+  aliases: []
   parents:
   - 53548
 2326541:
-  aliases: ['Aedes sp. JWDCH390-10']
+  aliases: []
   parents:
   - 53548
 2326542:
-  aliases: ['Aedes sp. JWDCH441-10']
+  aliases: []
   parents:
   - 53548
 2326543:
-  aliases: ['Aedes sp. JWDCH738-10']
+  aliases: []
   parents:
   - 53548
 2326544:
-  aliases: ['Aedes sp. JWDCH815-10']
+  aliases: []
   parents:
   - 53548
 2326545:
-  aliases: ['Aedes sp. JWDCH966-10']
+  aliases: []
   parents:
   - 53548
 2326546:
-  aliases: ['Aedes sp. JWDCH967-10']
+  aliases: []
   parents:
   - 53548
 2326547:
-  aliases: ['Aedes sp. JWDCI048-10']
+  aliases: []
   parents:
   - 53548
 2326548:
-  aliases: ['Aedes sp. JWDCI275-10']
+  aliases: []
   parents:
   - 53548
 2326549:
-  aliases: ['Aedes sp. JWDCI310-10']
+  aliases: []
   parents:
   - 53548
 2326550:
-  aliases: ['Aedes sp. JWDCI326-10']
+  aliases: []
   parents:
   - 53548
 2326551:
-  aliases: ['Aedes sp. JWDCI375-10']
+  aliases: []
   parents:
   - 53548
 2326552:
-  aliases: ['Aedes sp. JWDCI583-10']
+  aliases: []
   parents:
   - 53548
 2326553:
-  aliases: ['Aedes sp. JWDCI613-10']
+  aliases: []
   parents:
   - 53548
 2326554:
-  aliases: ['Aedes sp. JWDCI669-11']
+  aliases: []
   parents:
   - 53548
 2326555:
-  aliases: ['Aedes sp. JWDCI716-11']
+  aliases: []
   parents:
   - 53548
 2326556:
-  aliases: ['Aedes sp. JWDCI812-11']
+  aliases: []
   parents:
   - 53548
 2326557:
-  aliases: ['Aedes sp. JWDCI856-11']
+  aliases: []
   parents:
   - 53548
 2326558:
-  aliases: ['Aedes sp. JWDCJ1002-11']
+  aliases: []
   parents:
   - 53548
 2326559:
-  aliases: ['Aedes sp. JWDCJ1301-11']
+  aliases: []
   parents:
   - 53548
 2326560:
-  aliases: ['Aedes sp. JWDCJ150-11']
+  aliases: []
   parents:
   - 53548
 2326561:
-  aliases: ['Aedes sp. JWDCJ1520-11']
+  aliases: []
   parents:
   - 53548
 2326562:
-  aliases: ['Aedes sp. JWDCJ218-11']
+  aliases: []
   parents:
   - 53548
 2326563:
-  aliases: ['Aedes sp. JWDCJ276-11']
+  aliases: []
   parents:
   - 53548
 2326564:
-  aliases: ['Aedes sp. JWDCJ277-11']
+  aliases: []
   parents:
   - 53548
 2326565:
-  aliases: ['Aedes sp. JWDCJ362-11']
+  aliases: []
   parents:
   - 53548
 2326566:
-  aliases: ['Aedes sp. JWDCJ363-11']
+  aliases: []
   parents:
   - 53548
 2326567:
-  aliases: ['Aedes sp. JWDCJ407-11']
+  aliases: []
   parents:
   - 53548
 2326568:
-  aliases: ['Aedes sp. JWDCJ408-11']
+  aliases: []
   parents:
   - 53548
 2326569:
-  aliases: ['Aedes sp. JWDCL361-11']
+  aliases: []
   parents:
   - 53548
 2326570:
-  aliases: ['Aedes sp. JWDCL363-11']
+  aliases: []
   parents:
   - 53548
 1803710:
-  aliases: ['Aedes sp. M11YA']
+  aliases: []
   parents:
   - 53548
 1803711:
-  aliases: ['Aedes sp. M21YA']
+  aliases: []
   parents:
   - 53548
 1529941:
-  aliases: ['Aedes sp. MA02']
+  aliases: []
   parents:
   - 53548
 3014952:
-  aliases: ['Aedes sp. Madagascar BC-2022a']
+  aliases: []
   parents:
   - 53548
 3048046:
-  aliases: ['Aedes sp. Marks No 51']
+  aliases: []
   parents:
   - 53548
 2665660:
-  aliases: ['Aedes sp. Mm-99']
+  aliases: []
   parents:
   - 53548
 2853122:
-  aliases: ['Aedes sp. P_142_FSTST']
+  aliases: []
   parents:
   - 53548
 2853121:
-  aliases: ['Aedes sp. P_273_FSTHT']
+  aliases: []
   parents:
   - 53548
 1723311:
-  aliases: ['Aedes sp. RRSSA3765-15']
+  aliases: []
   parents:
   - 53548
 1723312:
-  aliases: ['Aedes sp. RRSSA583-15']
+  aliases: []
   parents:
   - 53548
 1742201:
-  aliases: ['Aedes sp. SSJAE10225-13']
+  aliases: []
   parents:
   - 53548
 1742202:
-  aliases: ['Aedes sp. SSJAE10368-13']
+  aliases: []
   parents:
   - 53548
 1742203:
-  aliases: ['Aedes sp. SSJAE3215-13']
+  aliases: []
   parents:
   - 53548
 1742204:
-  aliases: ['Aedes sp. SSJAE8301-13']
+  aliases: []
   parents:
   - 53548
 1742205:
-  aliases: ['Aedes sp. SSJAE8302-13']
+  aliases: []
   parents:
   - 53548
 1742206:
-  aliases: ['Aedes sp. SSJAE8684-13']
+  aliases: []
   parents:
   - 53548
 1742207:
-  aliases: ['Aedes sp. SSJAE8693-13']
+  aliases: []
   parents:
   - 53548
 1742208:
-  aliases: ['Aedes sp. SSJAE8711-13']
+  aliases: []
   parents:
   - 53548
 1742209:
-  aliases: ['Aedes sp. SSJAE8755-13']
+  aliases: []
   parents:
   - 53548
 1742210:
-  aliases: ['Aedes sp. SSJAE9080-13']
+  aliases: []
   parents:
   - 53548
 1742211:
-  aliases: ['Aedes sp. SSJAE9156-13']
+  aliases: []
   parents:
   - 53548
 1742212:
-  aliases: ['Aedes sp. SSJAE9174-13']
+  aliases: []
   parents:
   - 53548
 1742213:
-  aliases: ['Aedes sp. SSJAE9245-13']
+  aliases: []
   parents:
   - 53548
 1742214:
-  aliases: ['Aedes sp. SSJAE9941-13']
+  aliases: []
   parents:
   - 53548
 1742215:
-  aliases: ['Aedes sp. SSJAE9999-13']
+  aliases: []
   parents:
   - 53548
 2314939:
-  aliases: ['Aedes sp. SW-01-04']
+  aliases: []
   parents:
   - 53548
 2314989:
-  aliases: ['Aedes sp. SW-01-08']
+  aliases: []
   parents:
   - 53548
 2326571:
-  aliases: ['Aedes sp. SWSWP011-09']
+  aliases: []
   parents:
   - 53548
 2326572:
-  aliases: ['Aedes sp. SWSWP013-09']
+  aliases: []
   parents:
   - 53548
 2326573:
-  aliases: ['Aedes sp. SWSWP016-09']
+  aliases: []
   parents:
   - 53548
 2326574:
-  aliases: ['Aedes sp. SWSWP023-09']
+  aliases: []
   parents:
   - 53548
 2326575:
-  aliases: ['Aedes sp. SWSWP026-09']
+  aliases: []
   parents:
   - 53548
 2326576:
-  aliases: ['Aedes sp. SWSWP027-09']
+  aliases: []
   parents:
   - 53548
 2326577:
-  aliases: ['Aedes sp. SWSWP028-09']
+  aliases: []
   parents:
   - 53548
 2326578:
-  aliases: ['Aedes sp. SWSWP036-09']
+  aliases: []
   parents:
   - 53548
 2326579:
-  aliases: ['Aedes sp. SWSWP048-09']
+  aliases: []
   parents:
   - 53548
 2326580:
-  aliases: ['Aedes sp. SWSWP055-09']
+  aliases: []
   parents:
   - 53548
 2326581:
-  aliases: ['Aedes sp. SWSWP056-09']
+  aliases: []
   parents:
   - 53548
 2326582:
-  aliases: ['Aedes sp. SWSWP058-09']
+  aliases: []
   parents:
   - 53548
 2326583:
-  aliases: ['Aedes sp. SWSWP059-09']
+  aliases: []
   parents:
   - 53548
 2326584:
-  aliases: ['Aedes sp. SWSWP061-09']
+  aliases: []
   parents:
   - 53548
 2326585:
-  aliases: ['Aedes sp. SWSWP063-09']
+  aliases: []
   parents:
   - 53548
 2326586:
-  aliases: ['Aedes sp. SWSWP065-09']
+  aliases: []
   parents:
   - 53548
 2326587:
-  aliases: ['Aedes sp. SWSWP067-09']
+  aliases: []
   parents:
   - 53548
 2326588:
-  aliases: ['Aedes sp. SWSWP072-09']
+  aliases: []
   parents:
   - 53548
 2326589:
-  aliases: ['Aedes sp. SWSWP074-09']
+  aliases: []
   parents:
   - 53548
 2326590:
-  aliases: ['Aedes sp. SWSWP075-09']
+  aliases: []
   parents:
   - 53548
 2326591:
-  aliases: ['Aedes sp. SWSWP076-09']
+  aliases: []
   parents:
   - 53548
 2326592:
-  aliases: ['Aedes sp. SWSWP082-09']
+  aliases: []
   parents:
   - 53548
 3682668:
-  aliases: ['Aedes sp. T76722-1']
+  aliases: []
   parents:
   - 53548
 3687342:
-  aliases: ['Aedes sp. T77541-1']
+  aliases: []
   parents:
   - 53548
 1929009:
-  aliases: ['Aedes sp. TCW-2016']
+  aliases: []
   parents:
   - 53548
 2314952:
-  aliases: ['Aedes sp. WP-04-01']
+  aliases: []
   parents:
   - 53548
 2314987:
-  aliases: ['Aedes sp. WP-04-02']
+  aliases: []
   parents:
   - 53548
 2314962:
-  aliases: ['Aedes sp. WP-04-08']
+  aliases: []
   parents:
   - 53548
 2314982:
-  aliases: ['Aedes sp. WP-04-09']
+  aliases: []
   parents:
   - 53548
 2292408:
-  aliases: ['Aedes sp. n. RPC135']
+  aliases: []
   parents:
   - 53548
 2792259:
-  aliases: ['Aedes sp. sls25']
+  aliases: []
   parents:
   - 53548
 3014962:
-  aliases: ['Aedes spinosipes']
+  aliases: []
   parents:
   - 346061
 498397:
-  aliases: ['Aedes subalbopictus']
+  aliases: []
   parents:
   - 53541
 2732660:
-  aliases: ['Aedes subargenteus']
+  aliases: []
   parents:
   - 53541
 3014963:
-  aliases: ['Aedes subbasalis']
+  aliases: []
   parents:
   - 1806171
 2793100:
-  aliases: ['Aedes subniveus']
+  aliases: []
   parents:
   - 1245382
 2067460:
-  aliases: ['Aedes sudanensis']
+  aliases: []
   parents:
   - 53543
 2773401:
-  aliases: ['Aedes suffusus']
+  aliases: []
   parents:
   - 1806188
 2880926:
-  aliases: ['Aedes suzannae']
+  aliases: []
   parents:
   - 53540
 561252:
-  aliases: ['Aedes sylvaticum']
+  aliases: []
   parents:
   - 53544
 667567:
-  aliases: ['Aedes tarsalis']
+  aliases: []
   parents:
   - 53540
 299628:
-  aliases: ['Aedes taylori']
+  aliases: []
   parents:
   - 53539
 2014627:
-  aliases: ['Aedes tiptoni']
+  aliases: []
   parents:
   - 53539
 55967:
-  aliases: ['Aedes togoi']
+  aliases: []
   parents:
   - 53542
 316598:
-  aliases: ['Aedes tongae']
+  aliases: []
   parents:
   - 53541
 1806181:
-  aliases: ['Aedes tremulus']
+  aliases: []
   parents:
   - 346061
 3043245:
-  aliases: ['Aedes unalom']
+  aliases: []
   parents:
   - 53541
 2761510:
-  aliases: ['Aedes unidentatus']
+  aliases: []
   parents:
   - 53544
 1328038:
-  aliases: ['Aedes unilineatus']
+  aliases: []
   parents:
   - 53541
 7163:
-  aliases: ['Aedes vexans']
+  aliases: []
   parents:
   - 53540
 317808:
-  aliases: ['Aedes vittatus']
+  aliases: []
   parents:
   - 300149
 69821:
-  aliases: ['Aedes w-albus']
+  aliases: []
   parents:
   - 53541
 373845:
-  aliases: ['Aedes wadai']
+  aliases: []
   parents:
   - 53541
 1214262:
-  aliases: ['Aedes watasei']
+  aliases: []
   parents:
   - 53542
 1806182:
-  aliases: ['Aedes wattensis']
+  aliases: []
   parents:
   - 346061
 149332:
-  aliases: ['Aedes xinjiangensis']
+  aliases: []
   parents:
   - 1806188
 1652501:
-  aliases: ['Aedes yamadai']
+  aliases: []
   parents:
   - 149531
 2998957:
-  aliases: ['Aedes yunnanensis']
+  aliases: []
   parents:
   - 1245384
 44484:
-  aliases: ['Anopheles']
+  aliases: []
   parents:
   - 44483
 2510662:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 107KON']
+  aliases: []
   parents:
   - 54114
 2510663:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 110KON']
+  aliases: []
   parents:
   - 54114
 2510664:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 114KON']
+  aliases: []
   parents:
   - 54114
 2510665:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 115KON']
+  aliases: []
   parents:
   - 54114
 2510666:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 116KON']
+  aliases: []
   parents:
   - 54114
 2510667:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 117KON']
+  aliases: []
   parents:
   - 54114
 2510668:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 118KON']
+  aliases: []
   parents:
   - 54114
 2510669:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 119KON']
+  aliases: []
   parents:
   - 54114
 2510670:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 120KON']
+  aliases: []
   parents:
   - 54114
 2510671:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 121KON']
+  aliases: []
   parents:
   - 54114
 2510672:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 122KON']
+  aliases: []
   parents:
   - 54114
 2510673:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 123KON']
+  aliases: []
   parents:
   - 54114
 2510674:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 124KON']
+  aliases: []
   parents:
   - 54114
 2510675:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 125KON']
+  aliases: []
   parents:
   - 54114
 2510676:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 126KON']
+  aliases: []
   parents:
   - 54114
 2510677:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 127KON']
+  aliases: []
   parents:
   - 54114
 2510678:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 128KON']
+  aliases: []
   parents:
   - 54114
 2510679:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 129KON']
+  aliases: []
   parents:
   - 54114
 2510680:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 130KON']
+  aliases: []
   parents:
   - 54114
 2510681:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 131KON']
+  aliases: []
   parents:
   - 54114
 2510682:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 132KON']
+  aliases: []
   parents:
   - 54114
 2510683:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 133KON']
+  aliases: []
   parents:
   - 54114
 2510684:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 134KON']
+  aliases: []
   parents:
   - 54114
 2510685:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 135KON']
+  aliases: []
   parents:
   - 54114
 2510686:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 136KON']
+  aliases: []
   parents:
   - 54114
 2510687:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 137KON']
+  aliases: []
   parents:
   - 54114
 2510688:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 138KON']
+  aliases: []
   parents:
   - 54114
 2510689:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 139KON']
+  aliases: []
   parents:
   - 54114
 2510690:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 140KON']
+  aliases: []
   parents:
   - 54114
 2510691:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 141KON']
+  aliases: []
   parents:
   - 54114
 2510692:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 142KON']
+  aliases: []
   parents:
   - 54114
 2510693:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 143KON']
+  aliases: []
   parents:
   - 54114
 2510694:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 144KON']
+  aliases: []
   parents:
   - 54114
 2510695:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 145KON']
+  aliases: []
   parents:
   - 54114
 2510696:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 146KON']
+  aliases: []
   parents:
   - 54114
 2510697:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 147KON']
+  aliases: []
   parents:
   - 54114
 2510698:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 148KON']
+  aliases: []
   parents:
   - 54114
 2510699:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 149KON']
+  aliases: []
   parents:
   - 54114
 2510700:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 150KON']
+  aliases: []
   parents:
   - 54114
 2510701:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 151KON']
+  aliases: []
   parents:
   - 54114
 2510702:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 152KON']
+  aliases: []
   parents:
   - 54114
 2510660:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 36KON']
+  aliases: []
   parents:
   - 54114
 2510661:
-  aliases: ['Anopheles (Nyssorhynchus) nr. konderi 38KON']
+  aliases: []
   parents:
   - 54114
 2841942:
-  aliases: ['Anopheles aff. albimanus B YML-2021a']
+  aliases: []
   parents:
   - 54114
 622773:
-  aliases: ['Anopheles ainshamsi']
+  aliases: []
   parents:
   - 44535
 59117:
-  aliases: ['Anopheles amictus']
+  aliases: []
   parents:
   - 44536
 59162:
-  aliases: ['Anopheles annularis group']
+  aliases: []
   parents:
   - 44535
 1387143:
-  aliases: ['Anopheles apicimacula']
+  aliases: []
   parents:
   - 190374
 262008:
-  aliases: ['Anopheles apoci']
+  aliases: []
   parents:
   - 59140
 1291063:
-  aliases: ['Anopheles argyropus']
+  aliases: []
   parents:
   - 190374
 3061999:
-  aliases: ['Anopheles atratipes']
+  aliases: []
   parents:
   - 190374
 2912046:
-  aliases: ['Anopheles baezai']
+  aliases: []
   parents:
   - 190374
 2918032:
-  aliases: ['Anopheles barberi']
+  aliases: []
   parents:
   - 190374
 927784:
-  aliases: ['Anopheles calderoni']
+  aliases: []
   parents:
   - 190374
 176099:
-  aliases: ["Anopheles cf. dthali 'Bluchistan'"]
+  aliases: []
   parents:
   - 59140
 43041:
-  aliases: ['Anopheles christyi']
+  aliases: []
   parents:
   - 44537
 1521112:
-  aliases: ['Anopheles cinctus']
+  aliases: []
   parents:
   - 44536
 3017357:
-  aliases: ['Anopheles cinereus hispaniola']
+  aliases: []
   parents:
   - 1632206
 2748955:
-  aliases: ['Anopheles concolor']
+  aliases: []
   parents:
   - 190374
 925981:
-  aliases: ['Anopheles costai']
+  aliases: []
   parents:
   - 190374
 869064:
-  aliases: ['Anopheles crucians']
+  aliases: []
   parents:
   - 190374
 1521113:
-  aliases: ['Anopheles demeilloni']
+  aliases: []
   parents:
   - 59140
 2745526:
-  aliases: ['Anopheles donaldi']
+  aliases: []
   parents:
   - 190374
 262009:
-  aliases: ['Anopheles dthali']
+  aliases: []
   parents:
   - 59140
 3241325:
-  aliases: ['Anopheles flavicosta']
+  aliases: []
   parents:
   - 59140
 1426903:
-  aliases: ['Anopheles forattinii']
+  aliases: []
   parents:
   - 190374
 1424568:
-  aliases: ['Anopheles fragilis']
+  aliases: []
   parents:
   - 190374
 2785382:
-  aliases: ['Anopheles franciscanus']
+  aliases: []
   parents:
   - 190374
 1521114:
-  aliases: ['Anopheles gabonensis']
+  aliases: []
   parents:
   - 59140
 3014964:
-  aliases: ['Anopheles grabhamii']
+  aliases: []
   parents:
   - 190374
 1521115:
-  aliases: ['Anopheles hancocki']
+  aliases: []
   parents:
   - 59140
 27470:
-  aliases: ['Anopheles hilli']
+  aliases: []
   parents:
   - 44536
 3062582:
-  aliases: ['Anopheles hodgkini']
+  aliases: []
   parents:
   - 190374
 758766:
-  aliases: ['Anopheles insulaeflorum']
+  aliases: []
   parents:
   - 190374
 308710:
-  aliases: ['Anopheles jamesii']
+  aliases: []
   parents:
   - 44535
 59148:
-  aliases: ['Anopheles karwari']
+  aliases: []
   parents:
   - 44535
 59150:
-  aliases: ['Anopheles kochi']
+  aliases: []
   parents:
   - 44536
 59151:
-  aliases: ['Anopheles litoralis']
+  aliases: []
   parents:
   - 44537
 74868:
-  aliases: ['Anopheles maculatus group']
+  aliases: []
   parents:
   - 44535
 1496333:
-  aliases: ['Anopheles maculipalpis']
+  aliases: []
   parents:
   - 44535
 1521116:
-  aliases: ['Anopheles marshallii']
+  aliases: []
   parents:
   - 59140
 2756213:
-  aliases: ['Anopheles maverlius']
+  aliases: []
   parents:
   - 190374
 59157:
-  aliases: ['Anopheles meraukensis']
+  aliases: []
   parents:
   - 44536
 186751:
-  aliases: ['Anopheles moucheti']
+  aliases: []
   parents:
   - 59140
 1199414:
-  aliases: ['Anopheles neomaculipalpus']
+  aliases: []
   parents:
   - 190374
 59158:
-  aliases: ['Anopheles novaguinensis']
+  aliases: []
   parents:
   - 44536
 2419668:
-  aliases: ['Anopheles nr. costai G1 MAMS-2018']
+  aliases: []
   parents:
   - 190374
 2419669:
-  aliases: ['Anopheles nr. costai G2 MAMS-2018']
+  aliases: []
   parents:
   - 190374
 2419670:
-  aliases: ['Anopheles nr. costai G3 MAMS-2018']
+  aliases: []
   parents:
   - 190374
 2419671:
-  aliases: ['Anopheles nr. costai G4 MAMS-2018']
+  aliases: []
   parents:
   - 190374
 2419672:
-  aliases: ['Anopheles nr. costai G5 MAMS-2018']
+  aliases: []
   parents:
   - 190374
 2171939:
-  aliases: ['Anopheles nr. costai SP02_17_3']
+  aliases: []
   parents:
   - 190374
 1426910:
-  aliases: ['Anopheles nr. konderi FR2013']
+  aliases: []
   parents:
   - 44544
 2875525:
-  aliases: ['Anopheles omorii']
+  aliases: []
   parents:
   - 190374
 622774:
-  aliases: ['Anopheles paltrinierii']
+  aliases: []
   parents:
   - 44535
 333671:
-  aliases: ['Anopheles pattoni']
+  aliases: []
   parents:
   - 44535
 874513:
-  aliases: ['Anopheles pristinus']
+  aliases: []
   parents:
   - 874512
 159154:
-  aliases: ['Anopheles pulcherrimus']
+  aliases: []
   parents:
   - 44535
 1291064:
-  aliases: ['Anopheles pursati']
+  aliases: []
   parents:
   - 190374
 3241326:
-  aliases: ['Anopheles radama']
+  aliases: []
   parents:
   - 44536
 1632232:
-  aliases: ['Anopheles rhodesiensis rupicola']
+  aliases: []
   parents:
   - 1632207
 325436:
-  aliases: ['Anopheles splendidus']
+  aliases: []
   parents:
   - 44535
 30069:
-  aliases: ['Anopheles stephensi']
+  aliases: []
   parents:
   - 44535
 3014965:
-  aliases: ['Anopheles stigmaticus']
+  aliases: []
   parents:
   - 190374
 262673:
-  aliases: ['Anopheles superpictus']
+  aliases: []
   parents:
   - 44535
 59161:
-  aliases: ['Anopheles tessellatus']
+  aliases: []
   parents:
   - 44536
 142887:
-  aliases: ['Anopheles vagus']
+  aliases: []
   parents:
   - 44537
 2903342:
-  aliases: ['Anopheles veruslanei']
+  aliases: []
   parents:
   - 190374
 869065:
-  aliases: ['Anopheles vestitipennis']
+  aliases: []
   parents:
   - 190374
 1245358:
-  aliases: ['Anopheles xui']
+  aliases: []
   parents:
   - 190374
 2968253:
-  aliases: ['Armigeres aureolineatus']
+  aliases: []
   parents:
   - 317811
 1245359:
-  aliases: ['Armigeres durhami']
+  aliases: []
   parents:
   - 317811
 1245360:
-  aliases: ['Armigeres flavus']
+  aliases: []
   parents:
   - 317812
 753891:
-  aliases: ['Armigeres kesseli']
+  aliases: []
   parents:
   - 317811
 2587274:
-  aliases: ['Armigeres longipalpis']
+  aliases: []
   parents:
   - 317812
 3137931:
-  aliases: ['Armigeres magnus']
+  aliases: []
   parents:
   - 317812
 2067461:
-  aliases: ['Armigeres malayi']
+  aliases: []
   parents:
   - 317811
 149458:
-  aliases: ['Armigeres obturbans']
+  aliases: []
   parents:
   - 317811
 3569224:
-  aliases: ['Armigeres omissus']
+  aliases: []
   parents:
   - 317812
 2853132:
-  aliases: ['Armigeres sp. P_141_FSTST']
+  aliases: []
   parents:
   - 2853149
 2853123:
-  aliases: ['Armigeres sp. P_195_FSTJD']
+  aliases: []
   parents:
   - 2853149
 2853136:
-  aliases: ['Armigeres sp. P_199_FSTHD']
+  aliases: []
   parents:
   - 2853149
 2853135:
-  aliases: ['Armigeres sp. P_201_FSTJD']
+  aliases: []
   parents:
   - 2853149
 2853134:
-  aliases: ['Armigeres sp. P_206_FSTAT']
+  aliases: []
   parents:
   - 2853149
 2853133:
-  aliases: ['Armigeres sp. P_209_FSTAT']
+  aliases: []
   parents:
   - 2853149
 2853127:
-  aliases: ['Armigeres sp. P_263_FSTHT']
+  aliases: []
   parents:
   - 2853149
 2853128:
-  aliases: ['Armigeres sp. P_264_FSTHT']
+  aliases: []
   parents:
   - 2853149
 2853129:
-  aliases: ['Armigeres sp. P_265_FSTHT']
+  aliases: []
   parents:
   - 2853149
 2853131:
-  aliases: ['Armigeres sp. P_271_FSTHT']
+  aliases: []
   parents:
   - 2853149
 2853130:
-  aliases: ['Armigeres sp. P_312_FSTCO']
+  aliases: []
   parents:
   - 2853149
 2853126:
-  aliases: ['Armigeres sp. P_322_FSTCO']
+  aliases: []
   parents:
   - 2853149
 2853125:
-  aliases: ['Armigeres sp. P_325_FSTCO']
+  aliases: []
   parents:
   - 2853149
 2853124:
-  aliases: ['Armigeres sp. P_328_FSTCO']
+  aliases: []
   parents:
   - 2853149
 124917:
-  aliases: ['Armigeres subalbatus']
+  aliases: []
   parents:
   - 317811
 58248:
-  aliases: ['Arribalzagia']
+  aliases: []
   parents:
   - 58247
 2729127:
-  aliases: ['Choroterpides apiculata (nomen nudum)']
+  aliases: []
   parents:
   - 1125803
 58249:
-  aliases: ['Christya']
+  aliases: []
   parents:
   - 58247
 2989696:
-  aliases: ['Coquillettidia sp.']
+  aliases: []
   parents:
   - 2637621
 1822822:
-  aliases: ['Coquillettidia sp. BOLD:AAB2539']
+  aliases: []
   parents:
   - 2637621
 2232092:
-  aliases: ['Culex (Anoedioporpa) sp. CA1']
+  aliases: []
   parents:
   - 1426913
 2232093:
-  aliases: ['Culex (Anoedioporpa) sp. CA2']
+  aliases: []
   parents:
   - 1426913
 2496364:
-  aliases: ['Culex (Culex) sp. 407 CSS-2018']
+  aliases: []
   parents:
   - 53527
 1899480:
-  aliases: ['Culex (Melanoconion) nr. aliciae PM1_6']
+  aliases: []
   parents:
   - 53535
 1899479:
-  aliases: ['Culex (Melanoconion) nr. aliciae PM1_7']
+  aliases: []
   parents:
   - 53535
 1899267:
-  aliases: ['Culex (Melanoconion) nr. aureonotatus TO1_12_1']
+  aliases: []
   parents:
   - 53535
 1899268:
-  aliases: ['Culex (Melanoconion) nr. aureonotatus TO1_12_2']
+  aliases: []
   parents:
   - 53535
 1899269:
-  aliases: ['Culex (Melanoconion) nr. aureonotatus TO1_3']
+  aliases: []
   parents:
   - 53535
 1899270:
-  aliases: ['Culex (Melanoconion) nr. gnomatos gnomat_AC']
+  aliases: []
   parents:
   - 53535
 1899271:
-  aliases: ['Culex (Melanoconion) nr. inhibitator 1g']
+  aliases: []
   parents:
   - 53535
 1899481:
-  aliases: ['Culex (Melanoconion) nr. pedroi AC153_1']
+  aliases: []
   parents:
   - 53535
 1899272:
-  aliases: ['Culex (Melanoconion) nr. pedroi ped1']
+  aliases: []
   parents:
   - 53535
 1899273:
-  aliases: ['Culex (Melanoconion) nr. pedroi ped2']
+  aliases: []
   parents:
   - 53535
 1899482:
-  aliases: ['Culex (Melanoconion) nr. portesi AC312_8']
+  aliases: []
   parents:
   - 53535
 1899274:
-  aliases: ['Culex (Melanoconion) nr. rabelloi 1A']
+  aliases: []
   parents:
   - 53535
 1899277:
-  aliases: ['Culex (Melanoconion) nr. rabelloi 1H']
+  aliases: []
   parents:
   - 53535
 1899275:
-  aliases: ['Culex (Melanoconion) nr. rabelloi 1c']
+  aliases: []
   parents:
   - 53535
 1899276:
-  aliases: ['Culex (Melanoconion) nr. rabelloi 1e']
+  aliases: []
   parents:
   - 53535
 1899483:
-  aliases: ['Culex (Melanoconion) nr. spissipes spi_AC']
+  aliases: []
   parents:
   - 53535
 1899484:
-  aliases: ['Culex (Melanoconion) nr. theobaldi AC127_1']
+  aliases: []
   parents:
   - 53535
 1899278:
-  aliases: ['Culex (Melanoconion) nr. vomerifer AC322_1']
+  aliases: []
   parents:
   - 53535
 2725248:
-  aliases: ['Culex (Melanoconion) sp. 1 DJS-2020']
+  aliases: []
   parents:
   - 53535
 2725249:
-  aliases: ['Culex (Melanoconion) sp. 2 DJS-2020']
+  aliases: []
   parents:
   - 53535
 2496361:
-  aliases: ['Culex (Melanoconion) sp. 274 CSS-2018']
+  aliases: []
   parents:
   - 53535
 2725250:
-  aliases: ['Culex (Melanoconion) sp. 3 DJS-2020']
+  aliases: []
   parents:
   - 53535
 2725251:
-  aliases: ['Culex (Melanoconion) sp. 4 DJS-2020']
+  aliases: []
   parents:
   - 53535
 2725252:
-  aliases: ['Culex (Melanoconion) sp. 5 DJS-2020']
+  aliases: []
   parents:
   - 53535
 2725253:
-  aliases: ['Culex (Melanoconion) sp. 6 DJS-2020']
+  aliases: []
   parents:
   - 53535
 2725254:
-  aliases: ['Culex (Melanoconion) sp. 7 DJS-2020']
+  aliases: []
   parents:
   - 53535
 2233863:
-  aliases: ['Culex (Microculex) sp. CX1']
+  aliases: []
   parents:
   - 707272
 2233864:
-  aliases: ['Culex (Microculex) sp. CX2']
+  aliases: []
   parents:
   - 707272
 1085687:
-  aliases: ['Culex abominator']
+  aliases: []
   parents:
   - 53535
 3453671:
-  aliases: ['Culex abonnenci']
+  aliases: []
   parents:
   - 53535
 1640511:
-  aliases: ['Culex accelerans']
+  aliases: []
   parents:
   - 1640510
 1461355:
-  aliases: ['Culex acharistus']
+  aliases: []
   parents:
   - 53527
 284557:
-  aliases: ['Culex adamesi']
+  aliases: []
   parents:
   - 53535
 1799685:
-  aliases: ['Culex adersianus']
+  aliases: []
   parents:
   - 53531
 2171936:
-  aliases: ['Culex aff. dolosus CJForm PGF-2018']
+  aliases: []
   parents:
   - 53527
 1899234:
-  aliases: ['Culex akritos']
+  aliases: []
   parents:
   - 53535
 3014966:
-  aliases: ['Culex albinensis']
+  aliases: []
   parents:
   - 53535
 707274:
-  aliases: ['Culex aliciae']
+  aliases: []
   parents:
   - 53535
 3128999:
-  aliases: ['Culex alienus']
+  aliases: []
   parents:
   - 53527
 3453672:
-  aliases: ['Culex alinkios']
+  aliases: []
   parents:
   - 53535
 1899235:
-  aliases: ['Culex alogistus']
+  aliases: []
   parents:
   - 53535
 2719872:
-  aliases: ['Culex amazonensis']
+  aliases: []
   parents:
   - 1640510
 2918767:
-  aliases: ['Culex andersoni']
+  aliases: []
   parents:
   - 53527
 667566:
-  aliases: ['Culex annulioris']
+  aliases: []
   parents:
   - 667565
 162997:
-  aliases: ['Culex annulirostris']
+  aliases: []
   parents:
   - 53527
 182211:
-  aliases: ['Culex annulus']
+  aliases: []
   parents:
   - 53527
 911293:
-  aliases: ['Culex antennatus']
+  aliases: []
   parents:
   - 53527
 3014967:
-  aliases: ['Culex antillummagnorum']
+  aliases: []
   parents:
   - 2891964
 3453698:
-  aliases: ['Culex antunesi']
+  aliases: []
   parents:
   - 794814
 3423903:
-  aliases: ['Culex aphyllus']
+  aliases: []
   parents:
   - 53535
 1206046:
-  aliases: ['Culex apicalis']
+  aliases: []
   parents:
   - 53537
 571207:
-  aliases: ['Culex apicinus']
+  aliases: []
   parents:
   - 53527
 3017358:
-  aliases: ['Culex arbieeni']
+  aliases: []
   parents:
   - 53534
 2563467:
-  aliases: ['Culex argenteopunctatus']
+  aliases: []
   parents:
   - 53527
 1206308:
-  aliases: ['Culex arizonensis']
+  aliases: []
   parents:
   - 53537
 2292406:
-  aliases: ['Culex asteliae']
+  aliases: []
   parents:
   - 53527
 1085685:
-  aliases: ['Culex atratus']
+  aliases: []
   parents:
   - 53535
 1085686:
-  aliases: ['Culex atratus B Williams & Savage (2009)']
+  aliases: []
   parents:
   - 53535
 2563468:
-  aliases: ['Culex aurantapex']
+  aliases: []
   parents:
   - 667565
 1899236:
-  aliases: ['Culex aureonotatus']
+  aliases: []
   parents:
   - 53535
 1206047:
-  aliases: ['Culex bahamensis']
+  aliases: []
   parents:
   - 53527
 1899237:
-  aliases: ['Culex bastagarius']
+  aliases: []
   parents:
   - 53535
 3453673:
-  aliases: ['Culex batesi']
+  aliases: []
   parents:
   - 53535
 2803069:
-  aliases: ['Culex bhutanensis']
+  aliases: []
   parents:
   - 53527
 3453674:
-  aliases: ['Culex bibulus']
+  aliases: []
   parents:
   - 53535
 1214264:
-  aliases: ['Culex bicornutus']
+  aliases: []
   parents:
   - 308715
 707279:
-  aliases: ['Culex bidens']
+  aliases: []
   parents:
   - 53527
 2891963:
-  aliases: ['Culex bihaicola']
+  aliases: []
   parents:
   - 794814
 2171672:
-  aliases: ['Culex bilineatus']
+  aliases: []
   parents:
   - 53527
 3014968:
-  aliases: ['Culex biscaynensis']
+  aliases: []
   parents:
   - 2891964
 69822:
-  aliases: ['Culex bitaeniorhynchus']
+  aliases: []
   parents:
   - 667565
 2730085:
-  aliases: ['Culex boninensis']
+  aliases: []
   parents:
   - 2730084
 3453699:
-  aliases: ['Culex bonneae']
+  aliases: []
   parents:
   - 53527
 794815:
-  aliases: ['Culex bonnei']
+  aliases: []
   parents:
   - 794814
 3453675:
-  aliases: ['Culex brachiatus']
+  aliases: []
   parents:
   - 53535
 2171673:
-  aliases: ['Culex brami']
+  aliases: []
   parents:
   - 53527
 1091053:
-  aliases: ['Culex brethesi']
+  aliases: []
   parents:
   - 53527
 3453704:
-  aliases: ['Culex breviculus']
+  aliases: []
   parents:
   - 3453668
 317797:
-  aliases: ['Culex brevipalpis']
+  aliases: []
   parents:
   - 53531
 3453700:
-  aliases: ['Culex brevispinosus']
+  aliases: []
   parents:
   - 53527
 1426904:
-  aliases: ['Culex browni']
+  aliases: []
   parents:
   - 1426913
 2943529:
-  aliases: ['Culex cambournaci']
+  aliases: []
   parents:
   - 53530
 1461356:
-  aliases: ['Culex camposi']
+  aliases: []
   parents:
   - 53527
 3453676:
-  aliases: ['Culex carincii']
+  aliases: []
   parents:
   - 53535
 3014969:
-  aliases: ['Culex castroi']
+  aliases: []
   parents:
   - 1091057
 3453677:
-  aliases: ['Culex cauchensis']
+  aliases: []
   parents:
   - 53535
 3453678:
-  aliases: ['Culex caudatus']
+  aliases: []
   parents:
   - 53535
 707275:
-  aliases: ['Culex caudelli']
+  aliases: []
   parents:
   - 53535
 1085688:
-  aliases: ['Culex cedecei']
+  aliases: []
   parents:
   - 53535
 3018960:
-  aliases: ['Culex cf. perexiguus']
+  aliases: []
   parents:
   - 53527
 3239031:
-  aliases: ['Culex cf. sitiens']
+  aliases: []
   parents:
   - 53527
 2722877:
-  aliases: ['Culex cf. sitiens MAFP8.E9']
+  aliases: []
   parents:
   - 53527
 2722878:
-  aliases: ['Culex cf. watti MAFP5.C5']
+  aliases: []
   parents:
   - 53527
 707280:
-  aliases: ['Culex chidesteri']
+  aliases: []
   parents:
   - 53527
 1214265:
-  aliases: ['Culex cinctellus']
+  aliases: []
   parents:
   - 308715
 667563:
-  aliases: ['Culex cinereus']
+  aliases: []
   parents:
   - 53530
 1899238:
-  aliases: ['Culex clarki']
+  aliases: []
   parents:
   - 53535
 3382158:
-  aliases: ['Culex comatus']
+  aliases: []
   parents:
   - 53535
 1899239:
-  aliases: ['Culex commevynensis']
+  aliases: []
   parents:
   - 53535
 2758409:
-  aliases: ['Culex comminutor']
+  aliases: []
   parents:
   - 53535
 1426905:
-  aliases: ['Culex conservator']
+  aliases: []
   parents:
   - 1426913
 1677685:
-  aliases: ['Culex conspirator']
+  aliases: []
   parents:
   - 53535
 3449754:
-  aliases: ['Culex contei']
+  aliases: []
   parents:
   - 53535
 1899240:
-  aliases: ['Culex corentynensis']
+  aliases: []
   parents:
   - 53535
 707271:
-  aliases: ['Culex corniger']
+  aliases: []
   parents:
   - 707270
 317804:
-  aliases: ['Culex cornutus']
+  aliases: []
   parents:
   - 53527
 526217:
-  aliases: ['Culex coronator']
+  aliases: []
   parents:
   - 53527
 3382159:
-  aliases: ['Culex creole']
+  aliases: []
   parents:
   - 53535
 2821046:
-  aliases: ['Culex crinicauda']
+  aliases: []
   parents:
   - 53527
 3453679:
-  aliases: ['Culex cristovaoi']
+  aliases: []
   parents:
   - 53535
 1899241:
-  aliases: ['Culex crybda']
+  aliases: []
   parents:
   - 53535
 3014970:
-  aliases: ['Culex cubiculi']
+  aliases: []
   parents:
   - 308715
 1808015:
-  aliases: ['Culex cylindricus']
+  aliases: []
   parents:
   - 308715
 299630:
-  aliases: ['Culex decens']
+  aliases: []
   parents:
   - 53527
 707281:
-  aliases: ['Culex declarator']
+  aliases: []
   parents:
   - 53527
 1795353:
-  aliases: ['Culex deserticola']
+  aliases: []
   parents:
   - 53534
 2742860:
-  aliases: ['Culex diengensis']
+  aliases: []
   parents:
   - 53527
 707282:
-  aliases: ['Culex dolosus']
+  aliases: []
   parents:
   - 53527
 3014971:
-  aliases: ['Culex douglasi']
+  aliases: []
   parents:
   - 53537
 1273079:
-  aliases: ['Culex dunni']
+  aliases: []
   parents:
   - 53535
 1799675:
-  aliases: ['Culex duttoni']
+  aliases: []
   parents:
   - 53527
 707276:
-  aliases: ['Culex dyius']
+  aliases: []
   parents:
   - 53535
 1899242:
-  aliases: ['Culex eastor']
+  aliases: []
   parents:
   - 53535
 1091055:
-  aliases: ['Culex eduardoi']
+  aliases: []
   parents:
   - 53527
 1677686:
-  aliases: ['Culex educator']
+  aliases: []
   parents:
   - 53535
 1041092:
-  aliases: ['Culex edwardsi']
+  aliases: []
   parents:
   - 53527
 1899243:
-  aliases: ['Culex eknomios']
+  aliases: []
   parents:
   - 53535
 1206309:
-  aliases: ['Culex elevator']
+  aliases: []
   parents:
   - 53535
 1899244:
-  aliases: ['Culex ensiformis']
+  aliases: []
   parents:
   - 53535
 333812:
-  aliases: ['Culex environmental sample']
+  aliases: []
   parents:
   - 333811
 1821542:
-  aliases: ['Culex epanatasis']
+  aliases: []
   parents:
   - 53535
 471289:
-  aliases: ['Culex epidesmus']
+  aliases: []
   parents:
   - 53527
 1899245:
-  aliases: ['Culex equinoxialis']
+  aliases: []
   parents:
   - 53535
 2891966:
-  aliases: ['Culex erethyzonfer']
+  aliases: []
   parents:
   - 2891964
 3453680:
-  aliases: ['Culex ernanii']
+  aliases: []
   parents:
   - 53535
 3453681:
-  aliases: ['Culex ernsti']
+  aliases: []
   parents:
   - 53535
 42427:
-  aliases: ['Culex erraticus']
+  aliases: []
   parents:
   - 53535
 42428:
-  aliases: ['Culex erythrothorax']
+  aliases: []
   parents:
   - 53527
 1464558:
-  aliases: ['Culex europaeus']
+  aliases: []
   parents:
   - 53537
 1899246:
-  aliases: ['Culex evansae']
+  aliases: []
   parents:
   - 53535
 3453682:
-  aliases: ['Culex extenuatus']
+  aliases: []
   parents:
   - 53535
 1899247:
-  aliases: ['Culex faurani']
+  aliases: []
   parents:
   - 53535
 2792477:
-  aliases: ['Culex fergusoni']
+  aliases: []
   parents:
   - 53537
 3453683:
-  aliases: ['Culex flabellifer']
+  aliases: []
   parents:
   - 53535
 498398:
-  aliases: ['Culex flavicornis']
+  aliases: []
   parents:
   - 308715
 3453684:
-  aliases: ['Culex foliafer']
+  aliases: []
   parents:
   - 53535
 1245361:
-  aliases: ['Culex foliatus']
+  aliases: []
   parents:
   - 53531
 2853104:
-  aliases: ['Culex fragilis']
+  aliases: []
   parents:
   - 53530
 345740:
-  aliases: ['Culex fuscocephala']
+  aliases: []
   parents:
   - 53527
 3453685:
-  aliases: ['Culex galindoi']
+  aliases: []
   parents:
   - 53535
 569590:
-  aliases: ['Culex gaufini']
+  aliases: []
   parents:
   - 53537
 2793200:
-  aliases: ['Culex gaugleri']
+  aliases: []
   parents:
   - 53527
 308713:
-  aliases: ['Culex gelidus']
+  aliases: []
   parents:
   - 53527
 1806176:
-  aliases: ['Culex globocoxitus']
+  aliases: []
   parents:
   - 53527
 284516:
-  aliases: ['Culex gnomatos']
+  aliases: []
   parents:
   - 53535
 1206310:
-  aliases: ['Culex habilitator']
+  aliases: []
   parents:
   - 53527
 1214266:
-  aliases: ['Culex hayashii']
+  aliases: []
   parents:
   - 53531
 3114454:
-  aliases: ['Culex hilli']
+  aliases: []
   parents:
   - 308715
 1464559:
-  aliases: ['Culex hortensis']
+  aliases: []
   parents:
   - 53534
 3453686:
-  aliases: ['Culex hutchingsae']
+  aliases: []
   parents:
   - 53535
 345742:
-  aliases: ['Culex hutchinsoni']
+  aliases: []
   parents:
   - 53527
 1899248:
-  aliases: ['Culex idottus']
+  aliases: []
   parents:
   - 53535
 707273:
-  aliases: ['Culex imitator']
+  aliases: []
   parents:
   - 707272
 1464560:
-  aliases: ['Culex impudicus']
+  aliases: []
   parents:
   - 53537
 3453687:
-  aliases: ['Culex inadmirabilis']
+  aliases: []
   parents:
   - 53535
 1131596:
-  aliases: ['Culex inatomii']
+  aliases: []
   parents:
   - 53528
 2918769:
-  aliases: ['Culex inconspicuosus']
+  aliases: []
   parents:
   - 53531
 308717:
-  aliases: ['Culex infantulus']
+  aliases: []
   parents:
   - 308715
 2007261:
-  aliases: ['Culex infoliatus']
+  aliases: []
   parents:
   - 794814
 308720:
-  aliases: ['Culex infula']
+  aliases: []
   parents:
   - 53527
 1206048:
-  aliases: ['Culex inhibitator']
+  aliases: []
   parents:
   - 53535
 3383093:
-  aliases: ['Culex innovator']
+  aliases: []
   parents:
   - 53535
 571208:
-  aliases: ['Culex interfor']
+  aliases: []
   parents:
   - 53527
 556016:
-  aliases: ['Culex interrogator']
+  aliases: []
   parents:
   - 53527
 1899249:
-  aliases: ['Culex intrincatus']
+  aliases: []
   parents:
   - 53535
 1085689:
-  aliases: ['Culex iolambdis']
+  aliases: []
   parents:
   - 53535
 376793:
-  aliases: ['Culex iyengari']
+  aliases: []
   parents:
   - 53527
 2742861:
-  aliases: ['Culex jacksoni']
+  aliases: []
   parents:
   - 53527
 1206311:
-  aliases: ['Culex janitor']
+  aliases: []
   parents:
   - 53527
 3453688:
-  aliases: ['Culex johnnyi']
+  aliases: []
   parents:
   - 53535
 3453689:
-  aliases: ['Culex johnsoni']
+  aliases: []
   parents:
   - 53535
 1652503:
-  aliases: ['Culex kyotoensis']
+  aliases: []
   parents:
   - 53530
 1899250:
-  aliases: ['Culex lacertosus']
+  aliases: []
   parents:
   - 53535
 871896:
-  aliases: ['Culex lactator']
+  aliases: []
   parents:
   - 707270
 1464561:
-  aliases: ['Culex laticinctus']
+  aliases: []
   parents:
   - 53527
 3114455:
-  aliases: ['Culex latus']
+  aliases: []
   parents:
   - 53537
 3461572:
-  aliases: ['Culex litwakae']
+  aliases: []
   parents:
   - 53527
 3453690:
-  aliases: ['Culex longistriatus']
+  aliases: []
   parents:
   - 53535
 2807044:
-  aliases: ['Culex longitubus']
+  aliases: []
   parents:
   - 53527
 3453691:
-  aliases: ['Culex lucackermanni']
+  aliases: []
   parents:
   - 53535
 1677687:
-  aliases: ['Culex lucifugus']
+  aliases: []
   parents:
   - 53535
 1461354:
-  aliases: ['Culex lygrus']
+  aliases: []
   parents:
   - 53527
 1461374:
-  aliases: ['Culex lygrus s.l. SP56_25']
+  aliases: []
   parents:
   - 53527
 1461375:
-  aliases: ['Culex lygrus s.l. SP56_26']
+  aliases: []
   parents:
   - 53527
 345741:
-  aliases: ['Culex malayi']
+  aliases: []
   parents:
   - 53531
 2306907:
-  aliases: ['Culex martinii']
+  aliases: []
   parents:
   - 53537
 549330:
-  aliases: ['Culex maxi']
+  aliases: []
   parents:
   - 53527
 421623:
-  aliases: ['Culex mimeticus']
+  aliases: []
   parents:
   - 53527
 498399:
-  aliases: ['Culex mimuloides']
+  aliases: []
   parents:
   - 53527
 308722:
-  aliases: ['Culex mimulus']
+  aliases: []
   parents:
   - 53527
 2587280:
-  aliases: ['Culex mimulus complex sp. NN1189']
+  aliases: []
   parents:
   - 53527
 2587281:
-  aliases: ['Culex mimulus complex sp. NN912']
+  aliases: []
   parents:
   - 53527
 325443:
-  aliases: ['Culex minor']
+  aliases: []
   parents:
   - 308715
 345743:
-  aliases: ['Culex minutissimus']
+  aliases: []
   parents:
   - 308715
 2563469:
-  aliases: ['Culex mirificus']
+  aliases: []
   parents:
   - 53527
 1899251:
-  aliases: ['Culex misionensis']
+  aliases: []
   parents:
   - 53535
 545656:
-  aliases: ['Culex modestus']
+  aliases: []
   parents:
   - 53528
 549331:
-  aliases: ['Culex mollis']
+  aliases: []
   parents:
   - 53527
 2989692:
-  aliases: ['Culex moucheti']
+  aliases: []
   parents:
   - 2989691
 1085690:
-  aliases: ['Culex mulrennani']
+  aliases: []
   parents:
   - 53535
 314561:
-  aliases: ['Culex murrelli']
+  aliases: []
   parents:
   - 53527
 864528:
-  aliases: ['Culex neavei']
+  aliases: []
   parents:
   - 53527
 562834:
-  aliases: ['Culex nebulosus']
+  aliases: []
   parents:
   - 53530
 2007262:
-  aliases: ['Culex nigrimacula']
+  aliases: []
   parents:
   - 2007271
 42429:
-  aliases: ['Culex nigripalpus']
+  aliases: []
   parents:
   - 53527
 308723:
-  aliases: ['Culex nigropunctatus']
+  aliases: []
   parents:
   - 53530
 2793868:
-  aliases: ['Culex nr. alis KR26_A_1']
+  aliases: []
   parents:
   - 53527
 2793869:
-  aliases: ['Culex nr. alis KR39_L2_3']
+  aliases: []
   parents:
   - 53527
 3422312:
-  aliases: ['Culex nr. commevynensis']
+  aliases: []
   parents:
   - 53535
 284559:
-  aliases: ['Culex nr. pedroi MIR-01']
+  aliases: []
   parents:
   - 53535
 284561:
-  aliases: ['Culex nr. pedroi PER']
+  aliases: []
   parents:
   - 53535
 284560:
-  aliases: ['Culex nr. pedroi PER-05']
+  aliases: []
   parents:
   - 53535
 284568:
-  aliases: ['Culex nr. pedroi PERU-02']
+  aliases: []
   parents:
   - 53535
 284562:
-  aliases: ['Culex nr. pedroi Per4-3']
+  aliases: []
   parents:
   - 53535
 2803070:
-  aliases: ['Culex nr. tianpingensis MG21']
+  aliases: []
   parents:
   - 53527
 2803071:
-  aliases: ['Culex nr. tianpingensis MG22']
+  aliases: []
   parents:
   - 53527
 2803072:
-  aliases: ['Culex nr. tianpingensis SPTP1']
+  aliases: []
   parents:
   - 53527
 2803074:
-  aliases: ['Culex nr. tsengi JbTG-1']
+  aliases: []
   parents:
   - 53527
 2803073:
-  aliases: ['Culex nr. tsengi TPTG']
+  aliases: []
   parents:
   - 53527
 3422311:
-  aliases: ['Culex nr. vaxus']
+  aliases: []
   parents:
   - 53535
 2007263:
-  aliases: ['Culex ocellatus']
+  aliases: []
   parents:
   - 2007271
 2047781:
-  aliases: ['Culex ocossa']
+  aliases: []
   parents:
   - 53535
 1899252:
-  aliases: ['Culex oedipus']
+  aliases: []
   parents:
   - 53535
 1214267:
-  aliases: ['Culex okinawae']
+  aliases: []
   parents:
   - 53531
 1806177:
-  aliases: ['Culex orbostiensis']
+  aliases: []
   parents:
   - 308715
 3077182:
-  aliases: ['Culex organaboensis']
+  aliases: []
   parents:
   - 53535
 1131597:
-  aliases: ['Culex orientalis']
+  aliases: []
   parents:
   - 53527
 2758410:
-  aliases: ['Culex originator']
+  aliases: []
   parents:
   - 1426913
 345924:
-  aliases: ['Culex pallidothorax']
+  aliases: []
   parents:
   - 53530
 163000:
-  aliases: ['Culex palpalis']
+  aliases: []
   parents:
   - 53527
 3014972:
-  aliases: ['Culex panocossa']
+  aliases: []
   parents:
   - 53535
 2795829:
-  aliases: ['Culex pavlovskyi']
+  aliases: []
   parents:
   - 53535
 1085691:
-  aliases: ['Culex peccator']
+  aliases: []
   parents:
   - 53535
 284558:
-  aliases: ['Culex pedroi']
+  aliases: []
   parents:
   - 53535
 943103:
-  aliases: ['Culex perexiguus']
+  aliases: []
   parents:
   - 53527
 1899253:
-  aliases: ['Culex pereyrai']
+  aliases: []
   parents:
   - 53535
 864588:
-  aliases: ['Culex perfuscus']
+  aliases: []
   parents:
   - 53527
 260109:
-  aliases: ['Culex pervigilans']
+  aliases: []
   parents:
   - 53527
 1245362:
-  aliases: ['Culex peytoni']
+  aliases: []
   parents:
   - 308715
 3438412:
-  aliases: ['Culex phlogistus']
+  aliases: []
   parents:
   - 53535
 42430:
-  aliases: ['Culex pilosus']
+  aliases: []
   parents:
   - 53536
 2910795:
-  aliases: ['Culex pinarocampa']
+  aliases: []
   parents:
   - 53527
 518105:
-  aliases: ['Culex pipiens complex']
+  aliases: []
   parents:
   - 53527
 2007264:
-  aliases: ['Culex pleuristriatus']
+  aliases: []
   parents:
   - 707272
 363521:
-  aliases: ['Culex pluvialis']
+  aliases: []
   parents:
   - 53531
 450823:
-  aliases: ['Culex poicilipes']
+  aliases: []
   parents:
   - 53527
 284563:
-  aliases: ['Culex portesi']
+  aliases: []
   parents:
   - 53535
 3383094:
-  aliases: ['Culex productus']
+  aliases: []
   parents:
   - 53535
 2785383:
-  aliases: ['Culex pseudostigmatosoma']
+  aliases: []
   parents:
   - 53527
 100677:
-  aliases: ['Culex pseudovishnui']
+  aliases: []
   parents:
   - 53527
 1905332:
-  aliases: ['Culex pullus']
+  aliases: []
   parents:
   - 53527
 2860240:
-  aliases: ['Culex pusillus']
+  aliases: []
   parents:
   - 53528
 1899254:
-  aliases: ['Culex putumayensis']
+  aliases: []
   parents:
   - 53535
 3162573:
-  aliases: ['Culex rabanicolus']
+  aliases: []
   parents:
   - 53535
 1899255:
-  aliases: ['Culex rabelloi']
+  aliases: []
   parents:
   - 53535
 2785376:
-  aliases: ['Culex rejector']
+  aliases: []
   parents:
   - 707272
 1091054:
-  aliases: ['Culex renatoi']
+  aliases: []
   parents:
   - 1091057
 2785381:
-  aliases: ['Culex restrictor']
+  aliases: []
   parents:
   - 1426913
 38742:
-  aliases: ['Culex restuans']
+  aliases: []
   parents:
   - 53527
 284564:
-  aliases: ['Culex ribeirensis']
+  aliases: []
   parents:
   - 53535
 1245363:
-  aliases: ['Culex richei']
+  aliases: []
   parents:
   - 53531
 1799686:
-  aliases: ['Culex rima']
+  aliases: []
   parents:
   - 53531
 3453692:
-  aliases: ['Culex rorotaensis']
+  aliases: []
   parents:
   - 53535
 2292407:
-  aliases: ['Culex rotoruae']
+  aliases: []
   parents:
   - 53527
 1652502:
-  aliases: ['Culex rubensis']
+  aliases: []
   parents:
   - 53537
 1678250:
-  aliases: ['Culex rubinotus']
+  aliases: []
   parents:
   - 53531
 308724:
-  aliases: ['Culex rubithoracis']
+  aliases: []
   parents:
   - 308715
 1214268:
-  aliases: ['Culex ryukyensis']
+  aliases: []
   parents:
   - 53530
 284556:
-  aliases: ['Culex sacchettae']
+  aliases: []
   parents:
   - 53535
 38743:
-  aliases: ['Culex salinarius']
+  aliases: []
   parents:
   - 53527
 1631549:
-  aliases: ['Culex salinarius group sp. RHL-2015']
+  aliases: []
   parents:
   - 53527
 3453693:
-  aliases: ['Culex sallumae']
+  aliases: []
   parents:
   - 53535
 1461357:
-  aliases: ['Culex saltanensis']
+  aliases: []
   parents:
   - 53527
 3453694:
-  aliases: ['Culex saramaccensis']
+  aliases: []
   parents:
   - 53535
 1131598:
-  aliases: ['Culex sasai']
+  aliases: []
   parents:
   - 53530
 2758408:
-  aliases: ['Culex secundus']
+  aliases: []
   parents:
   - 794814
 1206312:
-  aliases: ['Culex secutor']
+  aliases: []
   parents:
   - 53527
 1426906:
-  aliases: ['Culex serratimarge']
+  aliases: []
   parents:
   - 53535
 2006700:
-  aliases: ['Culex shebbearei']
+  aliases: []
   parents:
   - 53530
 1406360:
-  aliases: ['Culex simpliciforceps']
+  aliases: []
   parents:
   - 53531
 1799676:
-  aliases: ['Culex simpsoni']
+  aliases: []
   parents:
   - 53527
 3453695:
-  aliases: ['Culex simulator']
+  aliases: []
   parents:
   - 53535
 1799677:
-  aliases: ['Culex sinaiticus']
+  aliases: []
   parents:
   - 53527
 162998:
-  aliases: ['Culex sitiens']
+  aliases: []
   parents:
   - 53527
 2912049:
-  aliases: ['Culex sp.']
+  aliases: []
   parents:
   - 3406907
 2448724:
-  aliases: ['Culex sp. 1 CLJ-2018']
+  aliases: []
   parents:
   - 3406907
 507998:
-  aliases: ['Culex sp. 1 NDD-2008']
+  aliases: []
   parents:
   - 3406907
 1803713:
-  aliases: ['Culex sp. 14702-CulexA07']
+  aliases: []
   parents:
   - 3406907
 1803714:
-  aliases: ['Culex sp. 14702-CulexA08']
+  aliases: []
   parents:
   - 3406907
 2665172:
-  aliases: ['Culex sp. 16GH 23-A']
+  aliases: []
   parents:
   - 3406907
 2665173:
-  aliases: ['Culex sp. 16GH 30-2']
+  aliases: []
   parents:
   - 3406907
 2665174:
-  aliases: ['Culex sp. 16GH 30-3']
+  aliases: []
   parents:
   - 3406907
 1803715:
-  aliases: ['Culex sp. 20974_CulexE01']
+  aliases: []
   parents:
   - 3406907
 1874919:
-  aliases: ['Culex sp. 20974_CulicF09']
+  aliases: []
   parents:
   - 3406907
 1803716:
-  aliases: ['Culex sp. 20974_CxwatA04']
+  aliases: []
   parents:
   - 3406907
 1133092:
-  aliases: ['Culex sp. A CMJ-2012']
+  aliases: []
   parents:
   - 3406907
 2665380:
-  aliases: ['Culex sp. APHA162017D12']
+  aliases: []
   parents:
   - 3406907
 2665381:
-  aliases: ['Culex sp. APHA162017E01']
+  aliases: []
   parents:
   - 3406907
 2665385:
-  aliases: ['Culex sp. APHA162017E02']
+  aliases: []
   parents:
   - 3406907
 2665376:
-  aliases: ['Culex sp. APHA162017E03']
+  aliases: []
   parents:
   - 3406907
 2665374:
-  aliases: ['Culex sp. APHA162017E04']
+  aliases: []
   parents:
   - 3406907
 2665375:
-  aliases: ['Culex sp. APHA162017E05']
+  aliases: []
   parents:
   - 3406907
 2665383:
-  aliases: ['Culex sp. APHA162017E06']
+  aliases: []
   parents:
   - 3406907
 2665386:
-  aliases: ['Culex sp. APHA162017E07']
+  aliases: []
   parents:
   - 3406907
 2665379:
-  aliases: ['Culex sp. APHA162017E08']
+  aliases: []
   parents:
   - 3406907
 2665378:
-  aliases: ['Culex sp. APHA162017E09']
+  aliases: []
   parents:
   - 3406907
 2665384:
-  aliases: ['Culex sp. APHA162017E10']
+  aliases: []
   parents:
   - 3406907
 2665382:
-  aliases: ['Culex sp. APHA162017E11']
+  aliases: []
   parents:
   - 3406907
 2665377:
-  aliases: ['Culex sp. APHA162017E12']
+  aliases: []
   parents:
   - 3406907
 1133093:
-  aliases: ['Culex sp. B CMJ-2012']
+  aliases: []
   parents:
   - 3406907
 2315011:
-  aliases: ['Culex sp. BIOUG01402-C08']
+  aliases: []
   parents:
   - 3406907
 2315008:
-  aliases: ['Culex sp. BIOUG01422-D05']
+  aliases: []
   parents:
   - 3406907
 2315005:
-  aliases: ['Culex sp. BIOUG01459-H08']
+  aliases: []
   parents:
   - 3406907
 2315006:
-  aliases: ['Culex sp. BIOUG08803-A08']
+  aliases: []
   parents:
   - 3406907
 2208999:
-  aliases: ['Culex sp. BIOUG17326-G03']
+  aliases: []
   parents:
   - 3406907
 2315004:
-  aliases: ['Culex sp. BIOUG21226-C09']
+  aliases: []
   parents:
   - 3406907
 2315002:
-  aliases: ['Culex sp. BIOUG21357-A11']
+  aliases: []
   parents:
   - 3406907
 2315009:
-  aliases: ['Culex sp. BIOUG25469-C05']
+  aliases: []
   parents:
   - 3406907
 2315012:
-  aliases: ['Culex sp. BIOUG25512-F06']
+  aliases: []
   parents:
   - 3406907
 2315001:
-  aliases: ['Culex sp. BIOUG25514-G02']
+  aliases: []
   parents:
   - 3406907
 2209000:
-  aliases: ['Culex sp. BIOUG26829-A11']
+  aliases: []
   parents:
   - 3406907
 2209001:
-  aliases: ['Culex sp. BIOUG27459-G03']
+  aliases: []
   parents:
   - 3406907
 2315003:
-  aliases: ['Culex sp. BIOUG27632-H09']
+  aliases: []
   parents:
   - 3406907
 2315007:
-  aliases: ['Culex sp. BIOUG28268-A01']
+  aliases: []
   parents:
   - 3406907
 2315010:
-  aliases: ['Culex sp. BIOUG28268-E06']
+  aliases: []
   parents:
   - 3406907
 1888157:
-  aliases: ['Culex sp. BOLD-2016']
+  aliases: []
   parents:
   - 3406907
 1754997:
-  aliases: ['Culex sp. BOLD:AAA7661']
+  aliases: []
   parents:
   - 3406907
 1695053:
-  aliases: ['Culex sp. BOLD:AAB6943']
+  aliases: []
   parents:
   - 3406907
 2658575:
-  aliases: ['Culex sp. BOLD:AAF1735']
+  aliases: []
   parents:
   - 3406907
 1578837:
-  aliases: ['Culex sp. BTLHVDV-2014']
+  aliases: []
   parents:
   - 3406907
 1795401:
-  aliases: ['Culex sp. Boussalem_2']
+  aliases: []
   parents:
   - 3406907
 1795402:
-  aliases: ['Culex sp. Boussalem_4']
+  aliases: []
   parents:
   - 3406907
 1795403:
-  aliases: ['Culex sp. Boussalem_6']
+  aliases: []
   parents:
   - 3406907
 1133094:
-  aliases: ['Culex sp. C CMJ-2012']
+  aliases: []
   parents:
   - 3406907
 1795404:
-  aliases: ['Culex sp. Corsica_1']
+  aliases: []
   parents:
   - 3406907
 1795405:
-  aliases: ['Culex sp. Corsica_2']
+  aliases: []
   parents:
   - 3406907
 1795406:
-  aliases: ['Culex sp. Corsica_3']
+  aliases: []
   parents:
   - 3406907
 2853138:
-  aliases: ['Culex sp. Cx_JM009']
+  aliases: []
   parents:
   - 3406907
 2853137:
-  aliases: ['Culex sp. Cx_JM884']
+  aliases: []
   parents:
   - 3406907
 1133095:
-  aliases: ['Culex sp. D CMJ-2012']
+  aliases: []
   parents:
   - 3406907
 2918772:
-  aliases: ['Culex sp. EM_331']
+  aliases: []
   parents:
   - 3406907
 1233179:
-  aliases: ['Culex sp. EP-2012a']
+  aliases: []
   parents:
   - 3406907
 1233180:
-  aliases: ['Culex sp. EP-2012b']
+  aliases: []
   parents:
   - 3406907
 1795407:
-  aliases: ['Culex sp. Field_2']
+  aliases: []
   parents:
   - 3406907
 1795408:
-  aliases: ['Culex sp. Field_4']
+  aliases: []
   parents:
   - 3406907
 1795409:
-  aliases: ['Culex sp. Field_7']
+  aliases: []
   parents:
   - 3406907
 1874920:
-  aliases: ['Culex sp. GP-A']
+  aliases: []
   parents:
   - 3406907
 1874921:
-  aliases: ['Culex sp. GP-B']
+  aliases: []
   parents:
   - 3406907
 1874922:
-  aliases: ['Culex sp. GP-C']
+  aliases: []
   parents:
   - 3406907
 1795410:
-  aliases: ['Culex sp. Kef_2']
+  aliases: []
   parents:
   - 3406907
 1795411:
-  aliases: ['Culex sp. Kef_3']
+  aliases: []
   parents:
   - 3406907
 1795412:
-  aliases: ['Culex sp. Kef_4']
+  aliases: []
   parents:
   - 3406907
 1795413:
-  aliases: ['Culex sp. Kef_6']
+  aliases: []
   parents:
   - 3406907
 2931914:
-  aliases: ['Culex sp. M15']
+  aliases: []
   parents:
   - 3406907
 2931916:
-  aliases: ['Culex sp. M17']
+  aliases: []
   parents:
   - 3406907
 2931917:
-  aliases: ['Culex sp. M2A']
+  aliases: []
   parents:
   - 3406907
 2931918:
-  aliases: ['Culex sp. M2B']
+  aliases: []
   parents:
   - 3406907
 342877:
-  aliases: ['Culex sp. M42']
+  aliases: []
   parents:
   - 3406907
 342878:
-  aliases: ['Culex sp. M43']
+  aliases: []
   parents:
   - 3406907
 342879:
-  aliases: ['Culex sp. M44']
+  aliases: []
   parents:
   - 3406907
 342880:
-  aliases: ['Culex sp. M45']
+  aliases: []
   parents:
   - 3406907
 342881:
-  aliases: ['Culex sp. M46']
+  aliases: []
   parents:
   - 3406907
 342882:
-  aliases: ['Culex sp. M47']
+  aliases: []
   parents:
   - 3406907
 1803717:
-  aliases: ['Culex sp. M47YA']
+  aliases: []
   parents:
   - 3406907
 342883:
-  aliases: ['Culex sp. M54']
+  aliases: []
   parents:
   - 3406907
 342884:
-  aliases: ['Culex sp. M58']
+  aliases: []
   parents:
   - 3406907
 1803718:
-  aliases: ['Culex sp. M63YA']
+  aliases: []
   parents:
   - 3406907
 342885:
-  aliases: ['Culex sp. M67']
+  aliases: []
   parents:
   - 3406907
 342886:
-  aliases: ['Culex sp. M68']
+  aliases: []
   parents:
   - 3406907
 342887:
-  aliases: ['Culex sp. M69']
+  aliases: []
   parents:
   - 3406907
 1803719:
-  aliases: ['Culex sp. M70YA']
+  aliases: []
   parents:
   - 3406907
 342888:
-  aliases: ['Culex sp. M71']
+  aliases: []
   parents:
   - 3406907
 1803720:
-  aliases: ['Culex sp. M71YA']
+  aliases: []
   parents:
   - 3406907
 1803721:
-  aliases: ['Culex sp. M75YA']
+  aliases: []
   parents:
   - 3406907
 2931913:
-  aliases: ['Culex sp. M9']
+  aliases: []
   parents:
   - 3406907
 2821152:
-  aliases: ['Culex sp. Marks #32']
+  aliases: []
   parents:
   - 3406907
 1795414:
-  aliases: ['Culex sp. Mateur_1']
+  aliases: []
   parents:
   - 3406907
 1795415:
-  aliases: ['Culex sp. Mateur_2']
+  aliases: []
   parents:
   - 3406907
 1795416:
-  aliases: ['Culex sp. Mateur_3']
+  aliases: []
   parents:
   - 3406907
 2715101:
-  aliases: ['Culex sp. Na591']
+  aliases: []
   parents:
   - 3406907
 2292623:
-  aliases: ['Culex sp. O103']
+  aliases: []
   parents:
   - 3406907
 1795417:
-  aliases: ['Culex sp. Quest_1']
+  aliases: []
   parents:
   - 3406907
 1795418:
-  aliases: ['Culex sp. Quest_2']
+  aliases: []
   parents:
   - 3406907
 1795419:
-  aliases: ['Culex sp. Quest_3']
+  aliases: []
   parents:
   - 3406907
 1803722:
-  aliases: ['Culex sp. R32']
+  aliases: []
   parents:
   - 3406907
 1803723:
-  aliases: ['Culex sp. R33']
+  aliases: []
   parents:
   - 3406907
 1803724:
-  aliases: ['Culex sp. R34']
+  aliases: []
   parents:
   - 3406907
 1803725:
-  aliases: ['Culex sp. R73']
+  aliases: []
   parents:
   - 3406907
 2609014:
-  aliases: ['Culex sp. RDC6']
+  aliases: []
   parents:
   - 3406907
 2588652:
-  aliases: ['Culex sp. RP-2019-10']
+  aliases: []
   parents:
   - 3406907
 2588653:
-  aliases: ['Culex sp. RP-2019-11']
+  aliases: []
   parents:
   - 3406907
 2588654:
-  aliases: ['Culex sp. RP-2019-12']
+  aliases: []
   parents:
   - 3406907
 2588655:
-  aliases: ['Culex sp. RP-2019-15']
+  aliases: []
   parents:
   - 3406907
 2588645:
-  aliases: ['Culex sp. RP-2019-3']
+  aliases: []
   parents:
   - 3406907
 2588646:
-  aliases: ['Culex sp. RP-2019-4']
+  aliases: []
   parents:
   - 3406907
 2588647:
-  aliases: ['Culex sp. RP-2019-5']
+  aliases: []
   parents:
   - 3406907
 2588648:
-  aliases: ['Culex sp. RP-2019-6']
+  aliases: []
   parents:
   - 3406907
 2588649:
-  aliases: ['Culex sp. RP-2019-7']
+  aliases: []
   parents:
   - 3406907
 2588650:
-  aliases: ['Culex sp. RP-2019-8']
+  aliases: []
   parents:
   - 3406907
 2588651:
-  aliases: ['Culex sp. RP-2019-9']
+  aliases: []
   parents:
   - 3406907
 2562605:
-  aliases: ['Culex sp. S59']
+  aliases: []
   parents:
   - 3406907
 1576577:
-  aliases: ['Culex sp. SOKN051']
+  aliases: []
   parents:
   - 3406907
 1750489:
-  aliases: ['Culex sp. SSEIA4880-13']
+  aliases: []
   parents:
   - 3406907
 1795420:
-  aliases: ['Culex sp. Souala_1']
+  aliases: []
   parents:
   - 3406907
 1795421:
-  aliases: ['Culex sp. Souala_2']
+  aliases: []
   parents:
   - 3406907
 1795422:
-  aliases: ['Culex sp. Souala_3']
+  aliases: []
   parents:
   - 3406907
 1803726:
-  aliases: ['Culex sp. T15']
+  aliases: []
   parents:
   - 3406907
 1803727:
-  aliases: ['Culex sp. T16']
+  aliases: []
   parents:
   - 3406907
 2827231:
-  aliases: ['Culex sp. ZCCK 015']
+  aliases: []
   parents:
   - 3406907
 2827232:
-  aliases: ['Culex sp. ZCRK 181']
+  aliases: []
   parents:
   - 3406907
 1677834:
-  aliases: ['Culex sp. ZFMK PR011-Colombia']
+  aliases: []
   parents:
   - 3406907
 1677835:
-  aliases: ['Culex sp. ZFMK PR024-Colombia']
+  aliases: []
   parents:
   - 3406907
 1677836:
-  aliases: ['Culex sp. ZFMK PR028-Colombia']
+  aliases: []
   parents:
   - 3406907
 1677837:
-  aliases: ['Culex sp. ZFMK PR031-Colombia']
+  aliases: []
   parents:
   - 3406907
 1677838:
-  aliases: ['Culex sp. ZFMK PR033-Colombia']
+  aliases: []
   parents:
   - 3406907
 1677839:
-  aliases: ['Culex sp. ZFMK PR035-Colombia']
+  aliases: []
   parents:
   - 3406907
 1677840:
-  aliases: ['Culex sp. ZFMK PR036-Colombia']
+  aliases: []
   parents:
   - 3406907
 1677841:
-  aliases: ['Culex sp. ZFMK PR041-Colombia']
+  aliases: []
   parents:
   - 3406907
 1677842:
-  aliases: ['Culex sp. ZFMK PR043-Colombia']
+  aliases: []
   parents:
   - 3406907
 1677843:
-  aliases: ['Culex sp. ZFMK PR045-Colombia']
+  aliases: []
   parents:
   - 3406907
 1677844:
-  aliases: ['Culex sp. ZFMK PR075-Colombia']
+  aliases: []
   parents:
   - 3406907
 3018959:
-  aliases: ['Culex sp. n.']
+  aliases: []
   parents:
   - 3406907
 2814812:
-  aliases: ['Culex sp. n. 1 DS-2021']
+  aliases: []
   parents:
   - 3406907
 2007265:
-  aliases: ['Culex sp. stI']
+  aliases: []
   parents:
   - 3406907
 2007266:
-  aliases: ['Culex sp. stJ']
+  aliases: []
   parents:
   - 3406907
 2007267:
-  aliases: ['Culex sp. stK']
+  aliases: []
   parents:
   - 3406907
 2007268:
-  aliases: ['Culex sp. stL']
+  aliases: []
   parents:
   - 3406907
 1245364:
-  aliases: ['Culex spiculosus']
+  aliases: []
   parents:
   - 308715
 3382162:
-  aliases: ['Culex spinifer']
+  aliases: []
   parents:
   - 53535
 1461358:
-  aliases: ['Culex spinosus']
+  aliases: []
   parents:
   - 53527
 284565:
-  aliases: ['Culex spissipes']
+  aliases: []
   parents:
   - 53535
 1905333:
-  aliases: ['Culex squamosus']
+  aliases: []
   parents:
   - 53527
 2884703:
-  aliases: ['Culex starckeae']
+  aliases: []
   parents:
   - 667565
 1481111:
-  aliases: ['Culex stigmatosoma']
+  aliases: []
   parents:
   - 53527
 2007269:
-  aliases: ['Culex stonei']
+  aliases: []
   parents:
   - 707272
 1799678:
-  aliases: ['Culex striatipes']
+  aliases: []
   parents:
   - 53527
 3137932:
-  aliases: ['Culex sumatranus']
+  aliases: []
   parents:
   - 308715
 1461359:
-  aliases: ['Culex surinamensis']
+  aliases: []
   parents:
   - 53527
 284566:
-  aliases: ['Culex taeniopus']
+  aliases: []
   parents:
   - 53535
 7177:
-  aliases: ['Culex tarsalis']
+  aliases: []
   parents:
   - 53527
 1461360:
-  aliases: ['Culex tatoi']
+  aliases: []
   parents:
   - 53527
 1406361:
-  aliases: ['Culex telesilla']
+  aliases: []
   parents:
   - 53527
 1799679:
-  aliases: ['Culex tenagius']
+  aliases: []
   parents:
   - 53527
 42431:
-  aliases: ['Culex territans']
+  aliases: []
   parents:
   - 53537
 1799680:
-  aliases: ['Culex terzii']
+  aliases: []
   parents:
   - 53527
 1799681:
-  aliases: ['Culex thalassius']
+  aliases: []
   parents:
   - 53527
 561267:
-  aliases: ['Culex theileri']
+  aliases: []
   parents:
   - 53527
 1677688:
-  aliases: ['Culex theobaldi']
+  aliases: []
   parents:
   - 53535
 871895:
-  aliases: ['Culex thriambus']
+  aliases: []
   parents:
   - 53527
 42433:
-  aliases: ['Culex torrentium']
+  aliases: []
   parents:
   - 53527
 3453696:
-  aliases: ['Culex tournieri']
+  aliases: []
   parents:
   - 53535
 2918768:
-  aliases: ['Culex trifilatus']
+  aliases: []
   parents:
   - 53527
 1899256:
-  aliases: ['Culex trigeminatus']
+  aliases: []
   parents:
   - 53535
 7178:
-  aliases: ['Culex tritaeniorhynchus']
+  aliases: []
   parents:
   - 53527
 1214269:
-  aliases: ['Culex tuberis']
+  aliases: []
   parents:
   - 308715
 3453697:
-  aliases: ['Culex unicornis']
+  aliases: []
   parents:
   - 53535
 498400:
-  aliases: ['Culex uniformis']
+  aliases: []
   parents:
   - 308715
 420550:
-  aliases: ['Culex univittatus']
+  aliases: []
   parents:
   - 53527
 1426907:
-  aliases: ['Culex urichii']
+  aliases: []
   parents:
   - 794814
 2037950:
-  aliases: ['Culex usquatissimus']
+  aliases: []
   parents:
   - 53527
 707283:
-  aliases: ['Culex usquatus']
+  aliases: []
   parents:
   - 53527
 1144254:
-  aliases: ['Culex vagans']
+  aliases: []
   parents:
   - 53527
 1799682:
-  aliases: ['Culex vansomereni']
+  aliases: []
   parents:
   - 53527
 1899257:
-  aliases: ['Culex vaxus']
+  aliases: []
   parents:
   - 53535
 100678:
-  aliases: ['Culex vishnui']
+  aliases: []
   parents:
   - 53527
 1879284:
-  aliases: ['Culex vishnui group sp. GY-2016']
+  aliases: []
   parents:
   - 53527
 284567:
-  aliases: ['Culex vomerifer']
+  aliases: []
   parents:
   - 53535
 1799683:
-  aliases: ['Culex watti']
+  aliases: []
   parents:
   - 53527
 346051:
-  aliases: ['Culex whitmorei']
+  aliases: []
   parents:
   - 53527
 707277:
-  aliases: ['Culex ybarmis']
+  aliases: []
   parents:
   - 53535
 3077183:
-  aliases: ['Culex zabanicus']
+  aliases: []
   parents:
   - 53535
 707278:
-  aliases: ['Culex zeteki']
+  aliases: []
   parents:
   - 53535
 503353:
-  aliases: ['Culex zombaensis']
+  aliases: []
   parents:
   - 53527
 2907304:
-  aliases: ['Culiseta alaskaensis indica']
+  aliases: []
   parents:
   - 1788509
 3025212:
-  aliases: ['Culiseta sp.']
+  aliases: []
   parents:
   - 2619201
 2327011:
-  aliases: ['Culiseta sp. BBDCP560-10']
+  aliases: []
   parents:
   - 2619201
 2327012:
-  aliases: ['Culiseta sp. BBDCP561-10']
+  aliases: []
   parents:
   - 2619201
 2327013:
-  aliases: ['Culiseta sp. BBDCP562-10']
+  aliases: []
   parents:
   - 2619201
 2208866:
-  aliases: ['Culiseta sp. BIOUG06185-C11']
+  aliases: []
   parents:
   - 2619201
 2308357:
-  aliases: ['Culiseta sp. BIOUG26655-D07']
+  aliases: []
   parents:
   - 2619201
 2208867:
-  aliases: ['Culiseta sp. BIOUG27066-F12']
+  aliases: []
   parents:
   - 2619201
 2308358:
-  aliases: ['Culiseta sp. BIOUG30389-D10']
+  aliases: []
   parents:
   - 2619201
 1887097:
-  aliases: ['Culiseta sp. BOLD-2016']
+  aliases: []
   parents:
   - 2619201
 1741585:
-  aliases: ['Culiseta sp. BOLD:AAD3254']
+  aliases: []
   parents:
   - 2619201
 1822827:
-  aliases: ['Culiseta sp. BOLD:AAM8971']
+  aliases: []
   parents:
   - 2619201
 2749912:
-  aliases: ['Haemagogus (Haemagogus) sp. 1 DLL-2018']
+  aliases: []
   parents:
   - 464954
 2800849:
-  aliases: ['Haemagogus albomaculatus']
+  aliases: []
   parents:
   - 464954
 2715204:
-  aliases: ['Haemagogus anastasionis']
+  aliases: []
   parents:
   - 464954
 3153705:
-  aliases: ['Haemagogus capricornii']
+  aliases: []
   parents:
   - 464954
 2715205:
-  aliases: ['Haemagogus celeste']
+  aliases: []
   parents:
   - 464954
 2715206:
-  aliases: ['Haemagogus chalcospilans']
+  aliases: []
   parents:
   - 464954
 53526:
-  aliases: ['Haemagogus equinus']
+  aliases: []
   parents:
   - 464954
 1677689:
-  aliases: ['Haemagogus janthinomys']
+  aliases: []
   parents:
   - 464954
 1170321:
-  aliases: ['Haemagogus leucocelaenus']
+  aliases: []
   parents:
   - 464955
 464953:
-  aliases: ['Haemagogus lucifer']
+  aliases: []
   parents:
   - 464954
 7181:
-  aliases: ['Haemagogus mesodentatus']
+  aliases: []
   parents:
   - 464954
 2772555:
-  aliases: ['Haemagogus sp.']
+  aliases: []
   parents:
   - 3406951
 2820889:
-  aliases: ['Haemagogus sp. Caroni_2019']
+  aliases: []
   parents:
   - 3406951
 2820890:
-  aliases: ['Haemagogus sp. Cumana_2019']
+  aliases: []
   parents:
   - 3406951
 2820893:
-  aliases: ['Haemagogus sp. PtGourde13R_2019']
+  aliases: []
   parents:
   - 3406951
 2820894:
-  aliases: ['Haemagogus sp. PtGourde19R_2019']
+  aliases: []
   parents:
   - 3406951
 2820891:
-  aliases: ['Haemagogus sp. janth3_2006']
+  aliases: []
   parents:
   - 3406951
 2820892:
-  aliases: ['Haemagogus sp. leuco2_2006']
+  aliases: []
   parents:
   - 3406951
 864587:
-  aliases: ['Haemagogus spegazzinii']
+  aliases: []
   parents:
   - 464954
 2800850:
-  aliases: ['Haemagogus tropicalis']
+  aliases: []
   parents:
   - 464954
 2587282:
-  aliases: ['Heizmannia (Mattinglyia) sp. DBNB28']
+  aliases: []
   parents:
   - 317802
 2587275:
-  aliases: ['Heizmannia achaetae']
+  aliases: []
   parents:
   - 317802
 325438:
-  aliases: ['Heizmannia chandi']
+  aliases: []
   parents:
   - 325437
 1245365:
-  aliases: ['Heizmannia chengi']
+  aliases: []
   parents:
   - 325437
 317803:
-  aliases: ['Heizmannia discrepans']
+  aliases: []
   parents:
   - 317802
 1245366:
-  aliases: ['Heizmannia lii']
+  aliases: []
   parents:
   - 325437
 1245367:
-  aliases: ['Heizmannia menglianensis']
+  aliases: []
   parents:
   - 325437
 1245368:
-  aliases: ['Heizmannia proxima']
+  aliases: []
   parents:
   - 325437
 1245369:
-  aliases: ['Heizmannia reidi']
+  aliases: []
   parents:
   - 325437
 2793871:
-  aliases: ['Heizmannia sp. DF34_A_1']
+  aliases: []
   parents:
   - 3406956
 2793872:
-  aliases: ['Heizmannia sp. KR37_U_9']
+  aliases: []
   parents:
   - 3406956
 2793870:
-  aliases: ['Heizmannia sp. M84_A_2']
+  aliases: []
   parents:
   - 3406956
 2853139:
-  aliases: ['Heizmannia sp. P_200_FSTHD']
+  aliases: []
   parents:
   - 3406956
 498624:
-  aliases: ['Lophoscelomyia']
+  aliases: []
   parents:
   - 44483
 2725255:
-  aliases: ['Mansonia (Mansonia) sp. Mu148']
+  aliases: []
   parents:
   - 308734
 667564:
-  aliases: ['Mansonia africana']
+  aliases: []
   parents:
   - 308733
 2597065:
-  aliases: ['Mansonia amazonensis']
+  aliases: []
   parents:
   - 308734
 1041525:
-  aliases: ['Mansonia annulata']
+  aliases: []
   parents:
   - 308733
 308732:
-  aliases: ['Mansonia annulifera']
+  aliases: []
   parents:
   - 308733
 1038078:
-  aliases: ['Mansonia bonneae']
+  aliases: []
   parents:
   - 308733
 149460:
-  aliases: ['Mansonia dives']
+  aliases: []
   parents:
   - 308733
 2663023:
-  aliases: ['Mansonia dyari']
+  aliases: []
   parents:
   - 308734
 1206049:
-  aliases: ['Mansonia flaveola']
+  aliases: []
   parents:
   - 308734
 2993638:
-  aliases: ['Mansonia fonsecai']
+  aliases: []
   parents:
   - 308734
 2742697:
-  aliases: ['Mansonia humeralis']
+  aliases: []
   parents:
   - 308734
 2993639:
-  aliases: ['Mansonia iguassuensis']
+  aliases: []
   parents:
   - 308734
 2035320:
-  aliases: ['Mansonia indiana']
+  aliases: []
   parents:
   - 308733
 2232091:
-  aliases: ['Mansonia indubitans']
+  aliases: []
   parents:
   - 308734
 2951564:
-  aliases: ['Mansonia nr. titillans']
+  aliases: []
   parents:
   - 308734
 873169:
-  aliases: ['Mansonia pseudotitillans']
+  aliases: []
   parents:
   - 308734
 663930:
-  aliases: ['Mansonia septempunctata']
+  aliases: []
   parents:
   - 308733
 2046962:
-  aliases: ['Mansonia sp. (in: mosquitos)']
+  aliases: []
   parents:
   - 1147728
 1147729:
-  aliases: ['Mansonia sp. 1 BR-2012']
+  aliases: []
   parents:
   - 1147728
 1147730:
-  aliases: ['Mansonia sp. 2 BR-2012']
+  aliases: []
   parents:
   - 1147728
 2725256:
-  aliases: ['Mansonia sp. Ca130']
+  aliases: []
   parents:
   - 1147728
 2715100:
-  aliases: ['Mansonia sp. Mu148']
+  aliases: []
   parents:
   - 1147728
 869066:
-  aliases: ['Mansonia titillans']
+  aliases: []
   parents:
   - 308734
 308735:
-  aliases: ['Mansonia uniformis']
+  aliases: []
   parents:
   - 308733
 2027292:
-  aliases: ['Mansonia wilsoni']
+  aliases: []
   parents:
   - 308734
 2900300:
-  aliases: ['Mimomyia aurea']
+  aliases: []
   parents:
   - 308737
 308740:
-  aliases: ['Mimomyia chamberlaini']
+  aliases: []
   parents:
   - 308737
 2918771:
-  aliases: ['Mimomyia hispida']
+  aliases: []
   parents:
   - 308737
 704170:
-  aliases: ['Mimomyia luzonensis']
+  aliases: []
   parents:
   - 308739
 2563599:
-  aliases: ['Mimomyia mediolineata']
+  aliases: []
   parents:
   - 308739
 2563597:
-  aliases: ['Mimomyia mimomyiaformis']
+  aliases: []
   parents:
   - 308737
 2563598:
-  aliases: ['Mimomyia plumosa']
+  aliases: []
   parents:
   - 308737
 2912051:
-  aliases: ['Mimomyia sp.']
+  aliases: []
   parents:
   - 3407012
 1799684:
-  aliases: ['Mimomyia splendens']
+  aliases: []
   parents:
   - 308737
 58250:
-  aliases: ['Myzorhynchus']
+  aliases: []
   parents:
   - 58247
 2725257:
-  aliases: ['Ochlerotatus (Ochlerotatus) sp. 1 DJS-2020']
+  aliases: []
   parents:
   - 53545
 2725258:
-  aliases: ['Ochlerotatus (Ochlerotatus) sp. 2 DJS-2020']
+  aliases: []
   parents:
   - 53545
 329100:
-  aliases: ['Ochlerotatus abserratus']
+  aliases: []
   parents:
   - 53545
 1914896:
-  aliases: ['Ochlerotatus aculeatus']
+  aliases: []
   parents:
   - 53545
 571209:
-  aliases: ['Ochlerotatus albifasciatus']
+  aliases: []
   parents:
   - 53545
 1206301:
-  aliases: ['Ochlerotatus aloponotum']
+  aliases: []
   parents:
   - 53545
 1631547:
-  aliases: ['Ochlerotatus angustivittatus']
+  aliases: []
   parents:
   - 53545
 866103:
-  aliases: ['Ochlerotatus annulipes']
+  aliases: []
   parents:
   - 53545
 2292404:
-  aliases: ['Ochlerotatus antipodeus']
+  aliases: []
   parents:
   - 53545
 71822:
-  aliases: ['Ochlerotatus ashworthi']
+  aliases: []
   parents:
   - 71821
 1205936:
-  aliases: ['Ochlerotatus atlanticus']
+  aliases: []
   parents:
   - 53545
 329101:
-  aliases: ['Ochlerotatus aurifer']
+  aliases: []
   parents:
   - 53545
 71823:
-  aliases: ['Ochlerotatus australis']
+  aliases: []
   parents:
   - 71821
 1214260:
-  aliases: ['Ochlerotatus baisasi']
+  aliases: []
   parents:
   - 346056
 856742:
-  aliases: ['Ochlerotatus bancroftianus']
+  aliases: []
   parents:
   - 346065
 1315220:
-  aliases: ['Ochlerotatus behningi']
+  aliases: []
   parents:
   - 53545
 2579877:
-  aliases: ['Ochlerotatus berlandi']
+  aliases: []
   parents:
   - 53545
 1206034:
-  aliases: ['Ochlerotatus bicristatus']
+  aliases: []
   parents:
   - 190767
 3452916:
-  aliases: ['Ochlerotatus bimaculatus']
+  aliases: []
   parents:
   - 767021
 119226:
-  aliases: ['Ochlerotatus brelandi']
+  aliases: []
   parents:
   - 119225
 1206035:
-  aliases: ['Ochlerotatus burgeri']
+  aliases: []
   parents:
   - 119225
 3048044:
-  aliases: ['Ochlerotatus burpengaryensis']
+  aliases: []
   parents:
   - 53545
 1289171:
-  aliases: ['Ochlerotatus caballus']
+  aliases: []
   parents:
   - 1289136
 909054:
-  aliases: ['Ochlerotatus campestris']
+  aliases: []
   parents:
   - 53545
 644619:
-  aliases: ['Ochlerotatus camptorhynchus']
+  aliases: []
   parents:
   - 53545
 228917:
-  aliases: ['Ochlerotatus canadensis']
+  aliases: []
   parents:
   - 53545
 3014953:
-  aliases: ['Ochlerotatus candidoscutellum']
+  aliases: []
   parents:
   - 767021
 120869:
-  aliases: ['Ochlerotatus cantans']
+  aliases: []
   parents:
   - 53545
 329102:
-  aliases: ['Ochlerotatus cantator']
+  aliases: []
   parents:
   - 53545
 120870:
-  aliases: ['Ochlerotatus caspius']
+  aliases: []
   parents:
   - 53545
 120871:
-  aliases: ['Ochlerotatus cataphylla']
+  aliases: []
   parents:
   - 53545
 1709292:
-  aliases: ['Ochlerotatus cf. cantans/annulipes M18']
+  aliases: []
   parents:
   - 1125803
 1709293:
-  aliases: ['Ochlerotatus cf. cantans/annulipes M19']
+  aliases: []
   parents:
   - 1125803
 1709294:
-  aliases: ['Ochlerotatus cf. cantans/annulipes M20']
+  aliases: []
   parents:
   - 1125803
 1709295:
-  aliases: ['Ochlerotatus cf. cantans/annulipes M21']
+  aliases: []
   parents:
   - 1125803
 1709296:
-  aliases: ['Ochlerotatus cf. cantans/annulipes M22']
+  aliases: []
   parents:
   - 1125803
 1709297:
-  aliases: ['Ochlerotatus cf. cantans/annulipes M23']
+  aliases: []
   parents:
   - 1125803
 1709298:
-  aliases: ['Ochlerotatus cf. cantans/annulipes M25']
+  aliases: []
   parents:
   - 1125803
 1709299:
-  aliases: ['Ochlerotatus cf. cantans/annulipes M26']
+  aliases: []
   parents:
   - 1125803
 1709300:
-  aliases: ['Ochlerotatus cf. cantans/annulipes M27']
+  aliases: []
   parents:
   - 1125803
 1709301:
-  aliases: ['Ochlerotatus cf. cantans/annulipes M28']
+  aliases: []
   parents:
   - 1125803
 1709302:
-  aliases: ['Ochlerotatus cf. cantans/annulipes M29']
+  aliases: []
   parents:
   - 1125803
 1709303:
-  aliases: ['Ochlerotatus cf. cantans/annulipes M30']
+  aliases: []
   parents:
   - 1125803
 1709304:
-  aliases: ['Ochlerotatus cf. cantans/annulipes M31']
+  aliases: []
   parents:
   - 1125803
 1709305:
-  aliases: ['Ochlerotatus cf. cantans/annulipes M34']
+  aliases: []
   parents:
   - 1125803
 1709306:
-  aliases: ['Ochlerotatus cf. cantans/annulipes M35']
+  aliases: []
   parents:
   - 1125803
 3153704:
-  aliases: ['Ochlerotatus cf. serratus/nubilus']
+  aliases: []
   parents:
   - 767021
 2785378:
-  aliases: ['Ochlerotatus chionotum']
+  aliases: []
   parents:
   - 119225
 1315706:
-  aliases: ['Ochlerotatus churchillensis']
+  aliases: []
   parents:
   - 53545
 1969955:
-  aliases: ['Ochlerotatus clelandi']
+  aliases: []
   parents:
   - 53545
 1503992:
-  aliases: ['Ochlerotatus coluzzii']
+  aliases: []
   parents:
   - 53545
 329099:
-  aliases: ['Ochlerotatus communis']
+  aliases: []
   parents:
   - 53545
 1890520:
-  aliases: ['Ochlerotatus communis complex sp. BOLD-2016']
+  aliases: []
   parents:
   - 53545
 2340328:
-  aliases: ['Ochlerotatus communis complex sp. JWDCE418-10']
+  aliases: []
   parents:
   - 1125803
 2340329:
-  aliases: ['Ochlerotatus communis complex sp. JWDCE432-10']
+  aliases: []
   parents:
   - 1125803
 2340330:
-  aliases: ['Ochlerotatus communis complex sp. JWDCE433-10']
+  aliases: []
   parents:
   - 1125803
 2340331:
-  aliases: ['Ochlerotatus communis complex sp. JWDCI262-10']
+  aliases: []
   parents:
   - 1125803
 2340332:
-  aliases: ['Ochlerotatus communis complex sp. JWDCI264-10']
+  aliases: []
   parents:
   - 1125803
 2340333:
-  aliases: ['Ochlerotatus communis complex sp. JWDCJ451-11']
+  aliases: []
   parents:
   - 1125803
 2340334:
-  aliases: ['Ochlerotatus communis complex sp. JWDCJ453-11']
+  aliases: []
   parents:
   - 1125803
 1091056:
-  aliases: ['Ochlerotatus crinifer']
+  aliases: []
   parents:
   - 53545
 662895:
-  aliases: ['Ochlerotatus cyprius']
+  aliases: []
   parents:
   - 53545
 1205937:
-  aliases: ['Ochlerotatus deserticola']
+  aliases: []
   parents:
   - 767021
 120873:
-  aliases: ['Ochlerotatus detritus']
+  aliases: []
   parents:
   - 53545
 1129559:
-  aliases: ['Ochlerotatus diantaeus']
+  aliases: []
   parents:
   - 53545
 1245344:
-  aliases: ['Ochlerotatus dissimilis']
+  aliases: []
   parents:
   - 346058
 663928:
-  aliases: ['Ochlerotatus dorsalis']
+  aliases: []
   parents:
   - 53545
 2067447:
-  aliases: ['Ochlerotatus dupreei']
+  aliases: []
   parents:
   - 1379452
 1712862:
-  aliases: ['Ochlerotatus eatoni']
+  aliases: []
   parents:
   - 767021
 2654761:
-  aliases: ['Ochlerotatus eidsvoldensis']
+  aliases: []
   parents:
   - 767021
 3114449:
-  aliases: ['Ochlerotatus elchoensis']
+  aliases: []
   parents:
   - 346055
 173086:
-  aliases: ['Ochlerotatus epactius']
+  aliases: []
   parents:
   - 53545
 743690:
-  aliases: ['Ochlerotatus euedes']
+  aliases: []
   parents:
   - 53545
 1677690:
-  aliases: ['Ochlerotatus euiris']
+  aliases: []
   parents:
   - 767021
 2863126:
-  aliases: ['Ochlerotatus euplocamus']
+  aliases: []
   parents:
   - 767021
 329103:
-  aliases: ['Ochlerotatus excrucians']
+  aliases: []
   parents:
   - 53545
 743691:
-  aliases: ['Ochlerotatus fitchii']
+  aliases: []
   parents:
   - 53545
 662894:
-  aliases: ['Ochlerotatus flavescens']
+  aliases: []
   parents:
   - 53545
 2321073:
-  aliases: ['Ochlerotatus flavifrons']
+  aliases: []
   parents:
   - 53545
 658031:
-  aliases: ['Ochlerotatus fluviatilis']
+  aliases: []
   parents:
   - 53545
 1285602:
-  aliases: ['Ochlerotatus fulvus']
+  aliases: []
   parents:
   - 1285601
 2785379:
-  aliases: ['Ochlerotatus gabriel']
+  aliases: []
   parents:
   - 119225
 228920:
-  aliases: ['Ochlerotatus grossbecki']
+  aliases: []
   parents:
   - 53545
 1043727:
-  aliases: ['Ochlerotatus harrisoni']
+  aliases: []
   parents:
   - 767021
 2795830:
-  aliases: ['Ochlerotatus hastatus']
+  aliases: []
   parents:
   - 767021
 104516:
-  aliases: ['Ochlerotatus hendersoni']
+  aliases: []
   parents:
   - 119225
 1969954:
-  aliases: ['Ochlerotatus hesperonotius']
+  aliases: []
   parents:
   - 53545
 767797:
-  aliases: ['Ochlerotatus hexodontus']
+  aliases: []
   parents:
   - 53545
 1810856:
-  aliases: ['Ochlerotatus hungaricus']
+  aliases: []
   parents:
   - 53545
 1386052:
-  aliases: ['Ochlerotatus impiger']
+  aliases: []
   parents:
   - 53545
 743692:
-  aliases: ['Ochlerotatus implicatus']
+  aliases: []
   parents:
   - 53545
 1205938:
-  aliases: ['Ochlerotatus increpitus']
+  aliases: []
   parents:
   - 767021
 980429:
-  aliases: ['Ochlerotatus infirmatus']
+  aliases: []
   parents:
   - 53545
 2872821:
-  aliases: ['Ochlerotatus insolitus']
+  aliases: []
   parents:
   - 119225
 228921:
-  aliases: ['Ochlerotatus intrudens']
+  aliases: []
   parents:
   - 53545
 1289137:
-  aliases: ['Ochlerotatus juppi']
+  aliases: []
   parents:
   - 1289136
 1245356:
-  aliases: ['Ochlerotatus kasachstanicus']
+  aliases: []
   parents:
   - 767021
 1788511:
-  aliases: ['Ochlerotatus leucomelas']
+  aliases: []
   parents:
   - 53545
 149331:
-  aliases: ['Ochlerotatus longifilamentus']
+  aliases: []
   parents:
   - 53545
 2900298:
-  aliases: ['Ochlerotatus longirostris']
+  aliases: []
   parents:
   - 345925
 2059239:
-  aliases: ['Ochlerotatus macintoshi']
+  aliases: []
   parents:
   - 767021
 1206302:
-  aliases: ['Ochlerotatus mediovittatus']
+  aliases: []
   parents:
   - 346057
 767022:
-  aliases: ['Ochlerotatus melanimon']
+  aliases: []
   parents:
   - 767021
 1206303:
-  aliases: ['Ochlerotatus mitchellae']
+  aliases: []
   parents:
   - 767021
 1205939:
-  aliases: ['Ochlerotatus monticola']
+  aliases: []
   parents:
   - 767021
 1205940:
-  aliases: ['Ochlerotatus mueller']
+  aliases: []
   parents:
   - 767021
 2321074:
-  aliases: ['Ochlerotatus multiplex']
+  aliases: []
   parents:
   - 346065
 1788512:
-  aliases: ['Ochlerotatus nigrinus']
+  aliases: []
   parents:
   - 53545
 508662:
-  aliases: ['Ochlerotatus nigripes']
+  aliases: []
   parents:
   - 53545
 2792478:
-  aliases: ['Ochlerotatus nigrithorax']
+  aliases: []
   parents:
   - 767021
 767023:
-  aliases: ['Ochlerotatus nigromaculis']
+  aliases: []
   parents:
   - 767021
 1205941:
-  aliases: ['Ochlerotatus niphadopsis']
+  aliases: []
   parents:
   - 767021
 3014954:
-  aliases: ['Ochlerotatus nivalis']
+  aliases: []
   parents:
   - 767021
 666361:
-  aliases: ['Ochlerotatus normanensis']
+  aliases: []
   parents:
   - 53545
 1825799:
-  aliases: ['Ochlerotatus nr. cantans BOLD:AAB1098']
+  aliases: []
   parents:
   - 1125803
 2686177:
-  aliases: ['Ochlerotatus nr. caspius APHA-2-2015C02']
+  aliases: []
   parents:
   - 53545
 2686179:
-  aliases: ['Ochlerotatus nr. caspius APHA-2-2015E08']
+  aliases: []
   parents:
   - 53545
 2686165:
-  aliases: ['Ochlerotatus nr. caspius APHA-2-2015E09']
+  aliases: []
   parents:
   - 53545
 2686178:
-  aliases: ['Ochlerotatus nr. caspius APHA-2-2015E10']
+  aliases: []
   parents:
   - 53545
 2686159:
-  aliases: ['Ochlerotatus nr. caspius APHA-2-2015E11']
+  aliases: []
   parents:
   - 53545
 2686161:
-  aliases: ['Ochlerotatus nr. caspius APHA-2-2015E12']
+  aliases: []
   parents:
   - 53545
 2686163:
-  aliases: ['Ochlerotatus nr. caspius APHA-2-2015F01']
+  aliases: []
   parents:
   - 53545
 2686167:
-  aliases: ['Ochlerotatus nr. caspius APHA-2-2015F02']
+  aliases: []
   parents:
   - 53545
 2686164:
-  aliases: ['Ochlerotatus nr. caspius APHA-2-2015F03']
+  aliases: []
   parents:
   - 53545
 2686174:
-  aliases: ['Ochlerotatus nr. caspius APHA-2-2015F05']
+  aliases: []
   parents:
   - 53545
 2686162:
-  aliases: ['Ochlerotatus nr. caspius APHA-2-2015F06']
+  aliases: []
   parents:
   - 53545
 2686175:
-  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D02']
+  aliases: []
   parents:
   - 53545
 2686181:
-  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D03']
+  aliases: []
   parents:
   - 53545
 2686173:
-  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D04']
+  aliases: []
   parents:
   - 53545
 2686180:
-  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D05']
+  aliases: []
   parents:
   - 53545
 2686168:
-  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D06']
+  aliases: []
   parents:
   - 53545
 2686171:
-  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D07']
+  aliases: []
   parents:
   - 53545
 2686170:
-  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D08']
+  aliases: []
   parents:
   - 53545
 2686160:
-  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D09']
+  aliases: []
   parents:
   - 53545
 2686169:
-  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D10']
+  aliases: []
   parents:
   - 53545
 2686172:
-  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D11']
+  aliases: []
   parents:
   - 53545
 2686166:
-  aliases: ['Ochlerotatus nr. caspius APHA-4-2015D12']
+  aliases: []
   parents:
   - 53545
 2686176:
-  aliases: ['Ochlerotatus nr. caspius APHA-4-2015E02']
+  aliases: []
   parents:
   - 53545
 1825801:
-  aliases: ['Ochlerotatus nr. detritus BOLD:AAM2826']
+  aliases: []
   parents:
   - 1125803
 1825800:
-  aliases: ['Ochlerotatus nr. flavescens BOLD:ACE3017']
+  aliases: []
   parents:
   - 1125803
 2686182:
-  aliases: ['Ochlerotatus nr. punctor APHA-1-2015F03']
+  aliases: []
   parents:
   - 53545
 1206304:
-  aliases: ['Ochlerotatus obturbator']
+  aliases: []
   parents:
   - 767021
 1652500:
-  aliases: ['Ochlerotatus oreophilus']
+  aliases: []
   parents:
   - 767021
 1640878:
-  aliases: ['Ochlerotatus pertinax']
+  aliases: []
   parents:
   - 1379452
 3153703:
-  aliases: ['Ochlerotatus perventor']
+  aliases: []
   parents:
   - 3153702
 1315219:
-  aliases: ['Ochlerotatus pionips']
+  aliases: []
   parents:
   - 53545
 2872822:
-  aliases: ['Ochlerotatus podographicus']
+  aliases: []
   parents:
   - 119225
 376831:
-  aliases: ['Ochlerotatus portonovoensis']
+  aliases: []
   parents:
   - 345925
 1197336:
-  aliases: ['Ochlerotatus procax']
+  aliases: []
   parents:
   - 53545
 743693:
-  aliases: ['Ochlerotatus provocans']
+  aliases: []
   parents:
   - 53545
 1529939:
-  aliases: ['Ochlerotatus pulcritarsis']
+  aliases: []
   parents:
   - 53545
 120876:
-  aliases: ['Ochlerotatus pullatus']
+  aliases: []
   parents:
   - 53545
 1206305:
-  aliases: ['Ochlerotatus punctodes']
+  aliases: []
   parents:
   - 53545
 46209:
-  aliases: ['Ochlerotatus punctor']
+  aliases: []
   parents:
   - 53545
 1890521:
-  aliases: ['Ochlerotatus punctor subgroup sp. BOLD-2016']
+  aliases: []
   parents:
   - 53545
 1829910:
-  aliases: ['Ochlerotatus punctor subgroup sp. BOLD:AAA3748']
+  aliases: []
   parents:
   - 53545
 2740563:
-  aliases: ['Ochlerotatus punctor subgroup sp. L48']
+  aliases: []
   parents:
   - 53545
 2740564:
-  aliases: ['Ochlerotatus punctor subgroup sp. L49']
+  aliases: []
   parents:
   - 53545
 1206306:
-  aliases: ['Ochlerotatus purpureipes']
+  aliases: []
   parents:
   - 346059
 3114451:
-  aliases: ['Ochlerotatus ratcliffei']
+  aliases: []
   parents:
   - 767021
 1788513:
-  aliases: ['Ochlerotatus refiki']
+  aliases: []
   parents:
   - 190767
 1891864:
-  aliases: ['Ochlerotatus rempeli']
+  aliases: []
   parents:
   - 767021
 743694:
-  aliases: ['Ochlerotatus riparius']
+  aliases: []
   parents:
   - 53545
 120877:
-  aliases: ['Ochlerotatus rusticus']
+  aliases: []
   parents:
   - 190767
 1806184:
-  aliases: ['Ochlerotatus sagax']
+  aliases: []
   parents:
   - 53545
 2015797:
-  aliases: ['Ochlerotatus sallumae']
+  aliases: []
   parents:
   - 767021
 2891961:
-  aliases: ['Ochlerotatus sandrae']
+  aliases: []
   parents:
   - 119225
 571210:
-  aliases: ['Ochlerotatus scapularis']
+  aliases: []
   parents:
   - 53545
 1206307:
-  aliases: ['Ochlerotatus schizopinax']
+  aliases: []
   parents:
   - 767021
 873164:
-  aliases: ['Ochlerotatus serratus']
+  aliases: []
   parents:
   - 767021
 2795835:
-  aliases: ['Ochlerotatus serratus group sp. MOSA064']
+  aliases: []
   parents:
   - 1125803
 2795836:
-  aliases: ['Ochlerotatus serratus group sp. MOSA119']
+  aliases: []
   parents:
   - 1125803
 2795837:
-  aliases: ['Ochlerotatus serratus group sp. MOSA131']
+  aliases: []
   parents:
   - 1125803
 1205942:
-  aliases: ['Ochlerotatus sierrensis']
+  aliases: []
   parents:
   - 767021
 3014955:
-  aliases: ['Ochlerotatus silvestris']
+  aliases: []
   parents:
   - 767021
 310513:
-  aliases: ['Ochlerotatus sollicitans']
+  aliases: []
   parents:
   - 53545
 2792002:
-  aliases: ['Ochlerotatus sp.']
+  aliases: []
   parents:
   - 1125803
 2496363:
-  aliases: ['Ochlerotatus sp. 1 CSS-2018']
+  aliases: []
   parents:
   - 1125803
 2715166:
-  aliases: ['Ochlerotatus sp. 15009030']
+  aliases: []
   parents:
   - 1125803
 2715167:
-  aliases: ['Ochlerotatus sp. 15009031']
+  aliases: []
   parents:
   - 1125803
 2715168:
-  aliases: ['Ochlerotatus sp. 16079095']
+  aliases: []
   parents:
   - 1125803
 2715169:
-  aliases: ['Ochlerotatus sp. 16079097']
+  aliases: []
   parents:
   - 1125803
 2715170:
-  aliases: ['Ochlerotatus sp. 16079110']
+  aliases: []
   parents:
   - 1125803
 2715171:
-  aliases: ['Ochlerotatus sp. 16079112']
+  aliases: []
   parents:
   - 1125803
 2715172:
-  aliases: ['Ochlerotatus sp. 16079120']
+  aliases: []
   parents:
   - 1125803
 2715173:
-  aliases: ['Ochlerotatus sp. 16142001']
+  aliases: []
   parents:
   - 1125803
 2715174:
-  aliases: ['Ochlerotatus sp. 16142002']
+  aliases: []
   parents:
   - 1125803
 2715175:
-  aliases: ['Ochlerotatus sp. 16142010']
+  aliases: []
   parents:
   - 1125803
 2715176:
-  aliases: ['Ochlerotatus sp. 16142023']
+  aliases: []
   parents:
   - 1125803
 2715177:
-  aliases: ['Ochlerotatus sp. 16149009']
+  aliases: []
   parents:
   - 1125803
 2496365:
-  aliases: ['Ochlerotatus sp. 2 CSS-2018']
+  aliases: []
   parents:
   - 1125803
 1874498:
-  aliases: ['Ochlerotatus sp. 4DS']
+  aliases: []
   parents:
   - 1125803
 1892536:
-  aliases: ['Ochlerotatus sp. BOLD-2016']
+  aliases: []
   parents:
   - 1125803
 2660540:
-  aliases: ['Ochlerotatus sp. BOLD:AAV4152']
+  aliases: []
   parents:
   - 1125803
 1744826:
-  aliases: ['Ochlerotatus sp. BOLD:ACA3833']
+  aliases: []
   parents:
   - 1125803
 1406130:
-  aliases: ['Ochlerotatus sp. BOLD:ACB9328']
+  aliases: []
   parents:
   - 1125803
 1406131:
-  aliases: ['Ochlerotatus sp. BOLD:ACC8488']
+  aliases: []
   parents:
   - 1125803
 2924065:
-  aliases: ['Ochlerotatus sp. CROBB559']
+  aliases: []
   parents:
   - 1125803
 1125804:
-  aliases: ['Ochlerotatus sp. HANKV_BC_Contig1']
+  aliases: []
   parents:
   - 1125803
 1125805:
-  aliases: ['Ochlerotatus sp. HANKV_BC_Contig2']
+  aliases: []
   parents:
   - 1125803
 1125806:
-  aliases: ['Ochlerotatus sp. HANKV_BC_Contig3']
+  aliases: []
   parents:
   - 1125803
 2751523:
-  aliases: ['Ochlerotatus sp. HK-2020']
+  aliases: []
   parents:
   - 1125803
 1315221:
-  aliases: ['Ochlerotatus sp. NVK-2013']
+  aliases: []
   parents:
   - 1125803
 2593062:
-  aliases: ['Ochlerotatus sp. PANT7-L1']
+  aliases: []
   parents:
   - 1125803
 2593063:
-  aliases: ['Ochlerotatus sp. PANT7-L2']
+  aliases: []
   parents:
   - 1125803
 2853141:
-  aliases: ['Ochlerotatus sp. P_139_FSTST']
+  aliases: []
   parents:
   - 1125803
 2853145:
-  aliases: ['Ochlerotatus sp. P_146_FSTST']
+  aliases: []
   parents:
   - 1125803
 2853144:
-  aliases: ['Ochlerotatus sp. P_194_FSTJD']
+  aliases: []
   parents:
   - 1125803
 2853147:
-  aliases: ['Ochlerotatus sp. P_205_FSTAT']
+  aliases: []
   parents:
   - 1125803
 2853140:
-  aliases: ['Ochlerotatus sp. P_211_FSTAT']
+  aliases: []
   parents:
   - 1125803
 2853148:
-  aliases: ['Ochlerotatus sp. P_268_FSTHT']
+  aliases: []
   parents:
   - 1125803
 2853142:
-  aliases: ['Ochlerotatus sp. P_318_FSTCO']
+  aliases: []
   parents:
   - 1125803
 2853146:
-  aliases: ['Ochlerotatus sp. P_319_FSTCO']
+  aliases: []
   parents:
   - 1125803
 2853143:
-  aliases: ['Ochlerotatus sp. P_327_FSTCO']
+  aliases: []
   parents:
   - 1125803
 1750492:
-  aliases: ['Ochlerotatus sp. SSEIC6970-13']
+  aliases: []
   parents:
   - 1125803
 1205943:
-  aliases: ['Ochlerotatus spencerii']
+  aliases: []
   parents:
   - 767021
 767024:
-  aliases: ['Ochlerotatus squamiger']
+  aliases: []
   parents:
   - 767021
 120878:
-  aliases: ['Ochlerotatus sticticus']
+  aliases: []
   parents:
   - 53545
 2795831:
-  aliases: ['Ochlerotatus stigmaticus']
+  aliases: []
   parents:
   - 767021
 228919:
-  aliases: ['Ochlerotatus stimulans']
+  aliases: []
   parents:
   - 53545
 3114452:
-  aliases: ['Ochlerotatus stricklandi']
+  aliases: []
   parents:
   - 767021
 2292405:
-  aliases: ['Ochlerotatus subalbirostris']
+  aliases: []
   parents:
   - 767021
 2996711:
-  aliases: ['Ochlerotatus surcoufi']
+  aliases: []
   parents:
   - 767021
 329105:
-  aliases: ['Ochlerotatus taeniorhynchus']
+  aliases: []
   parents:
   - 53545
 767025:
-  aliases: ['Ochlerotatus tahoensis']
+  aliases: []
   parents:
   - 767021
 2891962:
-  aliases: ['Ochlerotatus tehuantepec']
+  aliases: []
   parents:
   - 119225
 1828552:
-  aliases: ['Ochlerotatus terrens']
+  aliases: []
   parents:
   - 119225
 1205944:
-  aliases: ['Ochlerotatus thelcter']
+  aliases: []
   parents:
   - 767021
 1197337:
-  aliases: ['Ochlerotatus theobaldi']
+  aliases: []
   parents:
   - 53545
 1205945:
-  aliases: ['Ochlerotatus thibaulti']
+  aliases: []
   parents:
   - 767021
 1379453:
-  aliases: ['Ochlerotatus tormentor']
+  aliases: []
   parents:
   - 1379452
 1205946:
-  aliases: ['Ochlerotatus tortilis']
+  aliases: []
   parents:
   - 767021
 7162:
-  aliases: ['Ochlerotatus triseriatus']
+  aliases: []
   parents:
   - 119225
 228918:
-  aliases: ['Ochlerotatus trivittatus']
+  aliases: []
   parents:
   - 53545
 3114453:
-  aliases: ['Ochlerotatus turneri']
+  aliases: []
   parents:
   - 767021
 2785380:
-  aliases: ['Ochlerotatus vargasi']
+  aliases: []
   parents:
   - 119225
 1205947:
-  aliases: ['Ochlerotatus varipalpus']
+  aliases: []
   parents:
   - 767021
 1205948:
-  aliases: ['Ochlerotatus ventrovittis']
+  aliases: []
   parents:
   - 767021
 569589:
-  aliases: ['Ochlerotatus vigilax']
+  aliases: []
   parents:
   - 53545
 1806185:
-  aliases: ['Ochlerotatus vittiger']
+  aliases: []
   parents:
   - 53545
 71824:
-  aliases: ['Ochlerotatus wardangensis']
+  aliases: []
   parents:
   - 71821
 345926:
-  aliases: ['Ochlerotatus wardi']
+  aliases: []
   parents:
   - 345925
 3014956:
-  aliases: ['Ochlerotatus washinoi']
+  aliases: []
   parents:
   - 767021
 1206036:
-  aliases: ['Ochlerotatus zoosophus']
+  aliases: []
   parents:
   - 119225
 2939154:
-  aliases: ['Onirion sp.']
+  aliases: []
   parents:
   - 2622204
 2007257:
-  aliases: ['Onirion sp. stA']
+  aliases: []
   parents:
   - 2622204
 2853117:
-  aliases: ['Orthopodomyia sp. P_202_FSTJD']
+  aliases: []
   parents:
   - 2853112
 2853113:
-  aliases: ['Orthopodomyia sp. P_274_FSTHT']
+  aliases: []
   parents:
   - 2853112
 2853114:
-  aliases: ['Orthopodomyia sp. P_275_FSTHT']
+  aliases: []
   parents:
   - 2853112
 2853115:
-  aliases: ['Orthopodomyia sp. P_320_FSTCO']
+  aliases: []
   parents:
   - 2853112
 2853116:
-  aliases: ['Orthopodomyia sp. P_324_FSTCO']
+  aliases: []
   parents:
   - 2853112
 3122449:
-  aliases: ['Psorophora sp.']
+  aliases: []
   parents:
   - 3122448
 2232094:
-  aliases: ['Runchomyia sp. RU1']
+  aliases: []
   parents:
   - 2647614
 2927968:
-  aliases: ['Sabethes sp.']
+  aliases: []
   parents:
   - 2646388
 2732043:
-  aliases: ['Sabethes sp. CIST0314']
+  aliases: []
   parents:
   - 2646388
 2007272:
-  aliases: ['Sabethes sp. MB10781']
+  aliases: []
   parents:
   - 2646388
 218602:
-  aliases: ['Sabethes sp. PP-2003']
+  aliases: []
   parents:
   - 2646388
 2007219:
-  aliases: ['Sabethes sp. stD']
+  aliases: []
   parents:
   - 2646388
 2007220:
-  aliases: ['Sabethes sp. stE']
+  aliases: []
   parents:
   - 2646388
 2007221:
-  aliases: ['Sabethes sp. stF']
+  aliases: []
   parents:
   - 2646388
 3123418:
-  aliases: ['Shannoniana sp. n. LMHT-2024']
+  aliases: []
   parents:
   - 3123417
 2872825:
-  aliases: ['Trichoprosopon sp. BOLD:ADL4862']
+  aliases: []
   parents:
   - 2630085
 2007231:
-  aliases: ['Trichoprosopon sp. stG']
+  aliases: []
   parents:
   - 2630085
 2007232:
-  aliases: ['Trichoprosopon sp. stH']
+  aliases: []
   parents:
   - 2630085
 2587283:
-  aliases: ['Tripteroides (Rachionotomyia) sp. NN324']
+  aliases: []
   parents:
   - 325440
 2587278:
-  aliases: ['Tripteroides (Tripteroides) complex sp. 1 MTM-2019']
+  aliases: []
   parents:
   - 3407135
 2587279:
-  aliases: ['Tripteroides (Tripteroides) complex sp. 2 MTM-2019']
+  aliases: []
   parents:
   - 3407135
 1826906:
-  aliases: ['Tripteroides aff. atripes JB-2016']
+  aliases: []
   parents:
   - 1806189
 498401:
-  aliases: ['Tripteroides affinis']
+  aliases: []
   parents:
   - 325440
 325441:
-  aliases: ['Tripteroides aranoides']
+  aliases: []
   parents:
   - 325440
 1806186:
-  aliases: ['Tripteroides atripes']
+  aliases: []
   parents:
   - 1806189
 53568:
-  aliases: ['Tripteroides bambusa']
+  aliases: []
   parents:
   - 325442
 3048045:
-  aliases: ['Tripteroides marksae']
+  aliases: []
   parents:
   - 1806189
 2761493:
-  aliases: ['Tripteroides melanesiensis']
+  aliases: []
   parents:
   - 1806189
 3114456:
-  aliases: ['Tripteroides punctolateralis']
+  aliases: []
   parents:
   - 1806189
 1245371:
-  aliases: ['Tripteroides similis']
+  aliases: []
   parents:
   - 325442
 3435817:
-  aliases: ['Tripteroides sp.']
+  aliases: []
   parents:
   - 3407135
 2793850:
-  aliases: ['Tripteroides sp. 1 HY-2020']
+  aliases: []
   parents:
   - 3407135
 2793851:
-  aliases: ['Tripteroides sp. 2 HY-2020']
+  aliases: []
   parents:
   - 3407135
 2661525:
-  aliases: ['Tripteroides sp. BOLD:AAV4159']
+  aliases: []
   parents:
   - 3407135
 3014977:
-  aliases: ['Tripteroides sylvestris']
+  aliases: []
   parents:
   - 3014975
 1245372:
-  aliases: ['Tripteroides tarsalis']
+  aliases: []
   parents:
   - 325442
 1806187:
-  aliases: ['Tripteroides tasmaniensis']
+  aliases: []
   parents:
   - 1806189
 2793862:
-  aliases: ['Uranotaenia aff. macfarlanei 1 HY-2020']
+  aliases: []
   parents:
   - 3407139
 2793863:
-  aliases: ['Uranotaenia aff. macfarlanei 2 HY-2020']
+  aliases: []
   parents:
   - 3407139
 2681166:
-  aliases: ['Uranotaenia albescens']
+  aliases: []
   parents:
   - 325429
 2038718:
-  aliases: ['Uranotaenia alboabdominalis']
+  aliases: []
   parents:
   - 325429
 1206294:
-  aliases: ['Uranotaenia anhydor']
+  aliases: []
   parents:
   - 325427
 3137933:
-  aliases: ['Uranotaenia annandalei']
+  aliases: []
   parents:
   - 325429
 2795832:
-  aliases: ['Uranotaenia apicalis']
+  aliases: []
   parents:
   - 325429
 2563474:
-  aliases: ['Uranotaenia apicotaeniata']
+  aliases: []
   parents:
   - 325427
 325433:
-  aliases: ['Uranotaenia atra']
+  aliases: []
   parents:
   - 325427
 1551375:
-  aliases: ['Uranotaenia balfouri']
+  aliases: []
   parents:
   - 325429
 325435:
-  aliases: ['Uranotaenia bicolor']
+  aliases: []
   parents:
   - 325429
 2563475:
-  aliases: ['Uranotaenia bilineata']
+  aliases: []
   parents:
   - 325429
 1426908:
-  aliases: ['Uranotaenia calosomata']
+  aliases: []
   parents:
   - 325429
 2891967:
-  aliases: ['Uranotaenia coatzacoalcos']
+  aliases: []
   parents:
   - 325429
 2943530:
-  aliases: ['Uranotaenia connali']
+  aliases: []
   parents:
   - 325429
 2597066:
-  aliases: ['Uranotaenia geometrica']
+  aliases: []
   parents:
   - 325429
 1245375:
-  aliases: ['Uranotaenia jinhongensis']
+  aliases: []
   parents:
   - 325427
 1055898:
-  aliases: ['Uranotaenia lateralis']
+  aliases: []
   parents:
   - 325429
 1424569:
-  aliases: ['Uranotaenia longirostris']
+  aliases: []
   parents:
   - 325429
 190385:
-  aliases: ['Uranotaenia lowii']
+  aliases: []
   parents:
   - 325429
 1245376:
-  aliases: ['Uranotaenia lutescens']
+  aliases: []
   parents:
   - 325427
 1245377:
-  aliases: ['Uranotaenia macfarlanei']
+  aliases: []
   parents:
   - 325429
 487103:
-  aliases: ['Uranotaenia mashonaensis']
+  aliases: []
   parents:
   - 325427
 1424570:
-  aliases: ['Uranotaenia micans']
+  aliases: []
   parents:
   - 325429
 2943531:
-  aliases: ['Uranotaenia micromelas']
+  aliases: []
   parents:
   - 325427
 1245378:
-  aliases: ['Uranotaenia nivipleura']
+  aliases: []
   parents:
   - 325427
 1245379:
-  aliases: ['Uranotaenia novobscura']
+  aliases: []
   parents:
   - 325427
 2758658:
-  aliases: ['Uranotaenia obscura']
+  aliases: []
   parents:
   - 325427
 2563476:
-  aliases: ['Uranotaenia philonuxia']
+  aliases: []
   parents:
   - 325429
 2721572:
-  aliases: ['Uranotaenia pulcherrima']
+  aliases: []
   parents:
   - 325429
 325428:
-  aliases: ['Uranotaenia recondita']
+  aliases: []
   parents:
   - 325427
 2576294:
-  aliases: ['Uranotaenia rutherfordi']
+  aliases: []
   parents:
   - 325429
 3569225:
-  aliases: ['Uranotaenia ryukyuana']
+  aliases: []
   parents:
   - 325427
 139056:
-  aliases: ['Uranotaenia sapphirina']
+  aliases: []
   parents:
   - 325429
 1206054:
-  aliases: ['Uranotaenia socialis']
+  aliases: []
   parents:
   - 325429
 2905922:
-  aliases: ['Uranotaenia sp.']
+  aliases: []
   parents:
   - 3407139
 2448166:
-  aliases: ['Uranotaenia sp. 1 CLJ-2018']
+  aliases: []
   parents:
   - 3407139
 2793854:
-  aliases: ['Uranotaenia sp. 1 HY-2020']
+  aliases: []
   parents:
   - 3407139
 2576295:
-  aliases: ['Uranotaenia sp. 1 WGDC-2019']
+  aliases: []
   parents:
   - 3407139
 2448167:
-  aliases: ['Uranotaenia sp. 2 CLJ-2018']
+  aliases: []
   parents:
   - 3407139
 2793855:
-  aliases: ['Uranotaenia sp. 2 HY-2020']
+  aliases: []
   parents:
   - 3407139
 2576296:
-  aliases: ['Uranotaenia sp. 2 WGDC-2019']
+  aliases: []
   parents:
   - 3407139
 2931912:
-  aliases: ['Uranotaenia sp. M1']
+  aliases: []
   parents:
   - 3407139
 2931915:
-  aliases: ['Uranotaenia sp. M16']
+  aliases: []
   parents:
   - 3407139
 498402:
-  aliases: ['Uranotaenia stricklandi']
+  aliases: []
   parents:
   - 325427
 2758659:
-  aliases: ['Uranotaenia trilineata']
+  aliases: []
   parents:
   - 325429
 559294:
-  aliases: ['Uranotaenia unguiculata']
+  aliases: []
   parents:
   - 325427
 1424565:
-  aliases: ['Verrallina butleri']
+  aliases: []
   parents:
   - 317810
 3014973:
-  aliases: ['Verrallina carmenti']
+  aliases: []
   parents:
   - 317810
 3137934:
-  aliases: ['Verrallina dux']
+  aliases: []
   parents:
   - 317810
 1590998:
-  aliases: ['Verrallina funerea']
+  aliases: []
   parents:
   - 317810
 317807:
-  aliases: ['Verrallina indica']
+  aliases: []
   parents:
   - 317806
 569591:
-  aliases: ['Verrallina lineata']
+  aliases: []
   parents:
   - 317810
 376830:
-  aliases: ['Verrallina lugubris']
+  aliases: []
   parents:
   - 317810
 1652499:
-  aliases: ['Verrallina nobukonis']
+  aliases: []
   parents:
   - 317809
 498403:
-  aliases: ['Verrallina pseudomediofasciata']
+  aliases: []
   parents:
   - 317806
 2793856:
-  aliases: ['Verrallina sp. 1 HY-2020']
+  aliases: []
   parents:
   - 3407142
 2793857:
-  aliases: ['Verrallina sp. 2 HY-2020']
+  aliases: []
   parents:
   - 3407142
 2793858:
-  aliases: ['Verrallina sp. 3 HY-2020']
+  aliases: []
   parents:
   - 3407142
 3048047:
-  aliases: ['Verrallina sp. Marks No 52']
+  aliases: []
   parents:
   - 3407142
 2761344:
-  aliases: ['Wyeomyia (Phoniomyia) sp.']
+  aliases: []
   parents:
   - 2631130
 2725263:
-  aliases: ['Wyeomyia (Triamyia) sp. 1 DJS-2020']
+  aliases: []
   parents:
   - 2631130
 2872827:
-  aliases: ['Wyeomyia adelpha/guatemala group sp. I LMHT-2021a']
+  aliases: []
   parents:
   - 2631130
 2872828:
-  aliases: ['Wyeomyia adelpha/guatemala group sp. II LMHT-2021a']
+  aliases: []
   parents:
   - 2631130
 2872829:
-  aliases: ['Wyeomyia adelpha/guatemala group sp. III LMHT-2021a']
+  aliases: []
   parents:
   - 2631130
 2872830:
-  aliases: ['Wyeomyia adelpha/guatemala group sp. IV LMHT-2021a']
+  aliases: []
   parents:
   - 2631130
 3240104:
-  aliases: ['Wyeomyia sp. 1 PSR-2024a']
+  aliases: []
   parents:
   - 2631130
 2496362:
-  aliases: ['Wyeomyia sp. 374 CSS-2018']
+  aliases: []
   parents:
   - 2631130
 869061:
-  aliases: ['Wyeomyia sp. BB-2010']
+  aliases: []
   parents:
   - 2631130
 2872826:
-  aliases: ['Wyeomyia sp. BOLD:ADE5359']
+  aliases: []
   parents:
   - 2631130
 2715096:
-  aliases: ['Wyeomyia sp. Mu340']
+  aliases: []
   parents:
   - 2631130
 2903344:
-  aliases: ['Wyeomyia sp. RCH1']
+  aliases: []
   parents:
   - 2631130
 2232095:
-  aliases: ['Wyeomyia sp. WA1']
+  aliases: []
   parents:
   - 2631130
 2715241:
-  aliases: ['Wyeomyia sp. WY1']
+  aliases: []
   parents:
   - 2631130
 2715243:
-  aliases: ['Wyeomyia sp. WY3']
+  aliases: []
   parents:
   - 2631130
 2715242:
-  aliases: ['Wyeomyia sp. Wy2']
+  aliases: []
   parents:
   - 2631130
 2007247:
-  aliases: ['Wyeomyia sp. stB']
+  aliases: []
   parents:
   - 2631130
 2007248:
-  aliases: ['Wyeomyia sp. stC']
+  aliases: []
   parents:
   - 2631130
 44547:
-  aliases: ['albimanus series']
+  aliases: []
   parents:
   - 44544
 58233:
-  aliases: ['albitarsis series']
+  aliases: []
   parents:
   - 44545
 59118:
-  aliases: ['annulipes species complex']
+  aliases: []
   parents:
   - 44536
 185573:
-  aliases: ['ardensis group']
+  aliases: []
   parents:
   - 44536
 44546:
-  aliases: ['argyritarsis series']
+  aliases: []
   parents:
   - 44545
 262670:
-  aliases: ['cinereus group']
+  aliases: []
   parents:
   - 262669
 63408:
-  aliases: ['culicifacies species complex']
+  aliases: []
   parents:
   - 59140
 59141:
-  aliases: ['demeilloni group']
+  aliases: []
   parents:
   - 59140
 59142:
-  aliases: ['funestus group']
+  aliases: []
   parents:
   - 59140
 44542:
-  aliases: ['gambiae species complex']
+  aliases: []
   parents:
   - 44537
 44538:
-  aliases: ['leucosphyrus group']
+  aliases: []
   parents:
   - 44536
 262671:
-  aliases: ['listeri group']
+  aliases: []
   parents:
   - 262669
 412010:
-  aliases: ['longipalpis species complex']
+  aliases: []
   parents:
   - 59140
 702664:
-  aliases: ['longirostris species complex']
+  aliases: []
   parents:
   - 44536
 59153:
-  aliases: ['lungae species complex']
+  aliases: []
   parents:
   - 44536
 59144:
-  aliases: ['minimus group']
+  aliases: []
   parents:
   - 59140
 2971825:
-  aliases: ['nr. Culex mimeticus']
+  aliases: []
   parents:
   - 3406907
 2971826:
-  aliases: ['nr. Culex tsengi']
+  aliases: []
   parents:
   - 3406907
 44548:
-  aliases: ['oswaldoi series']
+  aliases: []
   parents:
   - 44544
 44541:
-  aliases: ['punctulatus species complex']
+  aliases: []
   parents:
   - 44536
 59159:
-  aliases: ['subpictus species complex']
+  aliases: []
   parents:
   - 44537
 199889:
-  aliases: ['sundaicus species complex']
+  aliases: []
   parents:
   - 44537
 3398453:
-  aliases: ['unclassified Aedes (in: mosquitos, subgenus)']
+  aliases: []
   parents:
   - 149531
 2989694:
-  aliases: ['unclassified Culiciomyia']
+  aliases: []
   parents:
   - 53530
 2793860:
-  aliases: ['unclassified Lophoceraomyia']
+  aliases: []
   parents:
   - 308715
 2730094:
-  aliases: ['unclassified Myzomyia']
+  aliases: []
   parents:
   - 59140
 3398455:
-  aliases: ['unclassified Ochlerotatus (in: mosquitos, subgenus)']
+  aliases: []
   parents:
   - 53545
 3022036:
-  aliases: ['unclassified Stegomyia']
+  aliases: []
   parents:
   - 53541
 3022037:
-  aliases: ['Aedes (Stegomyia) sp.']
+  aliases: []
   parents:
   - 3022036
 2778558:
-  aliases: ['Aedes (Stegomyia) sp. KNP17MP639']
+  aliases: []
   parents:
   - 3022036
 1424507:
-  aliases: ['Aedes aegypti aegypti']
+  aliases: []
   parents:
   - 7159
 1769044:
-  aliases: ['Aedes aegypti formosus']
+  aliases: []
   parents:
   - 7159
 1214272:
-  aliases: ['Aedes aureostriatus okinawanus']
+  aliases: []
   parents:
   - 1214259
 1214273:
-  aliases: ['Aedes aureostriatus taiwanus']
+  aliases: []
   parents:
   - 1214259
 1214274:
-  aliases: ['Aedes flavopictus downsi']
+  aliases: []
   parents:
   - 166586
 1214275:
-  aliases: ['Aedes flavopictus miyarai']
+  aliases: []
   parents:
   - 166586
 2603929:
-  aliases: ['Aedes gardnerii imitator']
+  aliases: []
   parents:
   - 2603928
 706478:
-  aliases: ['Aedes japonicus amamiensis']
+  aliases: []
   parents:
   - 140438
 140439:
-  aliases: ['Aedes japonicus japonicus']
+  aliases: []
   parents:
   - 140438
 706479:
-  aliases: ['Aedes japonicus shintienensis']
+  aliases: []
   parents:
   - 140438
 706480:
-  aliases: ['Aedes japonicus yaeyamensis']
+  aliases: []
   parents:
   - 140438
 3398456:
-  aliases: ['Aedes sp. annulipes/cantans JVDB-2025']
+  aliases: []
   parents:
   - 3398455
 3398454:
-  aliases: ['Aedes sp. cinereus/geminus JVDB-2025']
+  aliases: []
   parents:
   - 3398453
 1214271:
-  aliases: ['Aedes vexans nipponii']
+  aliases: []
   parents:
   - 7163
 569585:
-  aliases: ['Aedes vexans nocturnus']
+  aliases: []
   parents:
   - 7163
 93947:
-  aliases: ['Anopheles aconitus']
+  aliases: []
   parents:
   - 59144
 2730970:
-  aliases: ['Anopheles aff. barbirostris A3']
+  aliases: []
   parents:
   - 58250
 3241327:
-  aliases: ['Anopheles aff. maculatus B MB-2024a']
+  aliases: []
   parents:
   - 74868
 2249359:
-  aliases: ['Anopheles aff. peryassui NECH295']
+  aliases: []
   parents:
   - 58248
 2249360:
-  aliases: ['Anopheles aff. peryassui NECH773']
+  aliases: []
   parents:
   - 58248
 2108331:
-  aliases: ['Anopheles aff. subpictus A SC-2018']
+  aliases: []
   parents:
   - 59159
 667066:
-  aliases: ['Anopheles aff. takasagoensis KTT-2009']
+  aliases: []
   parents:
   - 44538
 7167:
-  aliases: ['Anopheles albimanus']
+  aliases: []
   parents:
   - 44547
 1411912:
-  aliases: ['Anopheles algeriensis']
+  aliases: []
   parents:
   - 44484
 1962413:
-  aliases: ['Anopheles annularis sensu lato 524']
+  aliases: []
   parents:
   - 59162
 376584:
-  aliases: ['Anopheles annulipes']
+  aliases: []
   parents:
   - 59118
 59119:
-  aliases: ['Anopheles annulipes A']
+  aliases: []
   parents:
   - 59118
 59120:
-  aliases: ['Anopheles annulipes B']
+  aliases: []
   parents:
   - 59118
 376585:
-  aliases: ['Anopheles annulipes C']
+  aliases: []
   parents:
   - 59118
 59121:
-  aliases: ['Anopheles annulipes D']
+  aliases: []
   parents:
   - 59118
 376586:
-  aliases: ['Anopheles annulipes E']
+  aliases: []
   parents:
   - 59118
 376587:
-  aliases: ['Anopheles annulipes F']
+  aliases: []
   parents:
   - 59118
 59122:
-  aliases: ['Anopheles annulipes G']
+  aliases: []
   parents:
   - 59118
 376588:
-  aliases: ['Anopheles annulipes H']
+  aliases: []
   parents:
   - 59118
 376589:
-  aliases: ['Anopheles annulipes I']
+  aliases: []
   parents:
   - 59118
 376590:
-  aliases: ['Anopheles annulipes J']
+  aliases: []
   parents:
   - 59118
 376591:
-  aliases: ['Anopheles annulipes K']
+  aliases: []
   parents:
   - 59118
 376592:
-  aliases: ['Anopheles annulipes L']
+  aliases: []
   parents:
   - 59118
 376593:
-  aliases: ['Anopheles annulipes M']
+  aliases: []
   parents:
   - 59118
 376594:
-  aliases: ['Anopheles annulipes N']
+  aliases: []
   parents:
   - 59118
 376595:
-  aliases: ['Anopheles annulipes O']
+  aliases: []
   parents:
   - 59118
 376596:
-  aliases: ['Anopheles annulipes P']
+  aliases: []
   parents:
   - 59118
 376597:
-  aliases: ['Anopheles annulipes Q']
+  aliases: []
   parents:
   - 59118
 410740:
-  aliases: ['Anopheles annulipes s.l. JEB-2006']
+  aliases: []
   parents:
   - 59118
 7173:
-  aliases: ['Anopheles arabiensis']
+  aliases: []
   parents:
   - 44542
 2730971:
-  aliases: ['Anopheles barbirostris sensu lato GE']
+  aliases: []
   parents:
   - 58250
 42896:
-  aliases: ['Anopheles bwambae']
+  aliases: []
   parents:
   - 44542
 2807518:
-  aliases: ['Anopheles cf. coustani']
+  aliases: []
   parents:
   - 58250
 626351:
-  aliases: ['Anopheles cf. funestus BS-2009']
+  aliases: []
   parents:
   - 59142
 1141474:
-  aliases: ['Anopheles cf. funestus LN-2012a']
+  aliases: []
   parents:
   - 59142
 1254527:
-  aliases: ['Anopheles cf. funestus MALAF100']
+  aliases: []
   parents:
   - 59142
 1254528:
-  aliases: ['Anopheles cf. funestus MALAF103']
+  aliases: []
   parents:
   - 59142
 1254529:
-  aliases: ['Anopheles cf. funestus MALAF104']
+  aliases: []
   parents:
   - 59142
 1254530:
-  aliases: ['Anopheles cf. funestus MALAF105']
+  aliases: []
   parents:
   - 59142
 1254531:
-  aliases: ['Anopheles cf. funestus MALAF111']
+  aliases: []
   parents:
   - 59142
 1254532:
-  aliases: ['Anopheles cf. funestus MALAF112']
+  aliases: []
   parents:
   - 59142
 1254533:
-  aliases: ['Anopheles cf. funestus MALAF115']
+  aliases: []
   parents:
   - 59142
 1254534:
-  aliases: ['Anopheles cf. funestus MALAF117']
+  aliases: []
   parents:
   - 59142
 1254535:
-  aliases: ['Anopheles cf. funestus MALAF118']
+  aliases: []
   parents:
   - 59142
 1254536:
-  aliases: ['Anopheles cf. funestus MALAF119']
+  aliases: []
   parents:
   - 59142
 1254537:
-  aliases: ['Anopheles cf. funestus MALAF120']
+  aliases: []
   parents:
   - 59142
 1254538:
-  aliases: ['Anopheles cf. funestus MALAF121']
+  aliases: []
   parents:
   - 59142
 1254539:
-  aliases: ['Anopheles cf. funestus MALAF122']
+  aliases: []
   parents:
   - 59142
 1254540:
-  aliases: ['Anopheles cf. funestus MALAF123']
+  aliases: []
   parents:
   - 59142
 1254541:
-  aliases: ['Anopheles cf. funestus MALAF124']
+  aliases: []
   parents:
   - 59142
 1254542:
-  aliases: ['Anopheles cf. funestus MALAF125']
+  aliases: []
   parents:
   - 59142
 1254543:
-  aliases: ['Anopheles cf. funestus MALAF126']
+  aliases: []
   parents:
   - 59142
 1254544:
-  aliases: ['Anopheles cf. funestus MALAF127']
+  aliases: []
   parents:
   - 59142
 1254545:
-  aliases: ['Anopheles cf. funestus MALAF128']
+  aliases: []
   parents:
   - 59142
 1254546:
-  aliases: ['Anopheles cf. funestus MALAF129']
+  aliases: []
   parents:
   - 59142
 1254547:
-  aliases: ['Anopheles cf. funestus MALAF130']
+  aliases: []
   parents:
   - 59142
 1254548:
-  aliases: ['Anopheles cf. funestus MALAF131']
+  aliases: []
   parents:
   - 59142
 1254549:
-  aliases: ['Anopheles cf. funestus MALAF85']
+  aliases: []
   parents:
   - 59142
 1254550:
-  aliases: ['Anopheles cf. funestus MALAF91']
+  aliases: []
   parents:
   - 59142
 1254551:
-  aliases: ['Anopheles cf. funestus MALAF95']
+  aliases: []
   parents:
   - 59142
 1254552:
-  aliases: ['Anopheles cf. funestus MALAF96']
+  aliases: []
   parents:
   - 59142
 1254553:
-  aliases: ['Anopheles cf. funestus MALAF99']
+  aliases: []
   parents:
   - 59142
 1355220:
-  aliases: ['Anopheles cf. funestus SBV-2013']
+  aliases: []
   parents:
   - 59142
 2730095:
-  aliases: ['Anopheles cf. rivulorum']
+  aliases: []
   parents:
   - 2730094
 303176:
-  aliases: ['Anopheles cf. rivulorum CG-2004']
+  aliases: []
   parents:
   - 59142
 1141477:
-  aliases: ['Anopheles cf. rivulorum LN-2012b']
+  aliases: []
   parents:
   - 59142
 1712671:
-  aliases: ['Anopheles cf. rivulorum NFL-2015']
+  aliases: []
   parents:
   - 59142
 120868:
-  aliases: ['Anopheles claviger']
+  aliases: []
   parents:
   - 44484
 2579878:
-  aliases: ['Anopheles claviger sensu lato MLQSR032017C10']
+  aliases: []
   parents:
   - 44484
 2579879:
-  aliases: ['Anopheles claviger sensu lato MLQSR032017C11']
+  aliases: []
   parents:
   - 44484
 2579880:
-  aliases: ['Anopheles claviger sensu lato MLQSR032017C12']
+  aliases: []
   parents:
   - 44484
 2579881:
-  aliases: ['Anopheles claviger sensu lato MLQSR032017D01']
+  aliases: []
   parents:
   - 44484
 2579882:
-  aliases: ['Anopheles claviger sensu lato MLQSR032017D02']
+  aliases: []
   parents:
   - 44484
 2579883:
-  aliases: ['Anopheles claviger sensu lato MLQSR032017D03']
+  aliases: []
   parents:
   - 44484
 2579884:
-  aliases: ['Anopheles claviger sensu lato MLQSR032017D04']
+  aliases: []
   parents:
   - 44484
 2579885:
-  aliases: ['Anopheles claviger sensu lato MLQSR032017D05']
+  aliases: []
   parents:
   - 44484
 2579886:
-  aliases: ['Anopheles claviger sensu lato MLQSR032017D06']
+  aliases: []
   parents:
   - 44484
 2579887:
-  aliases: ['Anopheles claviger sensu lato MQLR-01-2017D03']
+  aliases: []
   parents:
   - 44484
 2579888:
-  aliases: ['Anopheles claviger sensu lato MQLR-01-2017F03']
+  aliases: []
   parents:
   - 44484
 103858:
-  aliases: ['Anopheles clowi']
+  aliases: []
   parents:
   - 44541
 1518534:
-  aliases: ['Anopheles coluzzii']
+  aliases: []
   parents:
   - 44542
 2081834:
-  aliases: ['Anopheles coluzzii x Anopheles gambiae']
+  aliases: []
   parents:
   - 44542
 139723:
-  aliases: ['Anopheles culicifacies']
+  aliases: []
   parents:
   - 63408
 63366:
-  aliases: ['Anopheles culicifacies A']
+  aliases: []
   parents:
   - 63408
 63367:
-  aliases: ['Anopheles culicifacies B']
+  aliases: []
   parents:
   - 63408
 63368:
-  aliases: ['Anopheles culicifacies C']
+  aliases: []
   parents:
   - 63408
 216372:
-  aliases: ['Anopheles culicifacies D']
+  aliases: []
   parents:
   - 63408
 216373:
-  aliases: ['Anopheles culicifacies E']
+  aliases: []
   parents:
   - 63408
 3121305:
-  aliases: ['Anopheles culicifacies complex sp.']
+  aliases: []
   parents:
   - 63408
 484759:
-  aliases: ['Anopheles culicifacies s.l. NPK-2007']
+  aliases: []
   parents:
   - 63408
 115967:
-  aliases: ['Anopheles dispar']
+  aliases: []
   parents:
   - 74868
 138536:
-  aliases: ['Anopheles dravidicus']
+  aliases: []
   parents:
   - 74868
 199890:
-  aliases: ['Anopheles epiroticus']
+  aliases: []
   parents:
   - 199889
 69004:
-  aliases: ['Anopheles farauti']
+  aliases: []
   parents:
   - 44541
 59191:
-  aliases: ['Anopheles farauti No. 4']
+  aliases: []
   parents:
   - 44541
 59192:
-  aliases: ['Anopheles farauti No. 5']
+  aliases: []
   parents:
   - 44541
 59193:
-  aliases: ['Anopheles farauti No. 6']
+  aliases: []
   parents:
   - 44541
 59146:
-  aliases: ['Anopheles filipinae']
+  aliases: []
   parents:
   - 59144
 59147:
-  aliases: ['Anopheles flavirostris']
+  aliases: []
   parents:
   - 59144
 364273:
-  aliases: ['Anopheles fluminensis']
+  aliases: []
   parents:
   - 58248
 2494418:
-  aliases: ['Anopheles fontenillei']
+  aliases: []
   parents:
   - 44542
 320068:
-  aliases: ['Anopheles freyi']
+  aliases: []
   parents:
   - 58250
 62324:
-  aliases: ['Anopheles funestus']
+  aliases: []
   parents:
   - 59142
 1316263:
-  aliases: ['Anopheles funestus s.l. MBC-2013']
+  aliases: []
   parents:
   - 59142
 2763070:
-  aliases: ['Anopheles funestus-like sensu Spillings et al. (2009)']
+  aliases: []
   parents:
   - 59142
 7165:
-  aliases: ['Anopheles gambiae']
+  aliases: []
   parents:
   - 44542
 1975581:
-  aliases: ['Anopheles gambiae x Anopheles arabiensis']
+  aliases: []
   parents:
   - 44542
 1547548:
-  aliases: ['Anopheles gambiae x Anopheles merus']
+  aliases: []
   parents:
   - 44542
 115968:
-  aliases: ['Anopheles greeni']
+  aliases: []
   parents:
   - 74868
 59189:
-  aliases: ['Anopheles hinesorum']
+  aliases: []
   parents:
   - 44541
 667562:
-  aliases: ['Anopheles implexus']
+  aliases: []
   parents:
   - 58249
 498628:
-  aliases: ['Anopheles interruptus']
+  aliases: []
   parents:
   - 498624
 59194:
-  aliases: ['Anopheles irenicus']
+  aliases: []
   parents:
   - 44541
 1962410:
-  aliases: ['Anopheles jamesii sensu lato 145']
+  aliases: []
   parents:
   - 59162
 107326:
-  aliases: ['Anopheles jeyporiensis']
+  aliases: []
   parents:
   - 59144
 30065:
-  aliases: ['Anopheles koliensis']
+  aliases: []
   parents:
   - 44541
 162636:
-  aliases: ['Anopheles leesoni']
+  aliases: []
   parents:
   - 59144
 691885:
-  aliases: ['Anopheles leucosphyrus group Nusa Tenggara Barat species']
+  aliases: []
   parents:
   - 44538
 273150:
-  aliases: ['Anopheles listeri']
+  aliases: []
   parents:
   - 262671
 412009:
-  aliases: ['Anopheles longipalpis']
+  aliases: []
   parents:
   - 412010
 412011:
-  aliases: ['Anopheles longipalpis A']
+  aliases: []
   parents:
   - 412010
 412012:
-  aliases: ['Anopheles longipalpis C']
+  aliases: []
   parents:
   - 412010
 59152:
-  aliases: ['Anopheles longirostris']
+  aliases: []
   parents:
   - 702664
 702665:
-  aliases: ['Anopheles longirostris A NWB-2009']
+  aliases: []
   parents:
   - 702664
 702666:
-  aliases: ['Anopheles longirostris B NWB-2009']
+  aliases: []
   parents:
   - 702664
 702667:
-  aliases: ['Anopheles longirostris C1 NWB-2009']
+  aliases: []
   parents:
   - 702664
 702668:
-  aliases: ['Anopheles longirostris C2 NWB-2009']
+  aliases: []
   parents:
   - 702664
 702669:
-  aliases: ['Anopheles longirostris D NWB-2009']
+  aliases: []
   parents:
   - 702664
 702670:
-  aliases: ['Anopheles longirostris E NWB-2009']
+  aliases: []
   parents:
   - 702664
 702671:
-  aliases: ['Anopheles longirostris F NWB-2009']
+  aliases: []
   parents:
   - 702664
 702672:
-  aliases: ['Anopheles longirostris G NWB-2009']
+  aliases: []
   parents:
   - 702664
 702673:
-  aliases: ['Anopheles longirostris H NWB-2009']
+  aliases: []
   parents:
   - 702664
 59154:
-  aliases: ['Anopheles lungae']
+  aliases: []
   parents:
   - 59153
 74869:
-  aliases: ['Anopheles maculatus']
+  aliases: []
   parents:
   - 74868
 1962408:
-  aliases: ['Anopheles maculatus sensu lato 4821']
+  aliases: []
   parents:
   - 74868
 1043304:
-  aliases: ['Anopheles malefactor']
+  aliases: []
   parents:
   - 58248
 59156:
-  aliases: ['Anopheles mangyanus']
+  aliases: []
   parents:
   - 59144
 139049:
-  aliases: ['Anopheles mattogrossensis']
+  aliases: []
   parents:
   - 58248
 2803201:
-  aliases: ['Anopheles medialis']
+  aliases: []
   parents:
   - 58248
 184758:
-  aliases: ['Anopheles mediopunctatus']
+  aliases: []
   parents:
   - 58248
 34690:
-  aliases: ['Anopheles melas']
+  aliases: []
   parents:
   - 44542
 30066:
-  aliases: ['Anopheles merus']
+  aliases: []
   parents:
   - 44542
 1579502:
-  aliases: ['Anopheles merus x Anopheles coluzzii']
+  aliases: []
   parents:
   - 44542
 596826:
-  aliases: ['Anopheles minor']
+  aliases: []
   parents:
   - 58248
 373597:
-  aliases: ['Anopheles moucheti bervoetsi']
+  aliases: []
   parents:
   - 186751
 2789022:
-  aliases: ['Anopheles moucheti cf. moucheti']
+  aliases: []
   parents:
   - 186751
 2564025:
-  aliases: ['Anopheles moucheti moucheti']
+  aliases: []
   parents:
   - 186751
 373596:
-  aliases: ['Anopheles moucheti nigeriensis']
+  aliases: []
   parents:
   - 186751
 273151:
-  aliases: ['Anopheles multicolor']
+  aliases: []
   parents:
   - 262671
 301835:
-  aliases: ['Anopheles notanandai']
+  aliases: []
   parents:
   - 74868
 3424146:
-  aliases: ['Anopheles nr. fluminensis']
+  aliases: []
   parents:
   - 58248
 2848159:
-  aliases: ['Anopheles nr. fluminensis AC514-4']
+  aliases: []
   parents:
   - 58248
 1426911:
-  aliases: ['Anopheles nr. fluminensis BOLD:AAI4551']
+  aliases: []
   parents:
   - 58248
 2419673:
-  aliases: ['Anopheles nr. fluminensis G1 MAMS-2018']
+  aliases: []
   parents:
   - 58248
 2419674:
-  aliases: ['Anopheles nr. fluminensis ss MAMS-2018']
+  aliases: []
   parents:
   - 58248
 3424147:
-  aliases: ['Anopheles nr. malefactor']
+  aliases: []
   parents:
   - 58248
 2848160:
-  aliases: ['Anopheles nr. malefactor AC532-3']
+  aliases: []
   parents:
   - 58248
 2848161:
-  aliases: ['Anopheles nr. malefactor AM448-2']
+  aliases: []
   parents:
   - 58248
 2848162:
-  aliases: ['Anopheles nr. malefactor AM449-3']
+  aliases: []
   parents:
   - 58248
 2419675:
-  aliases: ['Anopheles nr. malefactor MAMS-2018']
+  aliases: []
   parents:
   - 58248
 1698798:
-  aliases: ['Anopheles obscurus']
+  aliases: []
   parents:
   - 58250
 308711:
-  aliases: ['Anopheles pallidus']
+  aliases: []
   parents:
   - 59162
 123673:
-  aliases: ['Anopheles pampanai']
+  aliases: []
   parents:
   - 59144
 162637:
-  aliases: ['Anopheles parensis']
+  aliases: []
   parents:
   - 59142
 184770:
-  aliases: ['Anopheles peryassui']
+  aliases: []
   parents:
   - 58248
 205392:
-  aliases: ['Anopheles petragnani']
+  aliases: []
   parents:
   - 44484
 138531:
-  aliases: ['Anopheles pseudowillmori']
+  aliases: []
   parents:
   - 74868
 190378:
-  aliases: ['Anopheles punctimacula']
+  aliases: []
   parents:
   - 58248
 30068:
-  aliases: ['Anopheles punctulatus']
+  aliases: []
   parents:
   - 44541
 34691:
-  aliases: ['Anopheles quadriannulatus']
+  aliases: []
   parents:
   - 44542
 383384:
-  aliases: ['Anopheles rampae']
+  aliases: []
   parents:
   - 74868
 70327:
-  aliases: ['Anopheles rivulorum']
+  aliases: []
   parents:
   - 59142
 142886:
-  aliases: ['Anopheles sawadwongporni']
+  aliases: []
   parents:
   - 74868
 273454:
-  aliases: ['Anopheles sergentii']
+  aliases: []
   parents:
   - 59141
 59155:
-  aliases: ['Anopheles solomonis']
+  aliases: []
   parents:
   - 59153
 468925:
-  aliases: ['Anopheles sp. OPS-2007']
+  aliases: []
   parents:
   - 59144
 38297:
-  aliases: ['Anopheles sp. near punctulatus']
+  aliases: []
   parents:
   - 44541
 410748:
-  aliases: ['Anopheles sp. near punctulatus JEB-2006']
+  aliases: []
   parents:
   - 44541
 59160:
-  aliases: ['Anopheles subpictus']
+  aliases: []
   parents:
   - 59159
 1064590:
-  aliases: ['Anopheles subpictus A MZ-2011']
+  aliases: []
   parents:
   - 59159
 484761:
-  aliases: ['Anopheles subpictus s.l. NPK-2007']
+  aliases: []
   parents:
   - 59159
 34692:
-  aliases: ['Anopheles sundaicus']
+  aliases: []
   parents:
   - 199889
 2778658:
-  aliases: ['Anopheles sundaicus sensu lato D OPS-2020']
+  aliases: []
   parents:
   - 199889
 2995625:
-  aliases: ['Anopheles sundaicus sensu lato sp.']
+  aliases: []
   parents:
   - 199889
 382961:
-  aliases: ['Anopheles superpictus B']
+  aliases: []
   parents:
   - 262673
 59190:
-  aliases: ['Anopheles torresiensis']
+  aliases: []
   parents:
   - 44541
 262672:
-  aliases: ['Anopheles turkhudi']
+  aliases: []
   parents:
   - 262670
 2793312:
-  aliases: ['Anopheles vagus vagus']
+  aliases: []
   parents:
   - 142887
 62325:
-  aliases: ['Anopheles vaneedeni']
+  aliases: []
   parents:
   - 59142
 93948:
-  aliases: ['Anopheles varuna']
+  aliases: []
   parents:
   - 59144
 1300248:
-  aliases: ['Anopheles vinckei']
+  aliases: []
   parents:
   - 185573
 142888:
-  aliases: ['Anopheles willmori']
+  aliases: []
   parents:
   - 74868
 2989695:
-  aliases: ['Culex (Culiciomyia) sp.']
+  aliases: []
   parents:
   - 2989694
 3038203:
-  aliases: ['Culex (Lophoceraomyia) sp.']
+  aliases: []
   parents:
   - 2793860
 2793839:
-  aliases: ['Culex (Lophoceraomyia) sp. 1 HY-2020']
+  aliases: []
   parents:
   - 2793860
 2793840:
-  aliases: ['Culex (Lophoceraomyia) sp. 10 HY-2020']
+  aliases: []
   parents:
   - 2793860
 2793841:
-  aliases: ['Culex (Lophoceraomyia) sp. 11 HY-2020']
+  aliases: []
   parents:
   - 2793860
 2793842:
-  aliases: ['Culex (Lophoceraomyia) sp. 2 HY-2020']
+  aliases: []
   parents:
   - 2793860
 2793843:
-  aliases: ['Culex (Lophoceraomyia) sp. 3 HY-2020']
+  aliases: []
   parents:
   - 2793860
 2793844:
-  aliases: ['Culex (Lophoceraomyia) sp. 4 HY-2020']
+  aliases: []
   parents:
   - 2793860
 2793845:
-  aliases: ['Culex (Lophoceraomyia) sp. 5 HY-2020']
+  aliases: []
   parents:
   - 2793860
 2793846:
-  aliases: ['Culex (Lophoceraomyia) sp. 6 HY-2020']
+  aliases: []
   parents:
   - 2793860
 2793847:
-  aliases: ['Culex (Lophoceraomyia) sp. 7 HY-2020']
+  aliases: []
   parents:
   - 2793860
 2793848:
-  aliases: ['Culex (Lophoceraomyia) sp. 8 HY-2020']
+  aliases: []
   parents:
   - 2793860
 2793849:
-  aliases: ['Culex (Lophoceraomyia) sp. 9 HY-2020']
+  aliases: []
   parents:
   - 2793860
 260110:
-  aliases: ['Culex australicus']
+  aliases: []
   parents:
   - 518105
 1771965:
-  aliases: ['Culex hayashii hayashii']
+  aliases: []
   parents:
   - 1214266
 1214270:
-  aliases: ['Culex hayashii ryukyuanus']
+  aliases: []
   parents:
   - 1214266
 2686152:
-  aliases: ['Culex nr. pipiens APHA-1-2015A11']
+  aliases: []
   parents:
   - 518105
 2686127:
-  aliases: ['Culex nr. pipiens APHA-1-2015B01']
+  aliases: []
   parents:
   - 518105
 2686134:
-  aliases: ['Culex nr. pipiens APHA-1-2015B04']
+  aliases: []
   parents:
   - 518105
 2686155:
-  aliases: ['Culex nr. pipiens APHA-1-2015B05']
+  aliases: []
   parents:
   - 518105
 2686143:
-  aliases: ['Culex nr. pipiens APHA-1-2015B06']
+  aliases: []
   parents:
   - 518105
 2686122:
-  aliases: ['Culex nr. pipiens APHA-1-2015B07']
+  aliases: []
   parents:
   - 518105
 2686150:
-  aliases: ['Culex nr. pipiens APHA-1-2015B10']
+  aliases: []
   parents:
   - 518105
 2686149:
-  aliases: ['Culex nr. pipiens APHA-1-2015B11']
+  aliases: []
   parents:
   - 518105
 2686138:
-  aliases: ['Culex nr. pipiens APHA-1-2015C01']
+  aliases: []
   parents:
   - 518105
 2686146:
-  aliases: ['Culex nr. pipiens APHA-1-2015C02']
+  aliases: []
   parents:
   - 518105
 2686126:
-  aliases: ['Culex nr. pipiens APHA-1-2015C05']
+  aliases: []
   parents:
   - 518105
 2686124:
-  aliases: ['Culex nr. pipiens APHA-1-2015C06']
+  aliases: []
   parents:
   - 518105
 2686157:
-  aliases: ['Culex nr. pipiens APHA-1-2015C07']
+  aliases: []
   parents:
   - 518105
 2686136:
-  aliases: ['Culex nr. pipiens APHA-1-2015C08']
+  aliases: []
   parents:
   - 518105
 2686142:
-  aliases: ['Culex nr. pipiens APHA-1-2015C09']
+  aliases: []
   parents:
   - 518105
 2686125:
-  aliases: ['Culex nr. pipiens APHA-1-2015C10']
+  aliases: []
   parents:
   - 518105
 2686156:
-  aliases: ['Culex nr. pipiens APHA-1-2015C12']
+  aliases: []
   parents:
   - 518105
 2686121:
-  aliases: ['Culex nr. pipiens APHA-1-2015D02']
+  aliases: []
   parents:
   - 518105
 2686148:
-  aliases: ['Culex nr. pipiens APHA-1-2015D03']
+  aliases: []
   parents:
   - 518105
 2686158:
-  aliases: ['Culex nr. pipiens APHA-1-2015D04']
+  aliases: []
   parents:
   - 518105
 2686145:
-  aliases: ['Culex nr. pipiens APHA-1-2015D05']
+  aliases: []
   parents:
   - 518105
 2686147:
-  aliases: ['Culex nr. pipiens APHA-1-2015D07']
+  aliases: []
   parents:
   - 518105
 2686132:
-  aliases: ['Culex nr. pipiens APHA-1-2015G03']
+  aliases: []
   parents:
   - 518105
 2686151:
-  aliases: ['Culex nr. pipiens APHA-10-2015E10']
+  aliases: []
   parents:
   - 518105
 2686153:
-  aliases: ['Culex nr. pipiens APHA-10-2015G02']
+  aliases: []
   parents:
   - 518105
 2686130:
-  aliases: ['Culex nr. pipiens APHA-3-2015G03']
+  aliases: []
   parents:
   - 518105
 2686131:
-  aliases: ['Culex nr. pipiens APHA-3-2015G05']
+  aliases: []
   parents:
   - 518105
 2686137:
-  aliases: ['Culex nr. pipiens APHA-3-2015G06']
+  aliases: []
   parents:
   - 518105
 2686129:
-  aliases: ['Culex nr. pipiens APHA-3-2015G07']
+  aliases: []
   parents:
   - 518105
 2686135:
-  aliases: ['Culex nr. pipiens APHA-3-2015G08']
+  aliases: []
   parents:
   - 518105
 2686123:
-  aliases: ['Culex nr. pipiens APHA-3-2015G09']
+  aliases: []
   parents:
   - 518105
 2686139:
-  aliases: ['Culex nr. pipiens APHA-3-2015G10']
+  aliases: []
   parents:
   - 518105
 2686141:
-  aliases: ['Culex nr. pipiens APHA-3-2015G11']
+  aliases: []
   parents:
   - 518105
 2686133:
-  aliases: ['Culex nr. pipiens APHA-3-2015H01']
+  aliases: []
   parents:
   - 518105
 2686128:
-  aliases: ['Culex nr. pipiens APHA-3-2015H02']
+  aliases: []
   parents:
   - 518105
 2686154:
-  aliases: ['Culex nr. pipiens APHA-3-2015H04']
+  aliases: []
   parents:
   - 518105
 2686140:
-  aliases: ['Culex nr. pipiens APHA-3-2015H07']
+  aliases: []
   parents:
   - 518105
 2686144:
-  aliases: ['Culex nr. pipiens APHA-3-2015H08']
+  aliases: []
   parents:
   - 518105
 7175:
-  aliases: ['Culex pipiens']
+  aliases: []
   parents:
   - 518105
 3018961:
-  aliases: ['Culex pipiens complex sp.']
+  aliases: []
   parents:
   - 518105
 2924060:
-  aliases: ['Culex pipiens complex sp. CROBB162']
+  aliases: []
   parents:
   - 518105
 2924055:
-  aliases: ['Culex pipiens complex sp. CROBB167']
+  aliases: []
   parents:
   - 518105
 2924063:
-  aliases: ['Culex pipiens complex sp. CROBB168']
+  aliases: []
   parents:
   - 518105
 2924053:
-  aliases: ['Culex pipiens complex sp. CROBB169']
+  aliases: []
   parents:
   - 518105
 2924057:
-  aliases: ['Culex pipiens complex sp. CROBB636']
+  aliases: []
   parents:
   - 518105
 2924056:
-  aliases: ['Culex pipiens complex sp. CROBB647']
+  aliases: []
   parents:
   - 518105
 2924062:
-  aliases: ['Culex pipiens complex sp. CROBB649']
+  aliases: []
   parents:
   - 518105
 2924054:
-  aliases: ['Culex pipiens complex sp. CROBB650']
+  aliases: []
   parents:
   - 518105
 2924064:
-  aliases: ['Culex pipiens complex sp. CROBB651']
+  aliases: []
   parents:
   - 518105
 2924059:
-  aliases: ['Culex pipiens complex sp. CROBB652']
+  aliases: []
   parents:
   - 518105
 2924061:
-  aliases: ['Culex pipiens complex sp. CROBB653']
+  aliases: []
   parents:
   - 518105
 2924058:
-  aliases: ['Culex pipiens complex sp. CROBB654']
+  aliases: []
   parents:
   - 518105
 1177198:
-  aliases: ['Culex pipiens complex sp. HZ-2012']
+  aliases: []
   parents:
   - 518105
 1179746:
-  aliases: ['Culex pipiens complex sp. MW-2012']
+  aliases: []
   parents:
   - 518105
 946124:
-  aliases: ['Culex pipiens complex sp. YL-2011']
+  aliases: []
   parents:
   - 518105
 2874183:
-  aliases: ['Culex pipiens sensu lato']
+  aliases: []
   parents:
   - 518105
 2579914:
-  aliases: ['Culex pipiens sensu lato LRMQ-2-2017E07']
+  aliases: []
   parents:
   - 518105
 2579915:
-  aliases: ['Culex pipiens sensu lato LRMQ-2-2017E09']
+  aliases: []
   parents:
   - 518105
 2579889:
-  aliases: ['Culex pipiens sensu lato LRMQ-2-2017F07']
+  aliases: []
   parents:
   - 518105
 2579890:
-  aliases: ['Culex pipiens sensu lato LRMQ-2-2017G02']
+  aliases: []
   parents:
   - 518105
 2579916:
-  aliases: ['Culex pipiens sensu lato LRMQ-2-2017G04']
+  aliases: []
   parents:
   - 518105
 2579891:
-  aliases: ['Culex pipiens sensu lato MLQSR032017A05']
+  aliases: []
   parents:
   - 518105
 2579892:
-  aliases: ['Culex pipiens sensu lato MLQSR032017A06']
+  aliases: []
   parents:
   - 518105
 2579893:
-  aliases: ['Culex pipiens sensu lato MLQSR032017A07']
+  aliases: []
   parents:
   - 518105
 2579894:
-  aliases: ['Culex pipiens sensu lato MLQSR032017B04']
+  aliases: []
   parents:
   - 518105
 2579895:
-  aliases: ['Culex pipiens sensu lato MLQSR032017F04']
+  aliases: []
   parents:
   - 518105
 2579896:
-  aliases: ['Culex pipiens sensu lato MLQSR032017G04']
+  aliases: []
   parents:
   - 518105
 2579897:
-  aliases: ['Culex pipiens sensu lato MLQSR032017G05']
+  aliases: []
   parents:
   - 518105
 2579898:
-  aliases: ['Culex pipiens sensu lato MQLR-01-2017B08']
+  aliases: []
   parents:
   - 518105
 2579899:
-  aliases: ['Culex pipiens sensu lato MQLR-01-2017B09']
+  aliases: []
   parents:
   - 518105
 2579900:
-  aliases: ['Culex pipiens sensu lato MQLR-01-2017C03']
+  aliases: []
   parents:
   - 518105
 2579901:
-  aliases: ['Culex pipiens sensu lato MQLR-01-2017C04']
+  aliases: []
   parents:
   - 518105
 2579902:
-  aliases: ['Culex pipiens sensu lato MQLR-01-2017C05']
+  aliases: []
   parents:
   - 518105
 2579903:
-  aliases: ['Culex pipiens sensu lato MQLR-01-2017C06']
+  aliases: []
   parents:
   - 518105
 2579904:
-  aliases: ['Culex pipiens sensu lato MQLR-01-2017C07']
+  aliases: []
   parents:
   - 518105
 2579905:
-  aliases: ['Culex pipiens sensu lato MQLR-01-2017F11']
+  aliases: []
   parents:
   - 518105
 2579906:
-  aliases: ['Culex pipiens sensu lato MQLR-01-2017F12']
+  aliases: []
   parents:
   - 518105
 2579907:
-  aliases: ['Culex pipiens sensu lato MQLR-01-2017G01']
+  aliases: []
   parents:
   - 518105
 2579908:
-  aliases: ['Culex pipiens sensu lato MQLR-01-2017G07']
+  aliases: []
   parents:
   - 518105
 2579909:
-  aliases: ['Culex pipiens sensu lato MQLR-01-2017G08']
+  aliases: []
   parents:
   - 518105
 2579910:
-  aliases: ['Culex pipiens sensu lato MQLR-01-2017H04']
+  aliases: []
   parents:
   - 518105
 2579911:
-  aliases: ['Culex pipiens sensu lato MQLR-01-2017H06']
+  aliases: []
   parents:
   - 518105
 2579912:
-  aliases: ['Culex pipiens sensu lato MQLR-01-2017H10']
+  aliases: []
   parents:
   - 518105
 2579913:
-  aliases: ['Culex pipiens sensu lato MQLR-01-2017H11']
+  aliases: []
   parents:
   - 518105
 42435:
-  aliases: ['Culex pipiens x Culex quinquefasciatus']
+  aliases: []
   parents:
   - 518105
 7176:
-  aliases: ['Culex quinquefasciatus']
+  aliases: []
   parents:
   - 518105
 329104:
-  aliases: ['Ochlerotatus canadensis canadensis']
+  aliases: []
   parents:
   - 228917
 1712864:
-  aliases: ['Ochlerotatus eatoni hewitti (nomen nudum)']
+  aliases: []
   parents:
   - 1712862
 1712863:
-  aliases: ['Ochlerotatus eatoni krimbasi (nomen nudum)']
+  aliases: []
   parents:
   - 1712862
 2067437:
-  aliases: ['Ochlerotatus fulvus pallens']
+  aliases: []
   parents:
   - 1285602
 2938205:
-  aliases: ['Ochlerotatus pulcritarsis asiaticus']
+  aliases: []
   parents:
   - 1529939
 2498887:
-  aliases: ['Tripteroides bambusa bambusa']
+  aliases: []
   parents:
   - 53568
 2498888:
-  aliases: ['Tripteroides bambusa yaeyamensis']
+  aliases: []
   parents:
   - 53568
 1771966:
-  aliases: ['Uranotaenia novobscura novobscura']
+  aliases: []
   parents:
   - 1245379
 44508:
-  aliases: ['aitkenii group']
+  aliases: []
   parents:
   - 44484
 58234:
-  aliases: ['albitarsis group']
+  aliases: []
   parents:
   - 58233
 59125:
-  aliases: ['albotaeniatus group']
+  aliases: []
   parents:
   - 58250
 348691:
-  aliases: ['annularis species complex']
+  aliases: []
   parents:
   - 59162
 58238:
-  aliases: ['argyritarsis group']
+  aliases: []
   parents:
   - 44546
 59126:
-  aliases: ['bancroftii group']
+  aliases: []
   parents:
   - 58250
 59127:
-  aliases: ['barbirostris group']
+  aliases: []
   parents:
   - 58250
 58235:
-  aliases: ['braziliensis group']
+  aliases: []
   parents:
   - 58233
 59130:
-  aliases: ['coustani group']
+  aliases: []
   parents:
   - 58250
 44512:
-  aliases: ['culiciformis group']
+  aliases: []
   parents:
   - 44484
 44552:
-  aliases: ['darlingi group']
+  aliases: []
   parents:
   - 44546
 409341:
-  aliases: ['elegans subgroup (in: mosquitos)']
+  aliases: []
   parents:
   - 44538
 112264:
-  aliases: ['fluviatilis species complex']
+  aliases: []
   parents:
   - 59144
 409348:
-  aliases: ['hackeri subgroup']
+  aliases: []
   parents:
   - 44538
 59131:
-  aliases: ['hyrcanus group']
+  aliases: []
   parents:
   - 58250
 44539:
-  aliases: ['leucosphyrus subgroup']
+  aliases: []
   parents:
   - 44538
 44513:
-  aliases: ['lindesayi group']
+  aliases: []
   parents:
   - 44484
 44485:
-  aliases: ['maculipennis group']
+  aliases: []
   parents:
   - 44484
 93949:
-  aliases: ['minimus species complex']
+  aliases: []
   parents:
   - 59144
 185574:
-  aliases: ['nili species complex']
+  aliases: []
   parents:
   - 185573
 74870:
-  aliases: ['nivipes species complex']
+  aliases: []
   parents:
   - 59162
 44549:
-  aliases: ['oswaldoi group']
+  aliases: []
   parents:
   - 44548
 58240:
-  aliases: ['pictipennis group']
+  aliases: []
   parents:
   - 44546
 44514:
-  aliases: ['plumbeus group']
+  aliases: []
   parents:
   - 44484
 44516:
-  aliases: ['pseudopunctipennis group']
+  aliases: []
   parents:
   - 44484
 44517:
-  aliases: ['punctipennis group']
+  aliases: []
   parents:
   - 44484
 409342:
-  aliases: ['riparis subgroup']
+  aliases: []
   parents:
   - 44538
 54113:
-  aliases: ['triannulatus group']
+  aliases: []
   parents:
   - 44548
 59134:
-  aliases: ['umbrosus group']
+  aliases: []
   parents:
   - 58250
 1354096:
-  aliases: ['(Anopheles kleini x Anopheles sinensis) x Anopheles kleini']
+  aliases: []
   parents:
   - 59131
 1354097:
-  aliases: ['(Anopheles sinensis x Anopheles kleini) x Anopheles sinensis']
+  aliases: []
   parents:
   - 59131
 2848153:
-  aliases: ['Anopheles aff. albitarsis G TMPO-2021']
+  aliases: []
   parents:
   - 58234
 2419677:
-  aliases: ['Anopheles aff. albitarsis H MAMS-2018']
+  aliases: []
   parents:
   - 58234
 2171924:
-  aliases: ['Anopheles aff. albitarsis H PGF-2018']
+  aliases: []
   parents:
   - 58234
 325439:
-  aliases: ['Anopheles aitkenii']
+  aliases: []
   parents:
   - 44508
 58236:
-  aliases: ['Anopheles albitarsis']
+  aliases: []
   parents:
   - 58234
 352057:
-  aliases: ['Anopheles albitarsis F Brochero et al., 2007']
+  aliases: []
   parents:
   - 58234
 908352:
-  aliases: ['Anopheles albitarsis G Krzywinski et al., 2011']
+  aliases: []
   parents:
   - 58234
 1155478:
-  aliases: ['Anopheles albitarsis H Ruiz-Lopez et al. 2012']
+  aliases: []
   parents:
   - 58234
 1155479:
-  aliases: ['Anopheles albitarsis I Ruiz-Lopez et al. 2012']
+  aliases: []
   parents:
   - 58234
 2719617:
-  aliases: ['Anopheles albitarsis J MTM-2020']
+  aliases: []
   parents:
   - 58234
 1221518:
-  aliases: ['Anopheles albitarsis s.l. MLQ-2012']
+  aliases: []
   parents:
   - 58234
 59163:
-  aliases: ['Anopheles annularis']
+  aliases: []
   parents:
   - 348691
 3121304:
-  aliases: ['Anopheles annularis complex sp.']
+  aliases: []
   parents:
   - 348691
 58241:
-  aliases: ['Anopheles argyritarsis']
+  aliases: []
   parents:
   - 58238
 2848165:
-  aliases: ['Anopheles argyritarsis sensu lato MG180-103']
+  aliases: []
   parents:
   - 58238
 722774:
-  aliases: ['Anopheles atacamensis']
+  aliases: []
   parents:
   - 58240
 190376:
-  aliases: ['Anopheles atropos']
+  aliases: []
   parents:
   - 44485
 48725:
-  aliases: ['Anopheles baimaii']
+  aliases: []
   parents:
   - 44539
 59136:
-  aliases: ['Anopheles bancroftii']
+  aliases: []
   parents:
   - 59126
 2793837:
-  aliases: ['Anopheles barbirostris complex sp. 1 HY-2020']
+  aliases: []
   parents:
   - 59127
 2793838:
-  aliases: ['Anopheles barbirostris complex sp. 2 HY-2020']
+  aliases: []
   parents:
   - 59127
 3230858:
-  aliases: ['Anopheles barbirostris group sp.']
+  aliases: []
   parents:
   - 59127
 1962411:
-  aliases: ['Anopheles barbirostris sensu lato 245']
+  aliases: []
   parents:
   - 59127
 254294:
-  aliases: ['Anopheles belenrae']
+  aliases: []
   parents:
   - 59131
 758765:
-  aliases: ['Anopheles bengalensis']
+  aliases: []
   parents:
   - 44508
 58242:
-  aliases: ['Anopheles braziliensis']
+  aliases: []
   parents:
   - 58235
 1712673:
-  aliases: ['Anopheles cf. coustani 1 NFL-2015']
+  aliases: []
   parents:
   - 59130
 1712674:
-  aliases: ['Anopheles cf. coustani 2 NFL-2015']
+  aliases: []
   parents:
   - 59130
 464762:
-  aliases: ['Anopheles cf. hyrcanus DDN-2007']
+  aliases: []
   parents:
   - 59131
 940851:
-  aliases: ['Anopheles cf. janconnae Gutierrez et al., 2010']
+  aliases: []
   parents:
   - 58234
 2024867:
-  aliases: ['Anopheles cf. janconnae MCAP-2017']
+  aliases: []
   parents:
   - 58234
 908353:
-  aliases: ['Anopheles cf. marajoara/albitarsis G SNM-2010']
+  aliases: []
   parents:
   - 58234
 93952:
-  aliases: ['Anopheles cf. minimus #157']
+  aliases: []
   parents:
   - 93949
 139045:
-  aliases: ['Anopheles coustani']
+  aliases: []
   parents:
   - 59130
 2569797:
-  aliases: ['Anopheles coustani group sp. BNG1032']
+  aliases: []
   parents:
   - 59130
 2569799:
-  aliases: ['Anopheles coustani group sp. BNG147']
+  aliases: []
   parents:
   - 59130
 2569798:
-  aliases: ['Anopheles coustani group sp. BNG4574']
+  aliases: []
   parents:
   - 59130
 2569796:
-  aliases: ['Anopheles coustani group sp. BNG492']
+  aliases: []
   parents:
   - 59130
 2569795:
-  aliases: ['Anopheles coustani group sp. BNG69']
+  aliases: []
   parents:
   - 59130
 3125891:
-  aliases: ['Anopheles coustani sensu lato sp.']
+  aliases: []
   parents:
   - 59130
 123217:
-  aliases: ['Anopheles cracens']
+  aliases: []
   parents:
   - 44539
 3142371:
-  aliases: ['Anopheles culiciformis group sp.']
+  aliases: []
   parents:
   - 44512
 43151:
-  aliases: ['Anopheles darlingi']
+  aliases: []
   parents:
   - 44552
 58243:
-  aliases: ['Anopheles deaneorum']
+  aliases: []
   parents:
   - 58234
 1513311:
-  aliases: ['Anopheles dissidens']
+  aliases: []
   parents:
   - 59127
 184757:
-  aliases: ['Anopheles eiseni']
+  aliases: []
   parents:
   - 44516
 409343:
-  aliases: ['Anopheles elegans']
+  aliases: []
   parents:
   - 409341
 261461:
-  aliases: ['Anopheles engarensis']
+  aliases: []
   parents:
   - 59131
 111615:
-  aliases: ['Anopheles fluviatilis']
+  aliases: []
   parents:
   - 112264
 112265:
-  aliases: ['Anopheles fluviatilis S']
+  aliases: []
   parents:
   - 112264
 112266:
-  aliases: ['Anopheles fluviatilis T']
+  aliases: []
   parents:
   - 112264
 175248:
-  aliases: ['Anopheles fluviatilis U']
+  aliases: []
   parents:
   - 112264
 1073928:
-  aliases: ['Anopheles fluviatilis V']
+  aliases: []
   parents:
   - 112264
 345575:
-  aliases: ['Anopheles fuscicolor']
+  aliases: []
   parents:
   - 59130
 180454:
-  aliases: ['Anopheles gambiae str. PEST']
+  aliases: []
   parents:
   - 7165
 138534:
-  aliases: ['Anopheles hyrcanus']
+  aliases: []
   parents:
   - 59131
 931282:
-  aliases: ['Anopheles hyrcanus group sp. 1 CPE-2010']
+  aliases: []
   parents:
   - 59131
 931283:
-  aliases: ['Anopheles hyrcanus group sp. 2 CPE-2010']
+  aliases: []
   parents:
   - 59131
 931284:
-  aliases: ['Anopheles hyrcanus group sp. 3 CPE-2010']
+  aliases: []
   parents:
   - 59131
 1254524:
-  aliases: ['Anopheles hyrcanus group sp. LL1']
+  aliases: []
   parents:
   - 59131
 1254525:
-  aliases: ['Anopheles hyrcanus group sp. LL2']
+  aliases: []
   parents:
   - 59131
 1254526:
-  aliases: ['Anopheles hyrcanus group sp. LL3']
+  aliases: []
   parents:
   - 59131
 1193693:
-  aliases: ['Anopheles hyrcanus group sp. RZ-2012']
+  aliases: []
   parents:
   - 59131
 1962412:
-  aliases: ['Anopheles hyrcanus sensu lato 2836']
+  aliases: []
   parents:
   - 59131
 337448:
-  aliases: ['Anopheles janconnae']
+  aliases: []
   parents:
   - 58234
 190377:
-  aliases: ['Anopheles judithae']
+  aliases: []
   parents:
   - 44514
 232293:
-  aliases: ['Anopheles junlianensis']
+  aliases: []
   parents:
   - 59131
 296717:
-  aliases: ['Anopheles kleini']
+  aliases: []
   parents:
   - 59131
 232291:
-  aliases: ['Anopheles kunmingensis']
+  aliases: []
   parents:
   - 59131
 138535:
-  aliases: ['Anopheles kweiyangensis']
+  aliases: []
   parents:
   - 59131
 113049:
-  aliases: ['Anopheles liangshanensis']
+  aliases: []
   parents:
   - 59131
 409346:
-  aliases: ['Anopheles macarthuri']
+  aliases: []
   parents:
   - 409342
 58244:
-  aliases: ['Anopheles marajoara']
+  aliases: []
   parents:
   - 58234
 112268:
-  aliases: ['Anopheles minimus']
+  aliases: []
   parents:
   - 93949
 93950:
-  aliases: ['Anopheles minimus A']
+  aliases: []
   parents:
   - 93949
 139059:
-  aliases: ['Anopheles minimus A x Anopheles minimus C']
+  aliases: []
   parents:
   - 93949
 344935:
-  aliases: ['Anopheles minimus A1']
+  aliases: []
   parents:
   - 93949
 344936:
-  aliases: ['Anopheles minimus A2']
+  aliases: []
   parents:
   - 93949
 93951:
-  aliases: ['Anopheles minimus C']
+  aliases: []
   parents:
   - 93949
 344937:
-  aliases: ['Anopheles minimus C1']
+  aliases: []
   parents:
   - 93949
 344938:
-  aliases: ['Anopheles minimus C2']
+  aliases: []
   parents:
   - 93949
 313724:
-  aliases: ['Anopheles minimus D3']
+  aliases: []
   parents:
   - 93949
 131314:
-  aliases: ['Anopheles minimus E']
+  aliases: []
   parents:
   - 93949
 487308:
-  aliases: ['Anopheles minimus s.l. NPK-2007']
+  aliases: []
   parents:
   - 93949
 1962409:
-  aliases: ['Anopheles minimus sensu lato 1775']
+  aliases: []
   parents:
   - 93949
 409349:
-  aliases: ['Anopheles mirans']
+  aliases: []
   parents:
   - 409348
 345576:
-  aliases: ['Anopheles namibiensis']
+  aliases: []
   parents:
   - 59130
 185578:
-  aliases: ['Anopheles nili']
+  aliases: []
   parents:
   - 185574
 185576:
-  aliases: ["Anopheles nili 'oveng form'"]
+  aliases: []
   parents:
   - 185574
 185575:
-  aliases: ['Anopheles nili T']
+  aliases: []
   parents:
   - 185574
 113074:
-  aliases: ['Anopheles nimpe']
+  aliases: []
   parents:
   - 59131
 1284620:
-  aliases: ['Anopheles nitidus']
+  aliases: []
   parents:
   - 59131
 74871:
-  aliases: ['Anopheles nivipes']
+  aliases: []
   parents:
   - 74870
 2171938:
-  aliases: ['Anopheles nr. braziliensis BA50_1_104']
+  aliases: []
   parents:
   - 58235
 58237:
-  aliases: ['Anopheles oryzalimnetes']
+  aliases: []
   parents:
   - 58234
 345577:
-  aliases: ['Anopheles paludis']
+  aliases: []
   parents:
   - 59130
 503459:
-  aliases: ['Anopheles pictipennis']
+  aliases: []
   parents:
   - 58240
 227531:
-  aliases: ['Anopheles plumbeus']
+  aliases: []
   parents:
   - 44514
 456297:
-  aliases: ['Anopheles pseudopictus']
+  aliases: []
   parents:
   - 59131
 46955:
-  aliases: ['Anopheles pseudopunctipennis']
+  aliases: []
   parents:
   - 44516
 3350976:
-  aliases: ['Anopheles pujutensis']
+  aliases: []
   parents:
   - 409348
 251639:
-  aliases: ['Anopheles pullus']
+  aliases: []
   parents:
   - 59131
 377122:
-  aliases: ['Anopheles quadriannulatus A']
+  aliases: []
   parents:
   - 34691
 193510:
-  aliases: ['Anopheles quadriannulatus B']
+  aliases: []
   parents:
   - 34691
 1513312:
-  aliases: ['Anopheles saeungae']
+  aliases: []
   parents:
   - 59127
 252133:
-  aliases: ['Anopheles saperoi']
+  aliases: []
   parents:
   - 59125
 1552952:
-  aliases: ['Anopheles sawyeri']
+  aliases: []
   parents:
   - 58238
 114091:
-  aliases: ['Anopheles scanloni']
+  aliases: []
   parents:
   - 44539
 74873:
-  aliases: ['Anopheles sinensis']
+  aliases: []
   parents:
   - 59131
 1354098:
-  aliases: ['Anopheles sinensis x Anopheles kleini']
+  aliases: []
   parents:
   - 59131
 261159:
-  aliases: ['Anopheles sineroides']
+  aliases: []
   parents:
   - 59131
 190123:
-  aliases: ['Anopheles somalicus']
+  aliases: []
   parents:
   - 185574
 286421:
-  aliases: ['Anopheles sp. YM-2004']
+  aliases: []
   parents:
   - 59131
 409344:
-  aliases: ['Anopheles sulawesi']
+  aliases: []
   parents:
   - 409341
 345579:
-  aliases: ['Anopheles tenebrosus']
+  aliases: []
   parents:
   - 59130
 58253:
-  aliases: ['Anopheles triannulatus']
+  aliases: []
   parents:
   - 54113
 1071030:
-  aliases: ["Anopheles triannulatus 'C' TFSN-2007"]
+  aliases: []
   parents:
   - 54113
 49923:
-  aliases: ['Anopheles walkeri']
+  aliases: []
   parents:
   - 44485
 1214263:
-  aliases: ['Anopheles yaeyamaensis']
+  aliases: []
   parents:
   - 93949
 113050:
-  aliases: ['Anopheles yatsushiroensis']
+  aliases: []
   parents:
   - 59131
 345580:
-  aliases: ['Anopheles ziemanni']
+  aliases: []
   parents:
   - 59130
 233155:
-  aliases: ['Culex pipiens molestus']
+  aliases: []
   parents:
   - 7175
 42434:
-  aliases: ['Culex pipiens pallens']
+  aliases: []
   parents:
   - 7175
 38569:
-  aliases: ['Culex pipiens pipiens']
+  aliases: []
   parents:
   - 7175
 1833972:
-  aliases: ['Culex pipiens pipiens x Culex pipiens molestus']
+  aliases: []
   parents:
   - 7175
 710234:
-  aliases: ['Culex quinquefasciatus quinquefasciatus']
+  aliases: []
   parents:
   - 7176
 59128:
-  aliases: ['barbirostris subgroup']
+  aliases: []
   parents:
   - 59127
 49916:
-  aliases: ['crucians subgroup']
+  aliases: []
   parents:
   - 44517
 409350:
-  aliases: ['dirus species complex']
+  aliases: []
   parents:
   - 44539
 2993839:
-  aliases: ['gigas subgroup']
+  aliases: []
   parents:
   - 44513
 59132:
-  aliases: ['lesteri subgroup']
+  aliases: []
   parents:
   - 59131
 59135:
-  aliases: ['letifer subgroup']
+  aliases: []
   parents:
   - 59134
 59123:
-  aliases: ['leucosphyrus species complex']
+  aliases: []
   parents:
   - 44539
 2993838:
-  aliases: ['lindesayi subgroup']
+  aliases: []
   parents:
   - 44513
 44533:
-  aliases: ['maculipennis species complex']
+  aliases: []
   parents:
   - 44485
 44486:
-  aliases: ['maculipennis subgroup']
+  aliases: []
   parents:
   - 44485
 59133:
-  aliases: ['nigerrimus subgroup']
+  aliases: []
   parents:
   - 59131
 44550:
-  aliases: ['oswaldoi subgroup']
+  aliases: []
   parents:
   - 44549
 49919:
-  aliases: ['punctipennis species complex']
+  aliases: []
   parents:
   - 44517
 44551:
-  aliases: ['strodei subgroup']
+  aliases: []
   parents:
   - 44549
 59129:
-  aliases: ['vanus subgroup']
+  aliases: []
   parents:
   - 59127
 2171925:
-  aliases: ['Anopheles aff. arthuri B PGF-2018']
+  aliases: []
   parents:
   - 44551
 2171926:
-  aliases: ['Anopheles aff. arthuri C PGF-2018']
+  aliases: []
   parents:
   - 44551
 2171927:
-  aliases: ['Anopheles aff. arthuri D PGF-2018']
+  aliases: []
   parents:
   - 44551
 2419678:
-  aliases: ['Anopheles aff. benarrochi B MAMS-2018']
+  aliases: []
   parents:
   - 44551
 2419679:
-  aliases: ['Anopheles aff. benarrochi G1 MAMS-2018']
+  aliases: []
   parents:
   - 44551
 2419680:
-  aliases: ['Anopheles aff. benarrochi G2 MAMS-2018']
+  aliases: []
   parents:
   - 44551
 2171933:
-  aliases: ['Anopheles aff. nuneztovari A PGF-2018']
+  aliases: []
   parents:
   - 44550
 2049327:
-  aliases: ['Anopheles aff. oswaldoi A JFS-2017']
+  aliases: []
   parents:
   - 44550
 2419681:
-  aliases: ['Anopheles aff. oswaldoi A MAMS-2018']
+  aliases: []
   parents:
   - 44550
 2171934:
-  aliases: ['Anopheles aff. oswaldoi A PGF-2018']
+  aliases: []
   parents:
   - 44550
 2049328:
-  aliases: ['Anopheles aff. oswaldoi B JFS-2017']
+  aliases: []
   parents:
   - 44550
 2024868:
-  aliases: ['Anopheles aff. oswaldoi B MCAP-2017']
+  aliases: []
   parents:
   - 44550
 2830292:
-  aliases: ['Anopheles aff. oswaldoi B TMPO-2021a']
+  aliases: []
   parents:
   - 44550
 2171935:
-  aliases: ['Anopheles aff. oswaldoi SPForm PGF-2018']
+  aliases: []
   parents:
   - 44550
 862807:
-  aliases: ['Anopheles albertoi']
+  aliases: []
   parents:
   - 44551
 382438:
-  aliases: ['Anopheles annularis A']
+  aliases: []
   parents:
   - 59163
 74872:
-  aliases: ['Anopheles anthropophagus']
+  aliases: []
   parents:
   - 59132
 42839:
-  aliases: ['Anopheles aquasalis']
+  aliases: []
   parents:
   - 44550
 297585:
-  aliases: ['Anopheles artemievi']
+  aliases: []
   parents:
   - 44533
 862808:
-  aliases: ['Anopheles arthuri']
+  aliases: []
   parents:
   - 44551
 2304035:
-  aliases: ['Anopheles arthuri complex sp. A BDS-2018']
+  aliases: []
   parents:
   - 44551
 2304036:
-  aliases: ['Anopheles arthuri complex sp. B BDS-2018']
+  aliases: []
   parents:
   - 44551
 2304037:
-  aliases: ['Anopheles arthuri complex sp. C BDS-2018']
+  aliases: []
   parents:
   - 44551
 2304038:
-  aliases: ['Anopheles arthuri complex sp. D BDS-2018']
+  aliases: []
   parents:
   - 44551
 1324767:
-  aliases: ['Anopheles arthuri s.l. A MAS-2013']
+  aliases: []
   parents:
   - 44551
 1324768:
-  aliases: ['Anopheles arthuri s.l. B MAS-2013']
+  aliases: []
   parents:
   - 44551
 1324769:
-  aliases: ['Anopheles arthuri s.l. C MAS-2013']
+  aliases: []
   parents:
   - 44551
 1324770:
-  aliases: ['Anopheles arthuri s.l. D MAS-2013']
+  aliases: []
   parents:
   - 44551
 41427:
-  aliases: ['Anopheles atroparvus']
+  aliases: []
   parents:
   - 44533
 49915:
-  aliases: ['Anopheles aztecus']
+  aliases: []
   parents:
   - 44486
 59124:
-  aliases: ['Anopheles balabacensis']
+  aliases: []
   parents:
   - 59123
 112267:
-  aliases: ['Anopheles barbirostris']
+  aliases: []
   parents:
   - 59128
 576155:
-  aliases: ['Anopheles barbirostris subgroup clade I']
+  aliases: []
   parents:
   - 59128
 576156:
-  aliases: ['Anopheles barbirostris subgroup clade II']
+  aliases: []
   parents:
   - 59128
 576157:
-  aliases: ['Anopheles barbirostris subgroup clade III']
+  aliases: []
   parents:
   - 59128
 576158:
-  aliases: ['Anopheles barbirostris subgroup clade IV']
+  aliases: []
   parents:
   - 59128
 3122452:
-  aliases: ['Anopheles barbirostris subgroup sp.']
+  aliases: []
   parents:
   - 59128
 1137571:
-  aliases: ['Anopheles barbumbrosus']
+  aliases: []
   parents:
   - 59129
 210816:
-  aliases: ['Anopheles beklemishevi']
+  aliases: []
   parents:
   - 44533
 43061:
-  aliases: ['Anopheles benarrochi']
+  aliases: []
   parents:
   - 44551
 360405:
-  aliases: ['Anopheles benarrochi B']
+  aliases: []
   parents:
   - 44551
 49917:
-  aliases: ['Anopheles bradleyi']
+  aliases: []
   parents:
   - 49916
 453036:
-  aliases: ['Anopheles campestris']
+  aliases: []
   parents:
   - 59128
 138537:
-  aliases: ['Anopheles crawfordi']
+  aliases: []
   parents:
   - 59132
 281737:
-  aliases: ['Anopheles daciae']
+  aliases: []
   parents:
   - 44533
 7168:
-  aliases: ['Anopheles dirus']
+  aliases: []
   parents:
   - 409350
 3122451:
-  aliases: ['Anopheles dirus complex sp.']
+  aliases: []
   parents:
   - 409350
 881808:
-  aliases: ['Anopheles dirus complex sp. X AP-2010']
+  aliases: []
   parents:
   - 409350
 1962414:
-  aliases: ['Anopheles dirus sensu lato 3856']
+  aliases: []
   parents:
   - 409350
 58245:
-  aliases: ['Anopheles dunhami']
+  aliases: []
   parents:
   - 44550
 49918:
-  aliases: ['Anopheles earlei']
+  aliases: []
   parents:
   - 44486
 2171668:
-  aliases: ['Anopheles eiseni geometricus']
+  aliases: []
   parents:
   - 184757
 53710:
-  aliases: ['Anopheles evansae']
+  aliases: []
   parents:
   - 44550
 58246:
-  aliases: ['Anopheles galvaoi']
+  aliases: []
   parents:
   - 44550
 585440:
-  aliases: ['Anopheles goeldii']
+  aliases: []
   parents:
   - 44550
 2126075:
-  aliases: ['Anopheles hyrcanus ssp. AKJ-2018']
+  aliases: []
   parents:
   - 138534
 658928:
-  aliases: ['Anopheles kleini x Anopheles sinensis']
+  aliases: []
   parents:
   - 296717
 262075:
-  aliases: ['Anopheles koreicus']
+  aliases: []
   parents:
   - 59128
 41428:
-  aliases: ['Anopheles labranchiae']
+  aliases: []
   parents:
   - 44533
 409347:
-  aliases: ['Anopheles latens']
+  aliases: []
   parents:
   - 59123
 109668:
-  aliases: ['Anopheles lesteri']
+  aliases: []
   parents:
   - 59132
 1137572:
-  aliases: ['Anopheles letifer']
+  aliases: []
   parents:
   - 59135
 2751809:
-  aliases: ['Anopheles letifer sensu lato']
+  aliases: []
   parents:
   - 59135
 409345:
-  aliases: ['Anopheles leucosphyrus']
+  aliases: []
   parents:
   - 59123
 2751810:
-  aliases: ['Anopheles leucosphyrus sensu lato']
+  aliases: []
   parents:
   - 59123
 41429:
-  aliases: ['Anopheles maculipennis']
+  aliases: []
   parents:
   - 44533
 2768836:
-  aliases: ['Anopheles maculipennis complex sp. 1 NMR-2020']
+  aliases: []
   parents:
   - 44533
 2768837:
-  aliases: ['Anopheles maculipennis complex sp. 2 NMR-2020']
+  aliases: []
   parents:
   - 44533
 1382457:
-  aliases: ['Anopheles maculipennis complex sp. GB-2013']
+  aliases: []
   parents:
   - 44533
 1578836:
-  aliases: ['Anopheles maculipennis sensu lato BTLHVDV-2014']
+  aliases: []
   parents:
   - 44533
 73142:
-  aliases: ['Anopheles martinius']
+  aliases: []
   parents:
   - 44533
 73143:
-  aliases: ['Anopheles melanoon']
+  aliases: []
   parents:
   - 44533
 41430:
-  aliases: ['Anopheles messeae']
+  aliases: []
   parents:
   - 44533
 2066577:
-  aliases: ['Anopheles messeae x Anopheles daciae']
+  aliases: []
   parents:
   - 44533
 409351:
-  aliases: ['Anopheles nemophilous']
+  aliases: []
   parents:
   - 409350
 209202:
-  aliases: ['Anopheles nigerrimus']
+  aliases: []
   parents:
   - 59133
 30067:
-  aliases: ['Anopheles nuneztovari']
+  aliases: []
   parents:
   - 44550
 2830335:
-  aliases: ['Anopheles nuneztovari sensu lato 1044']
+  aliases: []
   parents:
   - 44550
 2830334:
-  aliases: ['Anopheles nuneztovari sensu lato M5']
+  aliases: []
   parents:
   - 44550
 7172:
-  aliases: ['Anopheles occidentalis']
+  aliases: []
   parents:
   - 44486
 43181:
-  aliases: ['Anopheles oswaldoi']
+  aliases: []
   parents:
   - 44550
 1326106:
-  aliases: ['Anopheles oswaldoi A sensu Ruiz-Lopez et al. (2013)']
+  aliases: []
   parents:
   - 44550
 1326107:
-  aliases: ['Anopheles oswaldoi B sensu Ruiz-Lopez et al. (2013)']
+  aliases: []
   parents:
   - 44550
 1184685:
-  aliases: ['Anopheles oswaldoi s.l. AC18']
+  aliases: []
   parents:
   - 44550
 1221519:
-  aliases: ['Anopheles oswaldoi s.l. MLQ-2012']
+  aliases: []
   parents:
   - 44550
 1290811:
-  aliases: ['Anopheles oswaldoi s.l. PA_15']
+  aliases: []
   parents:
   - 44550
 741735:
-  aliases: ['Anopheles paraliae']
+  aliases: []
   parents:
   - 59132
 206113:
-  aliases: ['Anopheles peditaeniatus']
+  aliases: []
   parents:
   - 59132
 208662:
-  aliases: ['Anopheles persiensis']
+  aliases: []
   parents:
   - 44533
 102899:
-  aliases: ['Anopheles punctipennis']
+  aliases: []
   parents:
   - 49919
 49920:
-  aliases: ['Anopheles punctipennis E']
+  aliases: []
   parents:
   - 49919
 49921:
-  aliases: ['Anopheles punctipennis W']
+  aliases: []
   parents:
   - 49919
 42840:
-  aliases: ['Anopheles rangeli']
+  aliases: []
   parents:
   - 44550
 58252:
-  aliases: ['Anopheles rondoni']
+  aliases: []
   parents:
   - 44551
 72408:
-  aliases: ['Anopheles sacharovi']
+  aliases: []
   parents:
   - 44533
 3076058:
-  aliases: ['Anopheles sarpangensis']
+  aliases: []
   parents:
   - 59128
 284817:
-  aliases: ['Anopheles sp. AkKh10i']
+  aliases: []
   parents:
   - 44533
 284818:
-  aliases: ['Anopheles sp. KoKk10i']
+  aliases: []
   parents:
   - 44533
 284819:
-  aliases: ['Anopheles sp. NuKk1i']
+  aliases: []
   parents:
   - 44533
 470212:
-  aliases: ['Anopheles sp. RiFe30i']
+  aliases: []
   parents:
   - 44533
 474926:
-  aliases: ['Anopheles sp. RiFe51i']
+  aliases: []
   parents:
   - 44533
 2171671:
-  aliases: ['Anopheles striatus']
+  aliases: []
   parents:
   - 44551
 53711:
-  aliases: ['Anopheles strodei']
+  aliases: []
   parents:
   - 44551
 862092:
-  aliases: ['Anopheles strodei s.l. CP form']
+  aliases: []
   parents:
   - 44551
 409352:
-  aliases: ['Anopheles takasagoensis']
+  aliases: []
   parents:
   - 409350
 1285095:
-  aliases: ['Anopheles vanderwulpi']
+  aliases: []
   parents:
   - 59128
 1513313:
-  aliases: ['Anopheles wejchoochotei']
+  aliases: []
   parents:
   - 59128
 2993840:
-  aliases: ['baileyi species complex']
+  aliases: []
   parents:
   - 2993839
 232555:
-  aliases: ['crucians species complex']
+  aliases: []
   parents:
   - 49916
 44531:
-  aliases: ['freeborni species complex']
+  aliases: []
   parents:
   - 44486
 261162:
-  aliases: ['gigas species complex']
+  aliases: []
   parents:
   - 2993839
 261160:
-  aliases: ['lindesayi species complex']
+  aliases: []
   parents:
   - 2993838
 44532:
-  aliases: ['quadrimaculatus species complex']
+  aliases: []
   parents:
   - 44486
 1245357:
-  aliases: ['Anopheles baileyi']
+  aliases: []
   parents:
   - 2993840
 2993841:
-  aliases: ['Anopheles bhutanensis']
+  aliases: []
   parents:
   - 2993840
 232558:
-  aliases: ['Anopheles crucians A']
+  aliases: []
   parents:
   - 232555
 232559:
-  aliases: ['Anopheles crucians B']
+  aliases: []
   parents:
   - 232555
 247656:
-  aliases: ['Anopheles crucians C']
+  aliases: []
   parents:
   - 232555
 247657:
-  aliases: ['Anopheles crucians D']
+  aliases: []
   parents:
   - 232555
 247658:
-  aliases: ['Anopheles crucians E']
+  aliases: []
   parents:
   - 232555
 48724:
-  aliases: ['Anopheles dirus A']
+  aliases: []
   parents:
   - 7168
 7170:
-  aliases: ['Anopheles freeborni']
+  aliases: []
   parents:
   - 44531
 498620:
-  aliases: ['Anopheles gigas']
+  aliases: []
   parents:
   - 261162
 7171:
-  aliases: ['Anopheles hermsi']
+  aliases: []
   parents:
   - 44531
 2993853:
-  aliases: ['Anopheles inthanonensis']
+  aliases: []
   parents:
   - 2993840
 261161:
-  aliases: ['Anopheles lindesayi']
+  aliases: []
   parents:
   - 261160
 2993842:
-  aliases: ['Anopheles monticola']
+  aliases: []
   parents:
   - 2993840
 1708518:
-  aliases: ['Anopheles nilgiricus']
+  aliases: []
   parents:
   - 261160
 7166:
-  aliases: ['Anopheles quadrimaculatus']
+  aliases: []
   parents:
   - 44532
 42377:
-  aliases: ['Anopheles quadrimaculatus A']
+  aliases: []
   parents:
   - 44532
 42378:
-  aliases: ['Anopheles quadrimaculatus B']
+  aliases: []
   parents:
   - 44532
 49922:
-  aliases: ['Anopheles quadrimaculatus C']
+  aliases: []
   parents:
   - 44532
 42379:
-  aliases: ['Anopheles quadrimaculatus C1']
+  aliases: []
   parents:
   - 44532
 42380:
-  aliases: ['Anopheles quadrimaculatus C2']
+  aliases: []
   parents:
   - 44532
 42381:
-  aliases: ['Anopheles quadrimaculatus D']
+  aliases: []
   parents:
   - 44532
 3057578:
-  aliases: ['Anopheles gigas simlensis']
+  aliases: []
   parents:
   - 498620
 373689:
-  aliases: ['Anopheles lindesayi japonicus']
+  aliases: []
   parents:
   - 261161
 9397:
   aliases: ['Bats']
   parents: []
 30560:
-  aliases: ['Yangochiroptera']
+  aliases: []
   parents:
   - 9397
 30559:
-  aliases: ['Yinpterochiroptera']
+  aliases: []
   parents:
   - 9397
 1617257:
-  aliases: ['environmental samples']
+  aliases: []
   parents:
   - 9397
 727696:
-  aliases: ['unclassified Chiroptera']
+  aliases: []
   parents:
   - 9397
 2792177:
-  aliases: ['Chiroptera sp. B1002']
+  aliases: []
   parents:
   - 727696
 2792194:
-  aliases: ['Chiroptera sp. B1052']
+  aliases: []
   parents:
   - 727696
 2792202:
-  aliases: ['Chiroptera sp. B1342']
+  aliases: []
   parents:
   - 727696
 2792219:
-  aliases: ['Chiroptera sp. B1345']
+  aliases: []
   parents:
   - 727696
 2792220:
-  aliases: ['Chiroptera sp. B1349']
+  aliases: []
   parents:
   - 727696
 2792184:
-  aliases: ['Chiroptera sp. B1379']
+  aliases: []
   parents:
   - 727696
 2792178:
-  aliases: ['Chiroptera sp. B1398']
+  aliases: []
   parents:
   - 727696
 2792192:
-  aliases: ['Chiroptera sp. B1466']
+  aliases: []
   parents:
   - 727696
 2792198:
-  aliases: ['Chiroptera sp. B159']
+  aliases: []
   parents:
   - 727696
 2792179:
-  aliases: ['Chiroptera sp. B1682']
+  aliases: []
   parents:
   - 727696
 2792180:
-  aliases: ['Chiroptera sp. B1700']
+  aliases: []
   parents:
   - 727696
 2792181:
-  aliases: ['Chiroptera sp. B1707']
+  aliases: []
   parents:
   - 727696
 2792182:
-  aliases: ['Chiroptera sp. B1740']
+  aliases: []
   parents:
   - 727696
 2792173:
-  aliases: ['Chiroptera sp. B265']
+  aliases: []
   parents:
   - 727696
 2792186:
-  aliases: ['Chiroptera sp. B332']
+  aliases: []
   parents:
   - 727696
 2792218:
-  aliases: ['Chiroptera sp. B44']
+  aliases: []
   parents:
   - 727696
 2792174:
-  aliases: ['Chiroptera sp. B469']
+  aliases: []
   parents:
   - 727696
 2792215:
-  aliases: ['Chiroptera sp. B481']
+  aliases: []
   parents:
   - 727696
 2792216:
-  aliases: ['Chiroptera sp. B482']
+  aliases: []
   parents:
   - 727696
 2792191:
-  aliases: ['Chiroptera sp. B651']
+  aliases: []
   parents:
   - 727696
 2792204:
-  aliases: ['Chiroptera sp. B657']
+  aliases: []
   parents:
   - 727696
 2792175:
-  aliases: ['Chiroptera sp. B688']
+  aliases: []
   parents:
   - 727696
 2792207:
-  aliases: ['Chiroptera sp. B774']
+  aliases: []
   parents:
   - 727696
 2792188:
-  aliases: ['Chiroptera sp. B789']
+  aliases: []
   parents:
   - 727696
 2792205:
-  aliases: ['Chiroptera sp. B829']
+  aliases: []
   parents:
   - 727696
 2792171:
-  aliases: ['Chiroptera sp. B935']
+  aliases: []
   parents:
   - 727696
 2792176:
-  aliases: ['Chiroptera sp. B955']
+  aliases: []
   parents:
   - 727696
 2792206:
-  aliases: ['Chiroptera sp. B999']
+  aliases: []
   parents:
   - 727696
 816723:
-  aliases: ['Chiroptera sp. BOLD:AAA0002']
+  aliases: []
   parents:
   - 727696
 974259:
-  aliases: ['Chiroptera sp. BOLD:AAA0003']
+  aliases: []
   parents:
   - 727696
 816724:
-  aliases: ['Chiroptera sp. BOLD:AAA0874']
+  aliases: []
   parents:
   - 727696
 816725:
-  aliases: ['Chiroptera sp. BOLD:AAA1218']
+  aliases: []
   parents:
   - 727696
 816726:
-  aliases: ['Chiroptera sp. BOLD:AAA1219']
+  aliases: []
   parents:
   - 727696
 915892:
-  aliases: ['Chiroptera sp. BOLD:AAA1225']
+  aliases: []
   parents:
   - 727696
 816727:
-  aliases: ['Chiroptera sp. BOLD:AAA1245']
+  aliases: []
   parents:
   - 727696
 974260:
-  aliases: ['Chiroptera sp. BOLD:AAA1246']
+  aliases: []
   parents:
   - 727696
 915893:
-  aliases: ['Chiroptera sp. BOLD:AAA1247']
+  aliases: []
   parents:
   - 727696
 974261:
-  aliases: ['Chiroptera sp. BOLD:AAA1248']
+  aliases: []
   parents:
   - 727696
 915894:
-  aliases: ['Chiroptera sp. BOLD:AAA1268']
+  aliases: []
   parents:
   - 727696
 816728:
-  aliases: ['Chiroptera sp. BOLD:AAA1464']
+  aliases: []
   parents:
   - 727696
 915895:
-  aliases: ['Chiroptera sp. BOLD:AAA1465']
+  aliases: []
   parents:
   - 727696
 974262:
-  aliases: ['Chiroptera sp. BOLD:AAA1564']
+  aliases: []
   parents:
   - 727696
 816729:
-  aliases: ['Chiroptera sp. BOLD:AAA1667']
+  aliases: []
   parents:
   - 727696
 915896:
-  aliases: ['Chiroptera sp. BOLD:AAA2133']
+  aliases: []
   parents:
   - 727696
 915897:
-  aliases: ['Chiroptera sp. BOLD:AAA2159']
+  aliases: []
   parents:
   - 727696
 915898:
-  aliases: ['Chiroptera sp. BOLD:AAA2160']
+  aliases: []
   parents:
   - 727696
 816730:
-  aliases: ['Chiroptera sp. BOLD:AAA2242']
+  aliases: []
   parents:
   - 727696
 915899:
-  aliases: ['Chiroptera sp. BOLD:AAA2243']
+  aliases: []
   parents:
   - 727696
 915900:
-  aliases: ['Chiroptera sp. BOLD:AAA2244']
+  aliases: []
   parents:
   - 727696
 974263:
-  aliases: ['Chiroptera sp. BOLD:AAA2245']
+  aliases: []
   parents:
   - 727696
 915901:
-  aliases: ['Chiroptera sp. BOLD:AAA2293']
+  aliases: []
   parents:
   - 727696
 915902:
-  aliases: ['Chiroptera sp. BOLD:AAA2300']
+  aliases: []
   parents:
   - 727696
 915903:
-  aliases: ['Chiroptera sp. BOLD:AAA2332']
+  aliases: []
   parents:
   - 727696
 915904:
-  aliases: ['Chiroptera sp. BOLD:AAA2396']
+  aliases: []
   parents:
   - 727696
 974264:
-  aliases: ['Chiroptera sp. BOLD:AAA2454']
+  aliases: []
   parents:
   - 727696
 915905:
-  aliases: ['Chiroptera sp. BOLD:AAA2524']
+  aliases: []
   parents:
   - 727696
 816731:
-  aliases: ['Chiroptera sp. BOLD:AAA2574']
+  aliases: []
   parents:
   - 727696
 915906:
-  aliases: ['Chiroptera sp. BOLD:AAA2579']
+  aliases: []
   parents:
   - 727696
 915907:
-  aliases: ['Chiroptera sp. BOLD:AAA2648']
+  aliases: []
   parents:
   - 727696
 816732:
-  aliases: ['Chiroptera sp. BOLD:AAA2651']
+  aliases: []
   parents:
   - 727696
 915908:
-  aliases: ['Chiroptera sp. BOLD:AAA2653']
+  aliases: []
   parents:
   - 727696
 915909:
-  aliases: ['Chiroptera sp. BOLD:AAA2705']
+  aliases: []
   parents:
   - 727696
 816733:
-  aliases: ['Chiroptera sp. BOLD:AAA2799']
+  aliases: []
   parents:
   - 727696
 974265:
-  aliases: ['Chiroptera sp. BOLD:AAA2961']
+  aliases: []
   parents:
   - 727696
 974266:
-  aliases: ['Chiroptera sp. BOLD:AAA3113']
+  aliases: []
   parents:
   - 727696
 816734:
-  aliases: ['Chiroptera sp. BOLD:AAA3386']
+  aliases: []
   parents:
   - 727696
 816735:
-  aliases: ['Chiroptera sp. BOLD:AAA3811']
+  aliases: []
   parents:
   - 727696
 891568:
-  aliases: ['Chiroptera sp. BOLD:AAA4089']
+  aliases: []
   parents:
   - 727696
 1296574:
-  aliases: ['Chiroptera sp. BOLD:AAA4092']
+  aliases: []
   parents:
   - 727696
 915910:
-  aliases: ['Chiroptera sp. BOLD:AAA4162']
+  aliases: []
   parents:
   - 727696
 816736:
-  aliases: ['Chiroptera sp. BOLD:AAA4283']
+  aliases: []
   parents:
   - 727696
 974267:
-  aliases: ['Chiroptera sp. BOLD:AAA4430']
+  aliases: []
   parents:
   - 727696
 915911:
-  aliases: ['Chiroptera sp. BOLD:AAA4431']
+  aliases: []
   parents:
   - 727696
 915912:
-  aliases: ['Chiroptera sp. BOLD:AAA4504']
+  aliases: []
   parents:
   - 727696
 974268:
-  aliases: ['Chiroptera sp. BOLD:AAA4512']
+  aliases: []
   parents:
   - 727696
 974269:
-  aliases: ['Chiroptera sp. BOLD:AAA5412']
+  aliases: []
   parents:
   - 727696
 915913:
-  aliases: ['Chiroptera sp. BOLD:AAA5413']
+  aliases: []
   parents:
   - 727696
 915914:
-  aliases: ['Chiroptera sp. BOLD:AAA5616']
+  aliases: []
   parents:
   - 727696
 816737:
-  aliases: ['Chiroptera sp. BOLD:AAA5873']
+  aliases: []
   parents:
   - 727696
 974270:
-  aliases: ['Chiroptera sp. BOLD:AAA5902']
+  aliases: []
   parents:
   - 727696
 816738:
-  aliases: ['Chiroptera sp. BOLD:AAA5920']
+  aliases: []
   parents:
   - 727696
 974271:
-  aliases: ['Chiroptera sp. BOLD:AAA6041']
+  aliases: []
   parents:
   - 727696
 974272:
-  aliases: ['Chiroptera sp. BOLD:AAA6103']
+  aliases: []
   parents:
   - 727696
 816739:
-  aliases: ['Chiroptera sp. BOLD:AAA6105']
+  aliases: []
   parents:
   - 727696
 915915:
-  aliases: ['Chiroptera sp. BOLD:AAA6335']
+  aliases: []
   parents:
   - 727696
 1067767:
-  aliases: ['Chiroptera sp. BOLD:AAA6350']
+  aliases: []
   parents:
   - 727696
 915916:
-  aliases: ['Chiroptera sp. BOLD:AAA6450']
+  aliases: []
   parents:
   - 727696
 1158966:
-  aliases: ['Chiroptera sp. BOLD:AAA6452']
+  aliases: []
   parents:
   - 727696
 915917:
-  aliases: ['Chiroptera sp. BOLD:AAA6499']
+  aliases: []
   parents:
   - 727696
 915918:
-  aliases: ['Chiroptera sp. BOLD:AAA7459']
+  aliases: []
   parents:
   - 727696
 915919:
-  aliases: ['Chiroptera sp. BOLD:AAA7734']
+  aliases: []
   parents:
   - 727696
 974273:
-  aliases: ['Chiroptera sp. BOLD:AAA7750']
+  aliases: []
   parents:
   - 727696
 816740:
-  aliases: ['Chiroptera sp. BOLD:AAA7783']
+  aliases: []
   parents:
   - 727696
 974274:
-  aliases: ['Chiroptera sp. BOLD:AAA8314']
+  aliases: []
   parents:
   - 727696
 915920:
-  aliases: ['Chiroptera sp. BOLD:AAA8683']
+  aliases: []
   parents:
   - 727696
 816741:
-  aliases: ['Chiroptera sp. BOLD:AAA8747']
+  aliases: []
   parents:
   - 727696
 891570:
-  aliases: ['Chiroptera sp. BOLD:AAA8748']
+  aliases: []
   parents:
   - 727696
 1067768:
-  aliases: ['Chiroptera sp. BOLD:AAA8809']
+  aliases: []
   parents:
   - 727696
 915921:
-  aliases: ['Chiroptera sp. BOLD:AAA9061']
+  aliases: []
   parents:
   - 727696
 816742:
-  aliases: ['Chiroptera sp. BOLD:AAA9064']
+  aliases: []
   parents:
   - 727696
 974275:
-  aliases: ['Chiroptera sp. BOLD:AAA9090']
+  aliases: []
   parents:
   - 727696
 974276:
-  aliases: ['Chiroptera sp. BOLD:AAA9168']
+  aliases: []
   parents:
   - 727696
 816743:
-  aliases: ['Chiroptera sp. BOLD:AAA9336']
+  aliases: []
   parents:
   - 727696
 915922:
-  aliases: ['Chiroptera sp. BOLD:AAA9642']
+  aliases: []
   parents:
   - 727696
 1067769:
-  aliases: ['Chiroptera sp. BOLD:AAA9800']
+  aliases: []
   parents:
   - 727696
 816744:
-  aliases: ['Chiroptera sp. BOLD:AAA9952']
+  aliases: []
   parents:
   - 727696
 816745:
-  aliases: ['Chiroptera sp. BOLD:AAB1237']
+  aliases: []
   parents:
   - 727696
 974277:
-  aliases: ['Chiroptera sp. BOLD:AAB1868']
+  aliases: []
   parents:
   - 727696
 974278:
-  aliases: ['Chiroptera sp. BOLD:AAB1869']
+  aliases: []
   parents:
   - 727696
 816746:
-  aliases: ['Chiroptera sp. BOLD:AAB2554']
+  aliases: []
   parents:
   - 727696
 974279:
-  aliases: ['Chiroptera sp. BOLD:AAB2719']
+  aliases: []
   parents:
   - 727696
 915923:
-  aliases: ['Chiroptera sp. BOLD:AAB2781']
+  aliases: []
   parents:
   - 727696
 1067770:
-  aliases: ['Chiroptera sp. BOLD:AAB3099']
+  aliases: []
   parents:
   - 727696
 816747:
-  aliases: ['Chiroptera sp. BOLD:AAB3205']
+  aliases: []
   parents:
   - 727696
 974280:
-  aliases: ['Chiroptera sp. BOLD:AAB4238']
+  aliases: []
   parents:
   - 727696
 816748:
-  aliases: ['Chiroptera sp. BOLD:AAB4312']
+  aliases: []
   parents:
   - 727696
 816749:
-  aliases: ['Chiroptera sp. BOLD:AAB4668']
+  aliases: []
   parents:
   - 727696
 816750:
-  aliases: ['Chiroptera sp. BOLD:AAB4801']
+  aliases: []
   parents:
   - 727696
 816751:
-  aliases: ['Chiroptera sp. BOLD:AAB4878']
+  aliases: []
   parents:
   - 727696
 915924:
-  aliases: ['Chiroptera sp. BOLD:AAB5104']
+  aliases: []
   parents:
   - 727696
 915925:
-  aliases: ['Chiroptera sp. BOLD:AAB5595']
+  aliases: []
   parents:
   - 727696
 816752:
-  aliases: ['Chiroptera sp. BOLD:AAB5742']
+  aliases: []
   parents:
   - 727696
 974281:
-  aliases: ['Chiroptera sp. BOLD:AAB5743']
+  aliases: []
   parents:
   - 727696
 974282:
-  aliases: ['Chiroptera sp. BOLD:AAB5807']
+  aliases: []
   parents:
   - 727696
 816753:
-  aliases: ['Chiroptera sp. BOLD:AAB5809']
+  aliases: []
   parents:
   - 727696
 974283:
-  aliases: ['Chiroptera sp. BOLD:AAB5823']
+  aliases: []
   parents:
   - 727696
 915926:
-  aliases: ['Chiroptera sp. BOLD:AAB6222']
+  aliases: []
   parents:
   - 727696
 1067771:
-  aliases: ['Chiroptera sp. BOLD:AAB6224']
+  aliases: []
   parents:
   - 727696
 974284:
-  aliases: ['Chiroptera sp. BOLD:AAB6385']
+  aliases: []
   parents:
   - 727696
 974285:
-  aliases: ['Chiroptera sp. BOLD:AAB6408']
+  aliases: []
   parents:
   - 727696
 915927:
-  aliases: ['Chiroptera sp. BOLD:AAB6783']
+  aliases: []
   parents:
   - 727696
 816754:
-  aliases: ['Chiroptera sp. BOLD:AAB7229']
+  aliases: []
   parents:
   - 727696
 816755:
-  aliases: ['Chiroptera sp. BOLD:AAB7230']
+  aliases: []
   parents:
   - 727696
 816756:
-  aliases: ['Chiroptera sp. BOLD:AAB8126']
+  aliases: []
   parents:
   - 727696
 891572:
-  aliases: ['Chiroptera sp. BOLD:AAB8309']
+  aliases: []
   parents:
   - 727696
 974286:
-  aliases: ['Chiroptera sp. BOLD:AAB8311']
+  aliases: []
   parents:
   - 727696
 974287:
-  aliases: ['Chiroptera sp. BOLD:AAB9060']
+  aliases: []
   parents:
   - 727696
 816757:
-  aliases: ['Chiroptera sp. BOLD:AAB9061']
+  aliases: []
   parents:
   - 727696
 891573:
-  aliases: ['Chiroptera sp. BOLD:AAB9127']
+  aliases: []
   parents:
   - 727696
 891574:
-  aliases: ['Chiroptera sp. BOLD:AAB9238']
+  aliases: []
   parents:
   - 727696
 974288:
-  aliases: ['Chiroptera sp. BOLD:AAB9572']
+  aliases: []
   parents:
   - 727696
 974289:
-  aliases: ['Chiroptera sp. BOLD:AAB9950']
+  aliases: []
   parents:
   - 727696
 816758:
-  aliases: ['Chiroptera sp. BOLD:AAB9974']
+  aliases: []
   parents:
   - 727696
 816759:
-  aliases: ['Chiroptera sp. BOLD:AAC0085']
+  aliases: []
   parents:
   - 727696
 974290:
-  aliases: ['Chiroptera sp. BOLD:AAC0447']
+  aliases: []
   parents:
   - 727696
 974291:
-  aliases: ['Chiroptera sp. BOLD:AAC0448']
+  aliases: []
   parents:
   - 727696
 816760:
-  aliases: ['Chiroptera sp. BOLD:AAC1209']
+  aliases: []
   parents:
   - 727696
 816761:
-  aliases: ['Chiroptera sp. BOLD:AAC1210']
+  aliases: []
   parents:
   - 727696
 1067772:
-  aliases: ['Chiroptera sp. BOLD:AAC1299']
+  aliases: []
   parents:
   - 727696
 816762:
-  aliases: ['Chiroptera sp. BOLD:AAC1494']
+  aliases: []
   parents:
   - 727696
 816763:
-  aliases: ['Chiroptera sp. BOLD:AAC1895']
+  aliases: []
   parents:
   - 727696
 816764:
-  aliases: ['Chiroptera sp. BOLD:AAC1909']
+  aliases: []
   parents:
   - 727696
 816765:
-  aliases: ['Chiroptera sp. BOLD:AAC2754']
+  aliases: []
   parents:
   - 727696
 915928:
-  aliases: ['Chiroptera sp. BOLD:AAC2864']
+  aliases: []
   parents:
   - 727696
 974292:
-  aliases: ['Chiroptera sp. BOLD:AAC2867']
+  aliases: []
   parents:
   - 727696
 816766:
-  aliases: ['Chiroptera sp. BOLD:AAC2946']
+  aliases: []
   parents:
   - 727696
 816767:
-  aliases: ['Chiroptera sp. BOLD:AAC2947']
+  aliases: []
   parents:
   - 727696
 891575:
-  aliases: ['Chiroptera sp. BOLD:AAC3088']
+  aliases: []
   parents:
   - 727696
 974293:
-  aliases: ['Chiroptera sp. BOLD:AAC3741']
+  aliases: []
   parents:
   - 727696
 974294:
-  aliases: ['Chiroptera sp. BOLD:AAC3742']
+  aliases: []
   parents:
   - 727696
 915929:
-  aliases: ['Chiroptera sp. BOLD:AAC4061']
+  aliases: []
   parents:
   - 727696
 816768:
-  aliases: ['Chiroptera sp. BOLD:AAC4219']
+  aliases: []
   parents:
   - 727696
 816769:
-  aliases: ['Chiroptera sp. BOLD:AAC4846']
+  aliases: []
   parents:
   - 727696
 974295:
-  aliases: ['Chiroptera sp. BOLD:AAC5354']
+  aliases: []
   parents:
   - 727696
 974296:
-  aliases: ['Chiroptera sp. BOLD:AAC5425']
+  aliases: []
   parents:
   - 727696
 816770:
-  aliases: ['Chiroptera sp. BOLD:AAC5514']
+  aliases: []
   parents:
   - 727696
 816771:
-  aliases: ['Chiroptera sp. BOLD:AAC5524']
+  aliases: []
   parents:
   - 727696
 1067773:
-  aliases: ['Chiroptera sp. BOLD:AAC7539']
+  aliases: []
   parents:
   - 727696
 891576:
-  aliases: ['Chiroptera sp. BOLD:AAC8422']
+  aliases: []
   parents:
   - 727696
 974297:
-  aliases: ['Chiroptera sp. BOLD:AAC8894']
+  aliases: []
   parents:
   - 727696
 816772:
-  aliases: ['Chiroptera sp. BOLD:AAC9465']
+  aliases: []
   parents:
   - 727696
 891577:
-  aliases: ['Chiroptera sp. BOLD:AAC9527']
+  aliases: []
   parents:
   - 727696
 974298:
-  aliases: ['Chiroptera sp. BOLD:AAC9705']
+  aliases: []
   parents:
   - 727696
 1067774:
-  aliases: ['Chiroptera sp. BOLD:AAC9992']
+  aliases: []
   parents:
   - 727696
 1067775:
-  aliases: ['Chiroptera sp. BOLD:AAD1297']
+  aliases: []
   parents:
   - 727696
 1067776:
-  aliases: ['Chiroptera sp. BOLD:AAD1601']
+  aliases: []
   parents:
   - 727696
 816773:
-  aliases: ['Chiroptera sp. BOLD:AAD2238']
+  aliases: []
   parents:
   - 727696
 974299:
-  aliases: ['Chiroptera sp. BOLD:AAD3719']
+  aliases: []
   parents:
   - 727696
 915930:
-  aliases: ['Chiroptera sp. BOLD:AAD3874']
+  aliases: []
   parents:
   - 727696
 1067777:
-  aliases: ['Chiroptera sp. BOLD:AAD4873']
+  aliases: []
   parents:
   - 727696
 974300:
-  aliases: ['Chiroptera sp. BOLD:AAD6578']
+  aliases: []
   parents:
   - 727696
 974301:
-  aliases: ['Chiroptera sp. BOLD:AAD6796']
+  aliases: []
   parents:
   - 727696
 816774:
-  aliases: ['Chiroptera sp. BOLD:AAD6797']
+  aliases: []
   parents:
   - 727696
 816775:
-  aliases: ['Chiroptera sp. BOLD:AAD6799']
+  aliases: []
   parents:
   - 727696
 816776:
-  aliases: ['Chiroptera sp. BOLD:AAD7561']
+  aliases: []
   parents:
   - 727696
 816777:
-  aliases: ['Chiroptera sp. BOLD:AAD7720']
+  aliases: []
   parents:
   - 727696
 1067778:
-  aliases: ['Chiroptera sp. BOLD:AAD8132']
+  aliases: []
   parents:
   - 727696
 816778:
-  aliases: ['Chiroptera sp. BOLD:AAD8838']
+  aliases: []
   parents:
   - 727696
 915931:
-  aliases: ['Chiroptera sp. BOLD:AAD9402']
+  aliases: []
   parents:
   - 727696
 915932:
-  aliases: ['Chiroptera sp. BOLD:AAE0577']
+  aliases: []
   parents:
   - 727696
 915933:
-  aliases: ['Chiroptera sp. BOLD:AAE1185']
+  aliases: []
   parents:
   - 727696
 816779:
-  aliases: ['Chiroptera sp. BOLD:AAE3205']
+  aliases: []
   parents:
   - 727696
 974302:
-  aliases: ['Chiroptera sp. BOLD:AAE5107']
+  aliases: []
   parents:
   - 727696
 974303:
-  aliases: ['Chiroptera sp. BOLD:AAE6507']
+  aliases: []
   parents:
   - 727696
 1067779:
-  aliases: ['Chiroptera sp. BOLD:AAE6670']
+  aliases: []
   parents:
   - 727696
 915934:
-  aliases: ['Chiroptera sp. BOLD:AAE7621']
+  aliases: []
   parents:
   - 727696
 974304:
-  aliases: ['Chiroptera sp. BOLD:AAE8331']
+  aliases: []
   parents:
   - 727696
 974305:
-  aliases: ['Chiroptera sp. BOLD:AAF1080']
+  aliases: []
   parents:
   - 727696
 974306:
-  aliases: ['Chiroptera sp. BOLD:AAF3921']
+  aliases: []
   parents:
   - 727696
 816780:
-  aliases: ['Chiroptera sp. BOLD:AAF5010']
+  aliases: []
   parents:
   - 727696
 816781:
-  aliases: ['Chiroptera sp. BOLD:AAF5109']
+  aliases: []
   parents:
   - 727696
 891585:
-  aliases: ['Chiroptera sp. BOLD:AAF5805']
+  aliases: []
   parents:
   - 727696
 1067780:
-  aliases: ['Chiroptera sp. BOLD:AAH8358']
+  aliases: []
   parents:
   - 727696
 816782:
-  aliases: ['Chiroptera sp. BOLD:AAI3440']
+  aliases: []
   parents:
   - 727696
 816783:
-  aliases: ['Chiroptera sp. BOLD:AAI6650']
+  aliases: []
   parents:
   - 727696
 816784:
-  aliases: ['Chiroptera sp. BOLD:AAI8257']
+  aliases: []
   parents:
   - 727696
 974307:
-  aliases: ['Chiroptera sp. BOLD:AAJ0261']
+  aliases: []
   parents:
   - 727696
 816785:
-  aliases: ['Chiroptera sp. BOLD:AAJ2519']
+  aliases: []
   parents:
   - 727696
 974308:
-  aliases: ['Chiroptera sp. BOLD:AAJ2726']
+  aliases: []
   parents:
   - 727696
 974309:
-  aliases: ['Chiroptera sp. BOLD:AAJ3874']
+  aliases: []
   parents:
   - 727696
 816786:
-  aliases: ['Chiroptera sp. BOLD:AAJ4556']
+  aliases: []
   parents:
   - 727696
 974310:
-  aliases: ['Chiroptera sp. BOLD:AAK0536']
+  aliases: []
   parents:
   - 727696
 974311:
-  aliases: ['Chiroptera sp. BOLD:AAK5959']
+  aliases: []
   parents:
   - 727696
 974312:
-  aliases: ['Chiroptera sp. BOLD:AAK6473']
+  aliases: []
   parents:
   - 727696
 816787:
-  aliases: ['Chiroptera sp. BOLD:AAK7760']
+  aliases: []
   parents:
   - 727696
 816788:
-  aliases: ['Chiroptera sp. BOLD:AAK8598']
+  aliases: []
   parents:
   - 727696
 1067781:
-  aliases: ['Chiroptera sp. BOLD:AAK8797']
+  aliases: []
   parents:
   - 727696
 974313:
-  aliases: ['Chiroptera sp. BOLD:AAK9006']
+  aliases: []
   parents:
   - 727696
 816789:
-  aliases: ['Chiroptera sp. BOLD:AAL4116']
+  aliases: []
   parents:
   - 727696
 891589:
-  aliases: ['Chiroptera sp. BOLD:AAL5772']
+  aliases: []
   parents:
   - 727696
 891590:
-  aliases: ['Chiroptera sp. BOLD:AAL5777']
+  aliases: []
   parents:
   - 727696
 891591:
-  aliases: ['Chiroptera sp. BOLD:AAM0883']
+  aliases: []
   parents:
   - 727696
 915935:
-  aliases: ['Chiroptera sp. BOLD:AAM2888']
+  aliases: []
   parents:
   - 727696
 915936:
-  aliases: ['Chiroptera sp. BOLD:AAM4700']
+  aliases: []
   parents:
   - 727696
 915937:
-  aliases: ['Chiroptera sp. BOLD:AAM7559']
+  aliases: []
   parents:
   - 727696
 974314:
-  aliases: ['Chiroptera sp. BOLD:AAN2509']
+  aliases: []
   parents:
   - 727696
 974315:
-  aliases: ['Chiroptera sp. BOLD:AAN2514']
+  aliases: []
   parents:
   - 727696
 974316:
-  aliases: ['Chiroptera sp. BOLD:AAN2561']
+  aliases: []
   parents:
   - 727696
 974317:
-  aliases: ['Chiroptera sp. BOLD:AAN2666']
+  aliases: []
   parents:
   - 727696
 974318:
-  aliases: ['Chiroptera sp. BOLD:AAN2669']
+  aliases: []
   parents:
   - 727696
 974319:
-  aliases: ['Chiroptera sp. BOLD:AAN2670']
+  aliases: []
   parents:
   - 727696
 974320:
-  aliases: ['Chiroptera sp. BOLD:AAN2671']
+  aliases: []
   parents:
   - 727696
 974321:
-  aliases: ['Chiroptera sp. BOLD:AAN2688']
+  aliases: []
   parents:
   - 727696
 974322:
-  aliases: ['Chiroptera sp. BOLD:AAN2818']
+  aliases: []
   parents:
   - 727696
 974323:
-  aliases: ['Chiroptera sp. BOLD:AAN2861']
+  aliases: []
   parents:
   - 727696
 974324:
-  aliases: ['Chiroptera sp. BOLD:AAN3075']
+  aliases: []
   parents:
   - 727696
 974325:
-  aliases: ['Chiroptera sp. BOLD:AAN3259']
+  aliases: []
   parents:
   - 727696
 974326:
-  aliases: ['Chiroptera sp. BOLD:AAN3348']
+  aliases: []
   parents:
   - 727696
 974327:
-  aliases: ['Chiroptera sp. BOLD:AAN3459']
+  aliases: []
   parents:
   - 727696
 974328:
-  aliases: ['Chiroptera sp. BOLD:AAN3808']
+  aliases: []
   parents:
   - 727696
 974329:
-  aliases: ['Chiroptera sp. BOLD:AAN4101']
+  aliases: []
   parents:
   - 727696
 974330:
-  aliases: ['Chiroptera sp. BOLD:AAN9716']
+  aliases: []
   parents:
   - 727696
 974331:
-  aliases: ['Chiroptera sp. BOLD:AAN9771']
+  aliases: []
   parents:
   - 727696
 974332:
-  aliases: ['Chiroptera sp. BOLD:AAN9773']
+  aliases: []
   parents:
   - 727696
 974333:
-  aliases: ['Chiroptera sp. BOLD:AAN9981']
+  aliases: []
   parents:
   - 727696
 974334:
-  aliases: ['Chiroptera sp. BOLD:AAO0822']
+  aliases: []
   parents:
   - 727696
 974335:
-  aliases: ['Chiroptera sp. BOLD:AAO1393']
+  aliases: []
   parents:
   - 727696
 974336:
-  aliases: ['Chiroptera sp. BOLD:AAO1562']
+  aliases: []
   parents:
   - 727696
 974337:
-  aliases: ['Chiroptera sp. BOLD:AAO1567']
+  aliases: []
   parents:
   - 727696
 974338:
-  aliases: ['Chiroptera sp. BOLD:AAO1629']
+  aliases: []
   parents:
   - 727696
 1067782:
-  aliases: ['Chiroptera sp. BOLD:AAO1765']
+  aliases: []
   parents:
   - 727696
 974339:
-  aliases: ['Chiroptera sp. BOLD:AAO1832']
+  aliases: []
   parents:
   - 727696
 974340:
-  aliases: ['Chiroptera sp. BOLD:AAO2468']
+  aliases: []
   parents:
   - 727696
 974341:
-  aliases: ['Chiroptera sp. BOLD:AAO2496']
+  aliases: []
   parents:
   - 727696
 1067783:
-  aliases: ['Chiroptera sp. BOLD:AAU3776']
+  aliases: []
   parents:
   - 727696
 1067784:
-  aliases: ['Chiroptera sp. BOLD:AAU3777']
+  aliases: []
   parents:
   - 727696
 2792214:
-  aliases: ['Chiroptera sp. M1109']
+  aliases: []
   parents:
   - 727696
 2792203:
-  aliases: ['Chiroptera sp. M1121']
+  aliases: []
   parents:
   - 727696
 2792217:
-  aliases: ['Chiroptera sp. M1130']
+  aliases: []
   parents:
   - 727696
 2792187:
-  aliases: ['Chiroptera sp. M1148']
+  aliases: []
   parents:
   - 727696
 2792196:
-  aliases: ['Chiroptera sp. M222']
+  aliases: []
   parents:
   - 727696
 2792189:
-  aliases: ['Chiroptera sp. M308']
+  aliases: []
   parents:
   - 727696
 2792195:
-  aliases: ['Chiroptera sp. M437']
+  aliases: []
   parents:
   - 727696
 2792197:
-  aliases: ['Chiroptera sp. M468']
+  aliases: []
   parents:
   - 727696
 2792190:
-  aliases: ['Chiroptera sp. M48']
+  aliases: []
   parents:
   - 727696
 2792208:
-  aliases: ['Chiroptera sp. M489']
+  aliases: []
   parents:
   - 727696
 2792199:
-  aliases: ['Chiroptera sp. M493']
+  aliases: []
   parents:
   - 727696
 2792209:
-  aliases: ['Chiroptera sp. M494']
+  aliases: []
   parents:
   - 727696
 2792200:
-  aliases: ['Chiroptera sp. M496']
+  aliases: []
   parents:
   - 727696
 2792210:
-  aliases: ['Chiroptera sp. M500']
+  aliases: []
   parents:
   - 727696
 2792185:
-  aliases: ['Chiroptera sp. M591']
+  aliases: []
   parents:
   - 727696
 2792193:
-  aliases: ['Chiroptera sp. M60']
+  aliases: []
   parents:
   - 727696
 2792211:
-  aliases: ['Chiroptera sp. M820']
+  aliases: []
   parents:
   - 727696
 2792212:
-  aliases: ['Chiroptera sp. M826']
+  aliases: []
   parents:
   - 727696
 2792201:
-  aliases: ['Chiroptera sp. M828']
+  aliases: []
   parents:
   - 727696
 2792172:
-  aliases: ['Chiroptera sp. M853']
+  aliases: []
   parents:
   - 727696
 2792213:
-  aliases: ['Chiroptera sp. M865']
+  aliases: []
   parents:
   - 727696
 2792183:
-  aliases: ['Chiroptera sp. M886']
+  aliases: []
   parents:
   - 727696
 2676382:
-  aliases: ['Chiroptera sp. MI-2019']
+  aliases: []
   parents:
   - 727696
 3418545:
-  aliases: ['Chiroptera sp. n. RL-2025']
+  aliases: []
   parents:
   - 727696
 3136025:
-  aliases: ['Cistugidae']
+  aliases: []
   parents:
   - 30560
 30562:
-  aliases: ['Emballonuridae']
+  aliases: []
   parents:
   - 30560
 148080:
-  aliases: ['Furipteridae']
+  aliases: []
   parents:
   - 30560
 981671:
-  aliases: ['Miniopteridae']
+  aliases: []
   parents:
   - 30560
 9436:
-  aliases: ['Molossidae']
+  aliases: []
   parents:
   - 30560
 59445:
-  aliases: ['Mormoopidae']
+  aliases: []
   parents:
   - 30560
 94959:
-  aliases: ['Mystacinidae']
+  aliases: []
   parents:
   - 30560
 155036:
-  aliases: ['Myzopodidae']
+  aliases: []
   parents:
   - 30560
 59446:
-  aliases: ['Natalidae']
+  aliases: []
   parents:
   - 30560
 94957:
-  aliases: ['Noctilionidae']
+  aliases: []
   parents:
   - 30560
 59447:
-  aliases: ['Nycteridae']
+  aliases: []
   parents:
   - 30560
 9415:
-  aliases: ['Phyllostomidae']
+  aliases: []
   parents:
   - 30560
 3136023:
-  aliases: ['Pteropodoidea']
+  aliases: []
   parents:
   - 30559
 3136022:
-  aliases: ['Rhinolophoidea']
+  aliases: []
   parents:
   - 30559
 124757:
-  aliases: ['Thyropteridae']
+  aliases: []
   parents:
   - 30560
 9431:
-  aliases: ['Vespertilionidae']
+  aliases: []
   parents:
   - 30560
 1617258:
-  aliases: ['bat environmental sample']
+  aliases: []
   parents:
   - 1617257
 2778563:
-  aliases: ['Afronycteris']
+  aliases: []
   parents:
   - 9431
 3685292:
-  aliases: ['Afropipistrellus']
+  aliases: []
   parents:
   - 9431
 9439:
-  aliases: ['Antrozous']
+  aliases: []
   parents:
   - 9431
 526815:
-  aliases: ['Arielulus']
+  aliases: []
   parents:
   - 9431
 3072824:
-  aliases: ['Baeodon']
+  aliases: []
   parents:
   - 9431
 59448:
-  aliases: ['Barbastella']
+  aliases: []
   parents:
   - 9431
 3135596:
-  aliases: ['Bauerus']
+  aliases: []
   parents:
   - 9431
 40235:
-  aliases: ['Brachyphyllinae']
+  aliases: []
   parents:
   - 9415
 40231:
-  aliases: ['Carolliinae']
+  aliases: []
   parents:
   - 9415
 2069572:
-  aliases: ['Cassistrellus']
+  aliases: []
   parents:
   - 9431
 50352:
-  aliases: ['Chalinolobus']
+  aliases: []
   parents:
   - 9431
 270767:
-  aliases: ['Cheiromeles']
+  aliases: []
   parents:
   - 9436
 290567:
-  aliases: ['Chilonatalus']
+  aliases: []
   parents:
   - 59446
 712047:
-  aliases: ['Cistugo']
+  aliases: []
   parents:
   - 3136025
 29077:
-  aliases: ['Cnephaeus']
+  aliases: []
   parents:
   - 9431
 233861:
-  aliases: ['Corynorhinus']
+  aliases: []
   parents:
   - 9431
 217614:
-  aliases: ['Craseonycteridae']
+  aliases: []
   parents:
   - 3136022
 303306:
-  aliases: ['Cynomops']
+  aliases: []
   parents:
   - 9436
 40237:
-  aliases: ['Desmodontinae']
+  aliases: []
   parents:
   - 9415
 461394:
-  aliases: ['Emballonurinae']
+  aliases: []
   parents:
   - 30562
 3371007:
-  aliases: ['Eptesicus']
+  aliases: []
   parents:
   - 9431
 153290:
-  aliases: ['Euderma']
+  aliases: []
   parents:
   - 9431
 633650:
-  aliases: ['Eudiscopus']
+  aliases: []
   parents:
   - 9431
 27618:
-  aliases: ['Eumops']
+  aliases: []
   parents:
   - 9436
 1310229:
-  aliases: ['Falsistrellus']
+  aliases: []
   parents:
   - 9431
 148081:
-  aliases: ['Furipterus']
+  aliases: []
   parents:
   - 148080
 909366:
-  aliases: ['Glauconycteris']
+  aliases: []
   parents:
   - 9431
 526817:
-  aliases: ['Glischropus']
+  aliases: []
   parents:
   - 9431
 40236:
-  aliases: ['Glossophaginae']
+  aliases: []
   parents:
   - 9415
 124748:
-  aliases: ['Harpiocephalus']
+  aliases: []
   parents:
   - 9431
 685776:
-  aliases: ['Harpiola']
+  aliases: []
   parents:
   - 9431
 526819:
-  aliases: ['Hesperoptenus']
+  aliases: []
   parents:
   - 9431
 186994:
-  aliases: ['Hipposideridae']
+  aliases: []
   parents:
   - 3136022
 258918:
-  aliases: ['Histiotus']
+  aliases: []
   parents:
   - 9431
 109484:
-  aliases: ['Hypsugo']
+  aliases: []
   parents:
   - 9431
 360966:
-  aliases: ['Ia']
+  aliases: []
   parents:
   - 9431
 27664:
-  aliases: ['Idionycteris']
+  aliases: []
   parents:
   - 9431
 59454:
-  aliases: ['Kerivoula']
+  aliases: []
   parents:
   - 9431
 258926:
-  aliases: ['Laephotis']
+  aliases: []
   parents:
   - 9431
 27666:
-  aliases: ['Lasionycteris']
+  aliases: []
   parents:
   - 9431
 72130:
-  aliases: ['Lasiurus']
+  aliases: []
   parents:
   - 9431
 138703:
-  aliases: ['Lonchophyllinae']
+  aliases: []
   parents:
   - 9415
 9409:
-  aliases: ['Megadermatidae']
+  aliases: []
   parents:
   - 3136022
 3371053:
-  aliases: ['Micronomus']
+  aliases: []
   parents:
   - 9436
 2093333:
-  aliases: ['Mimetillus']
+  aliases: []
   parents:
   - 9431
 9432:
-  aliases: ['Miniopterus']
+  aliases: []
   parents:
   - 981671
 2741457:
-  aliases: ['Mirostrellus']
+  aliases: []
   parents:
   - 9431
 249031:
-  aliases: ['Molossops']
+  aliases: []
   parents:
   - 9436
 27621:
-  aliases: ['Molossus']
+  aliases: []
   parents:
   - 9436
 258862:
-  aliases: ['Mops']
+  aliases: []
   parents:
   - 9436
 59459:
-  aliases: ['Mormoops']
+  aliases: []
   parents:
   - 59445
 27623:
-  aliases: ['Mormopterus']
+  aliases: []
   parents:
   - 9436
 59488:
-  aliases: ['Murina']
+  aliases: []
   parents:
   - 9431
 1115869:
-  aliases: ['Myopterus']
+  aliases: []
   parents:
   - 9436
 9434:
-  aliases: ['Myotis']
+  aliases: []
   parents:
   - 9431
 94960:
-  aliases: ['Mystacina']
+  aliases: []
   parents:
   - 94959
 155037:
-  aliases: ['Myzopoda']
+  aliases: []
   parents:
   - 155036
 59486:
-  aliases: ['Natalus']
+  aliases: []
   parents:
   - 59446
 3371080:
-  aliases: ['Neoeptesicus']
+  aliases: []
   parents:
   - 9431
 3111555:
-  aliases: ['Neoplatymops']
+  aliases: []
   parents:
   - 9436
 568926:
-  aliases: ['Neoromicia']
+  aliases: []
   parents:
   - 9431
 94958:
-  aliases: ['Noctilio']
+  aliases: []
   parents:
   - 94957
 51299:
-  aliases: ['Nyctalus']
+  aliases: []
   parents:
   - 9431
 59466:
-  aliases: ['Nycteris']
+  aliases: []
   parents:
   - 59447
 59468:
-  aliases: ['Nycticeinops']
+  aliases: []
   parents:
   - 9431
 27669:
-  aliases: ['Nycticeius']
+  aliases: []
   parents:
   - 9431
 290565:
-  aliases: ['Nyctiellus']
+  aliases: []
   parents:
   - 59446
 27625:
-  aliases: ['Nyctinomops']
+  aliases: []
   parents:
   - 9436
 59470:
-  aliases: ['Nyctophilus']
+  aliases: []
   parents:
   - 9431
 258866:
-  aliases: ['Otomops']
+  aliases: []
   parents:
   - 9436
 153292:
-  aliases: ['Otonycteris']
+  aliases: []
   parents:
   - 9431
 2689069:
-  aliases: ['Ozimops']
+  aliases: []
   parents:
   - 9436
 712815:
-  aliases: ['Parastrellus']
+  aliases: []
   parents:
   - 9431
 3371047:
-  aliases: ['Paremballonura']
+  aliases: []
   parents:
   - 30562
 2057181:
-  aliases: ['Perimyotis']
+  aliases: []
   parents:
   - 9431
 867863:
-  aliases: ['Philetor']
+  aliases: []
   parents:
   - 9431
 867874:
-  aliases: ['Phoniscus']
+  aliases: []
   parents:
   - 9431
 138700:
-  aliases: ['Phyllonycterinae']
+  aliases: []
   parents:
   - 9415
 40238:
-  aliases: ['Phyllostominae']
+  aliases: []
   parents:
   - 9415
 27671:
-  aliases: ['Pipistrellus']
+  aliases: []
   parents:
   - 9431
 27673:
-  aliases: ['Plecotus']
+  aliases: []
   parents:
   - 9431
 27628:
-  aliases: ['Promops']
+  aliases: []
   parents:
   - 9436
 2778566:
-  aliases: ['Pseudoromicia']
+  aliases: []
   parents:
   - 9431
 59475:
-  aliases: ['Pteronotus']
+  aliases: []
   parents:
   - 59445
 9398:
-  aliases: ['Pteropodidae']
+  aliases: []
   parents:
   - 3136023
 58055:
-  aliases: ['Rhinolophidae']
+  aliases: []
   parents:
   - 3136022
 1677019:
-  aliases: ['Rhinonycteridae']
+  aliases: []
   parents:
   - 3136022
 124754:
-  aliases: ['Rhinopomatidae']
+  aliases: []
   parents:
   - 3136022
 153294:
-  aliases: ['Rhogeessa']
+  aliases: []
   parents:
   - 9431
 3411094:
-  aliases: ['Rhyneptesicus']
+  aliases: []
   parents:
   - 9431
 999965:
-  aliases: ['Sauromys']
+  aliases: []
   parents:
   - 9436
 258954:
-  aliases: ['Scotoecus']
+  aliases: []
   parents:
   - 9431
 258956:
-  aliases: ['Scotomanes']
+  aliases: []
   parents:
   - 9431
 153296:
-  aliases: ['Scotophilus']
+  aliases: []
   parents:
   - 9431
 270779:
-  aliases: ['Scotorepens']
+  aliases: []
   parents:
   - 9431
 2830903:
-  aliases: ['Scotozous']
+  aliases: []
   parents:
   - 9431
 3371055:
-  aliases: ['Setirostris']
+  aliases: []
   parents:
   - 9436
 40234:
-  aliases: ['Stenodermatinae']
+  aliases: []
   parents:
   - 9415
 1636536:
-  aliases: ['Submyotodon']
+  aliases: []
   parents:
   - 9431
 9437:
-  aliases: ['Tadarida']
+  aliases: []
   parents:
   - 9436
 461395:
-  aliases: ['Taphozoinae']
+  aliases: []
   parents:
   - 30562
 3371075:
-  aliases: ['Thainycteris']
+  aliases: []
   parents:
   - 9431
 124758:
-  aliases: ['Thyroptera']
+  aliases: []
   parents:
   - 124757
 27631:
-  aliases: ['Tomopeas']
+  aliases: []
   parents:
   - 9436
 258958:
-  aliases: ['Tylonycteris']
+  aliases: []
   parents:
   - 9431
 2778577:
-  aliases: ['Vansonia']
+  aliases: []
   parents:
   - 9431
 2689072:
-  aliases: ['Vespadelus']
+  aliases: []
   parents:
   - 9431
 59484:
-  aliases: ['Vespertilio']
+  aliases: []
   parents:
   - 9431
 3242306:
-  aliases: ['unclassified Phyllostomidae']
+  aliases: []
   parents:
   - 9415
 1296580:
-  aliases: ['unclassified Vespertilionidae']
+  aliases: []
   parents:
   - 9431
 3369693:
-  aliases: ['Afronycteris nanus']
+  aliases: []
   parents:
   - 2778563
 3370421:
-  aliases: ['Afropipistrellus eisentrauti']
+  aliases: []
   parents:
   - 3685292
 2608642:
-  aliases: ['Afropipistrellus happoldorum']
+  aliases: []
   parents:
   - 3685292
 148022:
-  aliases: ['Ametrida']
+  aliases: []
   parents:
   - 40234
 27641:
-  aliases: ['Anoura']
+  aliases: []
   parents:
   - 40236
 302396:
-  aliases: ['Anthops']
+  aliases: []
   parents:
   - 186994
 9440:
-  aliases: ['Antrozous pallidus']
+  aliases: []
   parents:
   - 9439
 148023:
-  aliases: ['Ardops']
+  aliases: []
   parents:
   - 40234
 867814:
-  aliases: ['Arielulus circumdatus']
+  aliases: []
   parents:
   - 526815
 526816:
-  aliases: ['Arielulus cuprosus']
+  aliases: []
   parents:
   - 526815
 3369719:
-  aliases: ['Arielulus societatis']
+  aliases: []
   parents:
   - 526815
 148024:
-  aliases: ['Ariteus']
+  aliases: []
   parents:
   - 40234
 9416:
-  aliases: ['Artibeus']
+  aliases: []
   parents:
   - 40234
 578339:
-  aliases: ['Asellia']
+  aliases: []
   parents:
   - 186994
 188567:
-  aliases: ['Aselliscus']
+  aliases: []
   parents:
   - 186994
 153295:
-  aliases: ['Baeodon alleni']
+  aliases: []
   parents:
   - 3072824
 3072825:
-  aliases: ['Baeodon gracilis']
+  aliases: []
   parents:
   - 3072824
 148079:
-  aliases: ['Balantiopteryx']
+  aliases: []
   parents:
   - 461394
 59449:
-  aliases: ['Barbastella barbastellus']
+  aliases: []
   parents:
   - 59448
 452650:
-  aliases: ['Barbastella beijingensis']
+  aliases: []
   parents:
   - 59448
 2505955:
-  aliases: ['Barbastella caspica']
+  aliases: []
   parents:
   - 59448
 999320:
-  aliases: ['Barbastella darjelingensis']
+  aliases: []
   parents:
   - 59448
 187009:
-  aliases: ['Barbastella leucomelas']
+  aliases: []
   parents:
   - 59448
 2505956:
-  aliases: ['Barbastella pacifica']
+  aliases: []
   parents:
   - 59448
 249033:
-  aliases: ['Bauerus dubiaquercus']
+  aliases: []
   parents:
   - 3135596
 9420:
-  aliases: ['Brachyphylla']
+  aliases: []
   parents:
   - 40235
 270763:
-  aliases: ['Cardioderma']
+  aliases: []
   parents:
   - 9409
 40232:
-  aliases: ['Carollia']
+  aliases: []
   parents:
   - 40231
 712050:
-  aliases: ['Cassistrellus dimissus']
+  aliases: []
   parents:
   - 2069572
 2069573:
-  aliases: ['Cassistrellus yokdonensis']
+  aliases: []
   parents:
   - 2069572
 461396:
-  aliases: ['Centronycteris']
+  aliases: []
   parents:
   - 461394
 27643:
-  aliases: ['Centurio']
+  aliases: []
   parents:
   - 40234
 2717975:
-  aliases: ['Chalinolobus dwyeri']
+  aliases: []
   parents:
   - 50352
 258889:
-  aliases: ['Chalinolobus gouldii']
+  aliases: []
   parents:
   - 50352
 50353:
-  aliases: ['Chalinolobus morio']
+  aliases: []
   parents:
   - 50352
 2093326:
-  aliases: ['Chalinolobus neocaledonicus']
+  aliases: []
   parents:
   - 50352
 270775:
-  aliases: ['Chalinolobus nigrogriseus']
+  aliases: []
   parents:
   - 50352
 2717976:
-  aliases: ['Chalinolobus picatus']
+  aliases: []
   parents:
   - 50352
 143942:
-  aliases: ['Chalinolobus tuberculatus']
+  aliases: []
   parents:
   - 50352
 270769:
-  aliases: ['Cheiromeles parvidens']
+  aliases: []
   parents:
   - 270767
 270768:
-  aliases: ['Cheiromeles torquatus']
+  aliases: []
   parents:
   - 270767
 155039:
-  aliases: ['Chilonatalus micropus']
+  aliases: []
   parents:
   - 290567
 290568:
-  aliases: ['Chilonatalus tumidifrons']
+  aliases: []
   parents:
   - 290567
 27645:
-  aliases: ['Chiroderma']
+  aliases: []
   parents:
   - 40234
 148042:
-  aliases: ['Choeroniscus']
+  aliases: []
   parents:
   - 40236
 148043:
-  aliases: ['Choeronycteris']
+  aliases: []
   parents:
   - 40236
 148075:
-  aliases: ['Chrotopterus']
+  aliases: []
   parents:
   - 40238
 265731:
-  aliases: ['Cistugo lesueuri']
+  aliases: []
   parents:
   - 712047
 712048:
-  aliases: ['Cistugo seabrae']
+  aliases: []
   parents:
   - 712047
 302399:
-  aliases: ['Cloeotis']
+  aliases: []
   parents:
   - 1677019
 3371008:
-  aliases: ['Cnephaeus anatolicus']
+  aliases: []
   parents:
   - 29077
 3371009:
-  aliases: ['Cnephaeus bottae']
+  aliases: []
   parents:
   - 29077
 3371011:
-  aliases: ['Cnephaeus gobiensis']
+  aliases: []
   parents:
   - 29077
 3371012:
-  aliases: ['Cnephaeus hottentotus']
+  aliases: []
   parents:
   - 29077
 3371013:
-  aliases: ['Cnephaeus isabellinus']
+  aliases: []
   parents:
   - 29077
 3371014:
-  aliases: ['Cnephaeus japonensis']
+  aliases: []
   parents:
   - 29077
 3371016:
-  aliases: ['Cnephaeus nilssonii']
+  aliases: []
   parents:
   - 29077
 3371017:
-  aliases: ['Cnephaeus ognevi']
+  aliases: []
   parents:
   - 29077
 3371018:
-  aliases: ['Cnephaeus pachyomus']
+  aliases: []
   parents:
   - 29077
 3371021:
-  aliases: ['Cnephaeus serotinus']
+  aliases: []
   parents:
   - 29077
 3371022:
-  aliases: ['Cnephaeus tatei']
+  aliases: []
   parents:
   - 29077
 187001:
-  aliases: ['Coelops']
+  aliases: []
   parents:
   - 186994
 461397:
-  aliases: ['Coleura']
+  aliases: []
   parents:
   - 461394
 249011:
-  aliases: ['Cormura']
+  aliases: []
   parents:
   - 461394
 712049:
-  aliases: ['Corynorhinus mexicanus']
+  aliases: []
   parents:
   - 233861
 27674:
-  aliases: ['Corynorhinus rafinesquii']
+  aliases: []
   parents:
   - 233861
 124745:
-  aliases: ['Corynorhinus townsendii']
+  aliases: []
   parents:
   - 233861
 208971:
-  aliases: ['Craseonycteris']
+  aliases: []
   parents:
   - 217614
 748910:
-  aliases: ['Cynomops abrasus']
+  aliases: []
   parents:
   - 303306
 1833834:
-  aliases: ['Cynomops greenhalli']
+  aliases: []
   parents:
   - 303306
 2850156:
-  aliases: ['Cynomops kuizha']
+  aliases: []
   parents:
   - 303306
 1833835:
-  aliases: ['Cynomops mexicanus']
+  aliases: []
   parents:
   - 303306
 303307:
-  aliases: ['Cynomops paranus']
+  aliases: []
   parents:
   - 303306
 409018:
-  aliases: ['Cynomops planirostris']
+  aliases: []
   parents:
   - 303306
 3136027:
-  aliases: ['Cynopterinae']
+  aliases: []
   parents:
   - 9398
 409019:
-  aliases: ['Cyttarops']
+  aliases: []
   parents:
   - 461394
 563992:
-  aliases: ['Dermanura']
+  aliases: []
   parents:
   - 40234
 9429:
-  aliases: ['Desmodus']
+  aliases: []
   parents:
   - 40237
 148076:
-  aliases: ['Diaemus']
+  aliases: []
   parents:
   - 40237
 148078:
-  aliases: ['Diclidurus']
+  aliases: []
   parents:
   - 461394
 148077:
-  aliases: ['Diphylla']
+  aliases: []
   parents:
   - 40237
 2664496:
-  aliases: ['Doryrhina']
+  aliases: []
   parents:
   - 186994
 148025:
-  aliases: ['Ectophylla']
+  aliases: []
   parents:
   - 40234
 110939:
-  aliases: ['Emballonura']
+  aliases: []
   parents:
   - 461394
 3136030:
-  aliases: ['Epomophorinae']
+  aliases: []
   parents:
   - 9398
 3369970:
-  aliases: ['Eptesicus dutertreus']
+  aliases: []
   parents:
   - 3371007
 29078:
-  aliases: ['Eptesicus fuscus']
+  aliases: []
   parents:
   - 3371007
 148091:
-  aliases: ['Erophylla']
+  aliases: []
   parents:
   - 138700
 153291:
-  aliases: ['Euderma maculatum']
+  aliases: []
   parents:
   - 153290
 633651:
-  aliases: ['Eudiscopus denticulus']
+  aliases: []
   parents:
   - 633650
 124747:
-  aliases: ['Eumops auripendulus']
+  aliases: []
   parents:
   - 27618
 649740:
-  aliases: ['Eumops bonariensis']
+  aliases: []
   parents:
   - 27618
 1848987:
-  aliases: ['Eumops chimaera']
+  aliases: []
   parents:
   - 27618
 1115884:
-  aliases: ['Eumops dabbenei']
+  aliases: []
   parents:
   - 27618
 1115867:
-  aliases: ['Eumops ferox']
+  aliases: []
   parents:
   - 27618
 27619:
-  aliases: ['Eumops glaucinus']
+  aliases: []
   parents:
   - 27618
 409027:
-  aliases: ['Eumops hansae']
+  aliases: []
   parents:
   - 27618
 1001578:
-  aliases: ['Eumops maurus']
+  aliases: []
   parents:
   - 27618
 1246553:
-  aliases: ['Eumops nanus']
+  aliases: []
   parents:
   - 27618
 1115866:
-  aliases: ['Eumops patagonicus']
+  aliases: []
   parents:
   - 27618
 27620:
-  aliases: ['Eumops perotis']
+  aliases: []
   parents:
   - 27618
 507606:
-  aliases: ['Eumops underwoodi']
+  aliases: []
   parents:
   - 27618
 1115868:
-  aliases: ['Eumops wilsoni']
+  aliases: []
   parents:
   - 27618
 2491053:
-  aliases: ['Falsistrellus mackenziei']
+  aliases: []
   parents:
   - 1310229
 2491054:
-  aliases: ['Falsistrellus tasmaniensis']
+  aliases: []
   parents:
   - 1310229
 148082:
-  aliases: ['Furipterus horrens']
+  aliases: []
   parents:
   - 148081
 1920523:
-  aliases: ['Gardnerycteris']
+  aliases: []
   parents:
   - 40238
 2093328:
-  aliases: ['Glauconycteris alboguttata']
+  aliases: []
   parents:
   - 909366
 909367:
-  aliases: ['Glauconycteris argentata']
+  aliases: []
   parents:
   - 909366
 2093329:
-  aliases: ['Glauconycteris atra']
+  aliases: []
   parents:
   - 909366
 177182:
-  aliases: ['Glauconycteris beatrix']
+  aliases: []
   parents:
   - 909366
 2093340:
-  aliases: ['Glauconycteris cf. humeralis R13-46']
+  aliases: []
   parents:
   - 909366
 2093341:
-  aliases: ['Glauconycteris cf. humeralis R13-98']
+  aliases: []
   parents:
   - 909366
 2093330:
-  aliases: ['Glauconycteris curryae']
+  aliases: []
   parents:
   - 909366
 909368:
-  aliases: ['Glauconycteris egeria']
+  aliases: []
   parents:
   - 909366
 2093331:
-  aliases: ['Glauconycteris humeralis']
+  aliases: []
   parents:
   - 909366
 258909:
-  aliases: ['Glauconycteris poensis']
+  aliases: []
   parents:
   - 909366
 2448840:
-  aliases: ['Glauconycteris superba']
+  aliases: []
   parents:
   - 909366
 909369:
-  aliases: ['Glauconycteris variegata']
+  aliases: []
   parents:
   - 909366
 1699683:
-  aliases: ['Glischropus aquilus']
+  aliases: []
   parents:
   - 526817
 1699682:
-  aliases: ['Glischropus bucephalus']
+  aliases: []
   parents:
   - 526817
 526818:
-  aliases: ['Glischropus tylopus']
+  aliases: []
   parents:
   - 526817
 27637:
-  aliases: ['Glossophaga']
+  aliases: []
   parents:
   - 40236
 409028:
-  aliases: ['Glyphonycteris']
+  aliases: []
   parents:
   - 40238
 124749:
-  aliases: ['Harpiocephalus harpia']
+  aliases: []
   parents:
   - 124748
 294655:
-  aliases: ['Harpiocephalus mordax']
+  aliases: []
   parents:
   - 124748
 685777:
-  aliases: ['Harpiola isodon']
+  aliases: []
   parents:
   - 685776
 3136028:
-  aliases: ['Harpyionycterinae']
+  aliases: []
   parents:
   - 9398
 867821:
-  aliases: ['Hesperoptenus blanfordi']
+  aliases: []
   parents:
   - 526819
 3129213:
-  aliases: ['Hesperoptenus doriae']
+  aliases: []
   parents:
   - 526819
 867822:
-  aliases: ['Hesperoptenus tickelli']
+  aliases: []
   parents:
   - 526819
 526820:
-  aliases: ['Hesperoptenus tomesi']
+  aliases: []
   parents:
   - 526819
 58068:
-  aliases: ['Hipposideros']
+  aliases: []
   parents:
   - 186994
 3044321:
-  aliases: ['Histiotus diaphanopterus']
+  aliases: []
   parents:
   - 258918
 2764696:
-  aliases: ['Histiotus humboldti']
+  aliases: []
   parents:
   - 258918
 2969767:
-  aliases: ['Histiotus laephotis']
+  aliases: []
   parents:
   - 258918
 258919:
-  aliases: ['Histiotus macrotus']
+  aliases: []
   parents:
   - 258918
 909363:
-  aliases: ['Histiotus magellanicus']
+  aliases: []
   parents:
   - 258918
 2969768:
-  aliases: ['Histiotus mochica']
+  aliases: []
   parents:
   - 258918
 1161940:
-  aliases: ['Histiotus montanus']
+  aliases: []
   parents:
   - 258918
 742904:
-  aliases: ['Histiotus velatus']
+  aliases: []
   parents:
   - 258918
 1470803:
-  aliases: ['Hsunycteris']
+  aliases: []
   parents:
   - 138703
 148044:
-  aliases: ['Hylonycteris']
+  aliases: []
   parents:
   - 40236
 999321:
-  aliases: ['Hypsugo alaschanicus']
+  aliases: []
   parents:
   - 109484
 1928619:
-  aliases: ['Hypsugo arabicus']
+  aliases: []
   parents:
   - 109484
 412094:
-  aliases: ['Hypsugo ariel']
+  aliases: []
   parents:
   - 109484
 342860:
-  aliases: ['Hypsugo cadornae']
+  aliases: []
   parents:
   - 109484
 1897726:
-  aliases: ['Hypsugo dolichodon']
+  aliases: []
   parents:
   - 109484
 1788295:
-  aliases: ['Hypsugo macrotis']
+  aliases: []
   parents:
   - 109484
 1310230:
-  aliases: ['Hypsugo petersi']
+  aliases: []
   parents:
   - 109484
 867834:
-  aliases: ['Hypsugo pulveratus']
+  aliases: []
   parents:
   - 109484
 109485:
-  aliases: ['Hypsugo savii']
+  aliases: []
   parents:
   - 109484
 2917788:
-  aliases: ['Hypsugo stubbei']
+  aliases: []
   parents:
   - 109484
 360967:
-  aliases: ['Ia io']
+  aliases: []
   parents:
   - 360966
 27665:
-  aliases: ['Idionycteris phyllotis']
+  aliases: []
   parents:
   - 27664
 1429989:
-  aliases: ['Kerivoula argentata']
+  aliases: []
   parents:
   - 59454
 867835:
-  aliases: ['Kerivoula cf. hardwickii CMF-2010']
+  aliases: []
   parents:
   - 59454
 867836:
-  aliases: ['Kerivoula cf. lenis CMF-2010']
+  aliases: []
   parents:
   - 59454
 294654:
-  aliases: ['Kerivoula cf. papillosa']
+  aliases: []
   parents:
   - 59454
 1987007:
-  aliases: ['Kerivoula cuprosa']
+  aliases: []
   parents:
   - 59454
 2918677:
-  aliases: ['Kerivoula depressa']
+  aliases: []
   parents:
   - 59454
 2918678:
-  aliases: ['Kerivoula dongduongana']
+  aliases: []
   parents:
   - 59454
 2015597:
-  aliases: ['Kerivoula furva']
+  aliases: []
   parents:
   - 59454
 155035:
-  aliases: ['Kerivoula hardwickii']
+  aliases: []
   parents:
   - 59454
 481313:
-  aliases: ['Kerivoula intermedia']
+  aliases: []
   parents:
   - 59454
 867839:
-  aliases: ['Kerivoula kachinensis']
+  aliases: []
   parents:
   - 59454
 867840:
-  aliases: ['Kerivoula krauensis']
+  aliases: []
   parents:
   - 59454
 2591342:
-  aliases: ['Kerivoula lanosa']
+  aliases: []
   parents:
   - 59454
 481312:
-  aliases: ['Kerivoula lenis']
+  aliases: []
   parents:
   - 59454
 685729:
-  aliases: ['Kerivoula minuta']
+  aliases: []
   parents:
   - 59454
 59455:
-  aliases: ['Kerivoula papillosa']
+  aliases: []
   parents:
   - 59454
 258925:
-  aliases: ['Kerivoula pellucida']
+  aliases: []
   parents:
   - 59454
 3242297:
-  aliases: ['Kerivoula phalaena']
+  aliases: []
   parents:
   - 59454
 867838:
-  aliases: ['Kerivoula picta']
+  aliases: []
   parents:
   - 59454
 3242298:
-  aliases: ['Kerivoula smithii']
+  aliases: []
   parents:
   - 59454
 633648:
-  aliases: ['Kerivoula titania']
+  aliases: []
   parents:
   - 59454
 481314:
-  aliases: ['Kerivoula whiteheadi']
+  aliases: []
   parents:
   - 59454
 2943201:
-  aliases: ['Laephotis angolensis']
+  aliases: []
   parents:
   - 258926
 110938:
-  aliases: ['Laephotis capensis']
+  aliases: []
   parents:
   - 258926
 3416122:
-  aliases: ['Laephotis cf. kirinyaga']
+  aliases: []
   parents:
   - 258926
 2778571:
-  aliases: ['Laephotis kirinyaga']
+  aliases: []
   parents:
   - 258926
 2778564:
-  aliases: ['Laephotis malagasyensis']
+  aliases: []
   parents:
   - 258926
 1162378:
-  aliases: ['Laephotis matroka']
+  aliases: []
   parents:
   - 258926
 258927:
-  aliases: ['Laephotis namibensis']
+  aliases: []
   parents:
   - 258926
 2778648:
-  aliases: ['Laephotis robertsi']
+  aliases: []
   parents:
   - 258926
 2778565:
-  aliases: ['Laephotis stanleyi']
+  aliases: []
   parents:
   - 258926
 294650:
-  aliases: ['Laephotis wintoni']
+  aliases: []
   parents:
   - 258926
 27667:
-  aliases: ['Lasionycteris noctivagans']
+  aliases: []
   parents:
   - 27666
 2720563:
-  aliases: ['Lasiurus arequipae']
+  aliases: []
   parents:
   - 72130
 258931:
-  aliases: ['Lasiurus atratus']
+  aliases: []
   parents:
   - 72130
 258932:
-  aliases: ['Lasiurus blossevillii']
+  aliases: []
   parents:
   - 72130
 258930:
-  aliases: ['Lasiurus borealis']
+  aliases: []
   parents:
   - 72130
 257879:
-  aliases: ['Lasiurus cinereus']
+  aliases: []
   parents:
   - 72130
 258928:
-  aliases: ['Lasiurus ega']
+  aliases: []
   parents:
   - 72130
 461400:
-  aliases: ['Lasiurus egregius']
+  aliases: []
   parents:
   - 72130
 1691932:
-  aliases: ['Lasiurus frantzii']
+  aliases: []
   parents:
   - 72130
 1691930:
-  aliases: ['Lasiurus insularis']
+  aliases: []
   parents:
   - 72130
 592573:
-  aliases: ['Lasiurus intermedius']
+  aliases: []
   parents:
   - 72130
 1857021:
-  aliases: ['Lasiurus minor']
+  aliases: []
   parents:
   - 72130
 1691931:
-  aliases: ['Lasiurus pfeifferi']
+  aliases: []
   parents:
   - 72130
 258929:
-  aliases: ['Lasiurus seminolus']
+  aliases: []
   parents:
   - 72130
 2904792:
-  aliases: ['Lasiurus semotus']
+  aliases: []
   parents:
   - 72130
 1691933:
-  aliases: ['Lasiurus varius']
+  aliases: []
   parents:
   - 72130
 3370141:
-  aliases: ['Lasiurus villosissimus']
+  aliases: []
   parents:
   - 72130
 72131:
-  aliases: ['Lasiurus xanthinus']
+  aliases: []
   parents:
   - 72130
 1582324:
-  aliases: ['Lavia']
+  aliases: []
   parents:
   - 9409
 55053:
-  aliases: ['Leptonycteris']
+  aliases: []
   parents:
   - 40236
 148045:
-  aliases: ['Lichonycteris']
+  aliases: []
   parents:
   - 40236
 148084:
-  aliases: ['Lionycteris']
+  aliases: []
   parents:
   - 138703
 138704:
-  aliases: ['Lonchophylla']
+  aliases: []
   parents:
   - 138703
 148054:
-  aliases: ['Lonchorhina']
+  aliases: []
   parents:
   - 40238
 263450:
-  aliases: ['Lophostoma']
+  aliases: []
   parents:
   - 40238
 3371052:
-  aliases: ['Lyroderma']
+  aliases: []
   parents:
   - 9409
 9410:
-  aliases: ['Macroderma']
+  aliases: []
   parents:
   - 9409
 77241:
-  aliases: ['Macroglossinae']
+  aliases: []
   parents:
   - 9398
 2603868:
-  aliases: ['Macronycteris']
+  aliases: []
   parents:
   - 186994
 148055:
-  aliases: ['Macrophyllum']
+  aliases: []
   parents:
   - 40238
 9418:
-  aliases: ['Macrotus']
+  aliases: []
   parents:
   - 40238
 9412:
-  aliases: ['Megaderma']
+  aliases: []
   parents:
   - 9409
 148026:
-  aliases: ['Mesophylla']
+  aliases: []
   parents:
   - 40234
 3371116:
-  aliases: ['Micronomus norfolkensis']
+  aliases: []
   parents:
   - 3371053
 148056:
-  aliases: ['Micronycteris']
+  aliases: []
   parents:
   - 40238
 2093334:
-  aliases: ['Mimetillus moloneyi']
+  aliases: []
   parents:
   - 2093333
 148057:
-  aliases: ['Mimon']
+  aliases: []
   parents:
   - 40238
 647618:
-  aliases: ['Miniopterus aelleni']
+  aliases: []
   parents:
   - 9432
 441364:
-  aliases: ['Miniopterus africanus']
+  aliases: []
   parents:
   - 9432
 1574122:
-  aliases: ['Miniopterus ambohitrensis']
+  aliases: []
   parents:
   - 9432
 117605:
-  aliases: ['Miniopterus australis']
+  aliases: []
   parents:
   - 9432
 647619:
-  aliases: ['Miniopterus brachytragos']
+  aliases: []
   parents:
   - 9432
 1477904:
-  aliases: ['Miniopterus cf. aelleni A']
+  aliases: []
   parents:
   - 9432
 1477905:
-  aliases: ['Miniopterus cf. aelleni B']
+  aliases: []
   parents:
   - 9432
 1286219:
-  aliases: ['Miniopterus cf. arenarius VG-2013']
+  aliases: []
   parents:
   - 9432
 947062:
-  aliases: ['Miniopterus egeri']
+  aliases: []
   parents:
   - 9432
 258933:
-  aliases: ['Miniopterus fraterculus']
+  aliases: []
   parents:
   - 9432
 187007:
-  aliases: ['Miniopterus fuliginosus']
+  aliases: []
   parents:
   - 9432
 187008:
-  aliases: ['Miniopterus fuscus']
+  aliases: []
   parents:
   - 9432
 409372:
-  aliases: ['Miniopterus gleni']
+  aliases: []
   parents:
   - 9432
 666442:
-  aliases: ['Miniopterus griffithsi']
+  aliases: []
   parents:
   - 9432
 568717:
-  aliases: ['Miniopterus griveaudi']
+  aliases: []
   parents:
   - 9432
 221087:
-  aliases: ['Miniopterus inflatus']
+  aliases: []
   parents:
   - 9432
 291300:
-  aliases: ['Miniopterus macrocneme']
+  aliases: []
   parents:
   - 9432
 1471367:
-  aliases: ['Miniopterus maghrebensis']
+  aliases: []
   parents:
   - 9432
 438766:
-  aliases: ['Miniopterus magnater']
+  aliases: []
   parents:
   - 9432
 647620:
-  aliases: ['Miniopterus mahafaliensis']
+  aliases: []
   parents:
   - 9432
 409373:
-  aliases: ['Miniopterus majori']
+  aliases: []
   parents:
   - 9432
 291301:
-  aliases: ['Miniopterus manavi']
+  aliases: []
   parents:
   - 9432
 867841:
-  aliases: ['Miniopterus medius']
+  aliases: []
   parents:
   - 9432
 221086:
-  aliases: ['Miniopterus minor']
+  aliases: []
   parents:
   - 9432
 1434095:
-  aliases: ['Miniopterus mossambicus']
+  aliases: []
   parents:
   - 9432
 291302:
-  aliases: ['Miniopterus natalensis']
+  aliases: []
   parents:
   - 9432
 442103:
-  aliases: ['Miniopterus newtonii']
+  aliases: []
   parents:
   - 9432
 2813654:
-  aliases: ['Miniopterus nimbae']
+  aliases: []
   parents:
   - 9432
 2291841:
-  aliases: ['Miniopterus orianae']
+  aliases: []
   parents:
   - 9432
 2715946:
-  aliases: ['Miniopterus paululus']
+  aliases: []
   parents:
   - 9432
 647617:
-  aliases: ['Miniopterus petersoni']
+  aliases: []
   parents:
   - 9432
 221089:
-  aliases: ['Miniopterus propitristis']
+  aliases: []
   parents:
   - 9432
 258934:
-  aliases: ['Miniopterus pusillus']
+  aliases: []
   parents:
   - 9432
 9433:
-  aliases: ['Miniopterus schreibersii']
+  aliases: []
   parents:
   - 9432
 947061:
-  aliases: ['Miniopterus sororculus']
+  aliases: []
   parents:
   - 9432
 221088:
-  aliases: ['Miniopterus tristis']
+  aliases: []
   parents:
   - 9432
 1410045:
-  aliases: ['Miniopterus villiersi']
+  aliases: []
   parents:
   - 9432
 2741458:
-  aliases: ['Mirostrellus joffrei']
+  aliases: []
   parents:
   - 2741457
 3082059:
-  aliases: ['Molossops griseiventer']
+  aliases: []
   parents:
   - 249031
 1115885:
-  aliases: ['Molossops mattogrossensis']
+  aliases: []
   parents:
   - 249031
 409036:
-  aliases: ['Molossops neglectus']
+  aliases: []
   parents:
   - 249031
 1001576:
-  aliases: ['Molossops temminckii']
+  aliases: []
   parents:
   - 249031
 1552295:
-  aliases: ['Molossus alvarezi']
+  aliases: []
   parents:
   - 27621
 270771:
-  aliases: ['Molossus ater']
+  aliases: []
   parents:
   - 27621
 2116674:
-  aliases: ['Molossus aztecus']
+  aliases: []
   parents:
   - 27621
 1769916:
-  aliases: ['Molossus barnesi']
+  aliases: []
   parents:
   - 27621
 999954:
-  aliases: ['Molossus cf. coibensis']
+  aliases: []
   parents:
   - 27621
 999942:
-  aliases: ['Molossus coibensis']
+  aliases: []
   parents:
   - 27621
 1269259:
-  aliases: ['Molossus currentium']
+  aliases: []
   parents:
   - 27621
 2116675:
-  aliases: ['Molossus fentoni']
+  aliases: []
   parents:
   - 27621
 3062012:
-  aliases: ['Molossus fluminensis']
+  aliases: []
   parents:
   - 27621
 2834119:
-  aliases: ['Molossus melini']
+  aliases: []
   parents:
   - 27621
 2116676:
-  aliases: ['Molossus milleri']
+  aliases: []
   parents:
   - 27621
 27622:
-  aliases: ['Molossus molossus']
+  aliases: []
   parents:
   - 27621
 2997257:
-  aliases: ['Molossus nigricans']
+  aliases: []
   parents:
   - 27621
 1982945:
-  aliases: ['Molossus pretiosus']
+  aliases: []
   parents:
   - 27621
 124751:
-  aliases: ['Molossus rufus']
+  aliases: []
   parents:
   - 27621
 58076:
-  aliases: ['Molossus sinaloae']
+  aliases: []
   parents:
   - 27621
 2482672:
-  aliases: ['Molossus verrilli']
+  aliases: []
   parents:
   - 27621
 148046:
-  aliases: ['Monophyllus']
+  aliases: []
   parents:
   - 40236
 3370270:
-  aliases: ['Mops ansorgei']
+  aliases: []
   parents:
   - 258862
 3370271:
-  aliases: ['Mops atsinanana']
+  aliases: []
   parents:
   - 258862
 1004697:
-  aliases: ['Mops bakarii']
+  aliases: []
   parents:
   - 258862
 3370273:
-  aliases: ['Mops bivittatus']
+  aliases: []
   parents:
   - 258862
 3370274:
-  aliases: ['Mops brachypterus']
+  aliases: []
   parents:
   - 258862
 3370275:
-  aliases: ['Mops bregullae']
+  aliases: []
   parents:
   - 258862
 3242304:
-  aliases: ['Mops cf. nanulus']
+  aliases: []
   parents:
   - 258862
 2448875:
-  aliases: ['Mops cf. nanulus DMR-2017']
+  aliases: []
   parents:
   - 258862
 2448865:
-  aliases: ['Mops cf. pumilus DMR-2017']
+  aliases: []
   parents:
   - 258862
 2598438:
-  aliases: ['Mops cf. pumilus GIN-1704']
+  aliases: []
   parents:
   - 258862
 3370276:
-  aliases: ['Mops chapini']
+  aliases: []
   parents:
   - 258862
 258863:
-  aliases: ['Mops condylurus']
+  aliases: []
   parents:
   - 258862
 3370279:
-  aliases: ['Mops jobensis']
+  aliases: []
   parents:
   - 258862
 3370280:
-  aliases: ['Mops jobimena']
+  aliases: []
   parents:
   - 258862
 3370282:
-  aliases: ['Mops leucogaster']
+  aliases: []
   parents:
   - 258862
 452596:
-  aliases: ['Mops leucostigma']
+  aliases: []
   parents:
   - 258862
 452595:
-  aliases: ['Mops midas']
+  aliases: []
   parents:
   - 258862
 867842:
-  aliases: ['Mops mops']
+  aliases: []
   parents:
   - 258862
 3370286:
-  aliases: ['Mops nigeriae']
+  aliases: []
   parents:
   - 258862
 3370289:
-  aliases: ['Mops plicatus']
+  aliases: []
   parents:
   - 258862
 242384:
-  aliases: ['Mops pumilus']
+  aliases: []
   parents:
   - 258862
 1380905:
-  aliases: ['Mops pumilus s.l. TN-2013']
+  aliases: []
   parents:
   - 258862
 1495469:
-  aliases: ['Mops pumilus s.l. TN-2014']
+  aliases: []
   parents:
   - 258862
 3370290:
-  aliases: ['Mops pusillus']
+  aliases: []
   parents:
   - 258862
 3370294:
-  aliases: ['Mops spurrelli']
+  aliases: []
   parents:
   - 258862
 3370295:
-  aliases: ['Mops thersites']
+  aliases: []
   parents:
   - 258862
 3370296:
-  aliases: ['Mops tomensis']
+  aliases: []
   parents:
   - 258862
 118852:
-  aliases: ['Mormoops blainvillei']
+  aliases: []
   parents:
   - 59459
 59460:
-  aliases: ['Mormoops megalophylla']
+  aliases: []
   parents:
   - 59459
 525717:
-  aliases: ['Mormopterus acetabulosus']
+  aliases: []
   parents:
   - 27623
 524134:
-  aliases: ['Mormopterus francoismoutoui']
+  aliases: []
   parents:
   - 27623
 999964:
-  aliases: ['Mormopterus jugularis']
+  aliases: []
   parents:
   - 27623
 27624:
-  aliases: ['Mormopterus kalinowskii']
+  aliases: []
   parents:
   - 27623
 450943:
-  aliases: ['Mosia']
+  aliases: []
   parents:
   - 461394
 685730:
-  aliases: ['Murina aenea']
+  aliases: []
   parents:
   - 59488
 1986510:
-  aliases: ['Murina aff. cyclotis PS.12.227']
+  aliases: []
   parents:
   - 59488
 1986508:
-  aliases: ['Murina aff. cyclotis PS100419.3']
+  aliases: []
   parents:
   - 59488
 1986516:
-  aliases: ['Murina aff. cyclotis PS120111.2']
+  aliases: []
   parents:
   - 59488
 1986514:
-  aliases: ['Murina aff. cyclotis SB080103.4']
+  aliases: []
   parents:
   - 59488
 3375538:
-  aliases: ['Murina aff. huttonii']
+  aliases: []
   parents:
   - 59488
 3477261:
-  aliases: ['Murina alvarezi']
+  aliases: []
   parents:
   - 59488
 3370307:
-  aliases: ['Murina annamitica']
+  aliases: []
   parents:
   - 59488
 3477262:
-  aliases: ['Murina baletei']
+  aliases: []
   parents:
   - 59488
 685779:
-  aliases: ['Murina bicolor']
+  aliases: []
   parents:
   - 59488
 294656:
-  aliases: ['Murina cf. cyclotis']
+  aliases: []
   parents:
   - 59488
 867852:
-  aliases: ['Murina cf. cyclotis 2 CMF-2010']
+  aliases: []
   parents:
   - 59488
 1007697:
-  aliases: ['Murina cf. cyclotis BOLD:AAC4219']
+  aliases: []
   parents:
   - 59488
 1986509:
-  aliases: ['Murina cf. eleryi PS120928.1']
+  aliases: []
   parents:
   - 59488
 1167684:
-  aliases: ['Murina cf. huttoni']
+  aliases: []
   parents:
   - 59488
 867853:
-  aliases: ['Murina cf. huttoni CMF-2010']
+  aliases: []
   parents:
   - 59488
 1986513:
-  aliases: ['Murina cf. peninsularis PS.12.255']
+  aliases: []
   parents:
   - 59488
 1986507:
-  aliases: ['Murina cf. peninsularis PS.12.268']
+  aliases: []
   parents:
   - 59488
 1986515:
-  aliases: ['Murina cf. peninsularis PS.12.272']
+  aliases: []
   parents:
   - 59488
 1986517:
-  aliases: ['Murina cf. peninsularis PS120905.1']
+  aliases: []
   parents:
   - 59488
 1986512:
-  aliases: ['Murina cf. peninsularis PSUZC-MM2011.29']
+  aliases: []
   parents:
   - 59488
 867851:
-  aliases: ['Murina chrysochaetes']
+  aliases: []
   parents:
   - 59488
 177185:
-  aliases: ['Murina cyclotis']
+  aliases: []
   parents:
   - 59488
 744863:
-  aliases: ['Murina eleryi']
+  aliases: []
   parents:
   - 59488
 1752043:
-  aliases: ['Murina fanjingshanensis']
+  aliases: []
   parents:
   - 59488
 1453894:
-  aliases: ['Murina feae']
+  aliases: []
   parents:
   - 59488
 3370310:
-  aliases: ['Murina fionae']
+  aliases: []
   parents:
   - 59488
 187016:
-  aliases: ['Murina florium']
+  aliases: []
   parents:
   - 59488
 685780:
-  aliases: ['Murina gracilis']
+  aliases: []
   parents:
   - 59488
 867898:
-  aliases: ['Murina harpioloides']
+  aliases: []
   parents:
   - 59488
 2695399:
-  aliases: ['Murina harrisoni']
+  aliases: []
   parents:
   - 59488
 685731:
-  aliases: ['Murina hilgendorfi']
+  aliases: []
   parents:
   - 59488
 3477263:
-  aliases: ['Murina hilonghilong']
+  aliases: []
   parents:
   - 59488
 2201223:
-  aliases: ['Murina hkakaboraziensis']
+  aliases: []
   parents:
   - 59488
 258935:
-  aliases: ['Murina huttoni']
+  aliases: []
   parents:
   - 59488
 2933636:
-  aliases: ['Murina huttonii']
+  aliases: []
   parents:
   - 59488
 1167681:
-  aliases: ['Murina jaintiana']
+  aliases: []
   parents:
   - 59488
 2695400:
-  aliases: ['Murina jinchui']
+  aliases: []
   parents:
   - 59488
 1727179:
-  aliases: ['Murina kontumensis']
+  aliases: []
   parents:
   - 59488
 187017:
-  aliases: ['Murina leucogaster']
+  aliases: []
   parents:
   - 59488
 2580526:
-  aliases: ['Murina liboensis']
+  aliases: []
   parents:
   - 59488
 1046851:
-  aliases: ['Murina lorelieae']
+  aliases: []
   parents:
   - 59488
 3477264:
-  aliases: ['Murina luzonensis']
+  aliases: []
   parents:
   - 59488
 3477265:
-  aliases: ['Murina mindorensis']
+  aliases: []
   parents:
   - 59488
 685783:
-  aliases: ['Murina peninsularis']
+  aliases: []
   parents:
   - 59488
 3477266:
-  aliases: ['Murina philippinensis']
+  aliases: []
   parents:
   - 59488
 1167679:
-  aliases: ['Murina pluvialis']
+  aliases: []
   parents:
   - 59488
 187018:
-  aliases: ['Murina puta']
+  aliases: []
   parents:
   - 59488
 685781:
-  aliases: ['Murina recondita']
+  aliases: []
   parents:
   - 59488
 2695401:
-  aliases: ['Murina rongjiangensis']
+  aliases: []
   parents:
   - 59488
 526814:
-  aliases: ['Murina rozendaali']
+  aliases: []
   parents:
   - 59488
 187019:
-  aliases: ['Murina ryukyuana']
+  aliases: []
   parents:
   - 59488
 1046852:
-  aliases: ['Murina shuipuensis']
+  aliases: []
   parents:
   - 59488
 59489:
-  aliases: ['Murina suilla']
+  aliases: []
   parents:
   - 59488
 685785:
-  aliases: ['Murina tubinaris']
+  aliases: []
   parents:
   - 59488
 187021:
-  aliases: ['Murina ussuriensis']
+  aliases: []
   parents:
   - 59488
 3237278:
-  aliases: ['Murina walstoni']
+  aliases: []
   parents:
   - 59488
 148047:
-  aliases: ['Musonycteris']
+  aliases: []
   parents:
   - 40236
 1115870:
-  aliases: ['Myopterus daubentonii']
+  aliases: []
   parents:
   - 1115869
 59461:
-  aliases: ['Myotis adversus']
+  aliases: []
   parents:
   - 9434
 1436298:
-  aliases: ['Myotis aff. alcathoe']
+  aliases: []
   parents:
   - 9434
 159322:
-  aliases: ['Myotis albescens']
+  aliases: []
   parents:
   - 9434
 155916:
-  aliases: ['Myotis alcathoe']
+  aliases: []
   parents:
   - 9434
 415933:
-  aliases: ['Myotis altarium']
+  aliases: []
   parents:
   - 9434
 2516277:
-  aliases: ['Myotis ancricola']
+  aliases: []
   parents:
   - 9434
 864758:
-  aliases: ['Myotis anjouanensis']
+  aliases: []
   parents:
   - 9434
 633645:
-  aliases: ['Myotis annamiticus']
+  aliases: []
   parents:
   - 9434
 2782710:
-  aliases: ['Myotis annatessae']
+  aliases: []
   parents:
   - 9434
 265733:
-  aliases: ['Myotis annectans']
+  aliases: []
   parents:
   - 9434
 2977340:
-  aliases: ['Myotis arescens']
+  aliases: []
   parents:
   - 9434
 2785030:
-  aliases: ['Myotis armiensis']
+  aliases: []
   parents:
   - 9434
 384633:
-  aliases: ['Myotis atacamensis']
+  aliases: []
   parents:
   - 9434
 376141:
-  aliases: ['Myotis ater']
+  aliases: []
   parents:
   - 9434
 2940077:
-  aliases: ['Myotis attenboroughi']
+  aliases: []
   parents:
   - 9434
 321263:
-  aliases: ['Myotis auriculus']
+  aliases: []
   parents:
   - 9434
 258936:
-  aliases: ['Myotis austroriparius']
+  aliases: []
   parents:
   - 9434
 2250430:
-  aliases: ['Myotis badius']
+  aliases: []
   parents:
   - 9434
 3370334:
-  aliases: ['Myotis barquezi']
+  aliases: []
   parents:
   - 9434
 59462:
-  aliases: ['Myotis bechsteinii']
+  aliases: []
   parents:
   - 9434
 109482:
-  aliases: ['Myotis blythii']
+  aliases: []
   parents:
   - 9434
 153284:
-  aliases: ['Myotis bocagii']
+  aliases: []
   parents:
   - 9434
 392318:
-  aliases: ['Myotis bombinus']
+  aliases: []
   parents:
   - 9434
 2933637:
-  aliases: ['Myotis borneoensis']
+  aliases: []
   parents:
   - 9434
 109478:
-  aliases: ['Myotis brandtii']
+  aliases: []
   parents:
   - 9434
 2794209:
-  aliases: ['Myotis bucharensis']
+  aliases: []
   parents:
   - 9434
 257882:
-  aliases: ['Myotis californicus']
+  aliases: []
   parents:
   - 9434
 109477:
-  aliases: ['Myotis capaccinii']
+  aliases: []
   parents:
   - 9434
 3098845:
-  aliases: ['Myotis caucensis']
+  aliases: []
   parents:
   - 9434
 1239423:
-  aliases: ['Myotis cf. albescens']
+  aliases: []
   parents:
   - 9434
 1195383:
-  aliases: ['Myotis cf. alcathoe']
+  aliases: []
   parents:
   - 9434
 2782709:
-  aliases: ['Myotis cf. annatessae HNHM 25348']
+  aliases: []
   parents:
   - 9434
 2748575:
-  aliases: ['Myotis cf. annectans MNR-2020']
+  aliases: []
   parents:
   - 9434
 3074279:
-  aliases: ['Myotis cf. ater']
+  aliases: []
   parents:
   - 9434
 1007693:
-  aliases: ['Myotis cf. ater BOLD:AAA8748']
+  aliases: []
   parents:
   - 9434
 867855:
-  aliases: ['Myotis cf. ater CMF-2010']
+  aliases: []
   parents:
   - 9434
 1393937:
-  aliases: ['Myotis cf. ater MR-2013']
+  aliases: []
   parents:
   - 9434
 3029340:
-  aliases: ['Myotis cf. ater ZMMU S-189230']
+  aliases: []
   parents:
   - 9434
 3029341:
-  aliases: ['Myotis cf. ater ZMMU S-189231']
+  aliases: []
   parents:
   - 9434
 3029342:
-  aliases: ['Myotis cf. ater ZMMU S-189232']
+  aliases: []
   parents:
   - 9434
 1195384:
-  aliases: ['Myotis cf. aurascens']
+  aliases: []
   parents:
   - 9434
 386772:
-  aliases: ['Myotis cf. browni']
+  aliases: []
   parents:
   - 9434
 1239424:
-  aliases: ['Myotis cf. californicus']
+  aliases: []
   parents:
   - 9434
 2891921:
-  aliases: ['Myotis cf. californicus/ciliolabrum BL-2021']
+  aliases: []
   parents:
   - 9434
 2742335:
-  aliases: ['Myotis cf. davidii ZMB Mam 108328']
+  aliases: []
   parents:
   - 9434
 2742338:
-  aliases: ['Myotis cf. davidii ZMB Mam 108337']
+  aliases: []
   parents:
   - 9434
 2742339:
-  aliases: ['Myotis cf. davidii ZMB Mam 108341']
+  aliases: []
   parents:
   - 9434
 2742340:
-  aliases: ['Myotis cf. davidii ZMB Mam 108342']
+  aliases: []
   parents:
   - 9434
 2742341:
-  aliases: ['Myotis cf. davidii ZMB Mam 108346']
+  aliases: []
   parents:
   - 9434
 2742342:
-  aliases: ['Myotis cf. davidii ZMB Mam 108348']
+  aliases: []
   parents:
   - 9434
 2742343:
-  aliases: ['Myotis cf. davidii ZMB Mam 108349']
+  aliases: []
   parents:
   - 9434
 2742344:
-  aliases: ['Myotis cf. davidii ZMB Mam 108353']
+  aliases: []
   parents:
   - 9434
 2742345:
-  aliases: ['Myotis cf. davidii ZMB Mam 108354']
+  aliases: []
   parents:
   - 9434
 2742346:
-  aliases: ['Myotis cf. davidii ZMB Mam 108355']
+  aliases: []
   parents:
   - 9434
 2742347:
-  aliases: ['Myotis cf. davidii ZMB Mam 108356']
+  aliases: []
   parents:
   - 9434
 2742348:
-  aliases: ['Myotis cf. davidii ZMB Mam 108357']
+  aliases: []
   parents:
   - 9434
 2742349:
-  aliases: ['Myotis cf. davidii ZMB Mam 108358']
+  aliases: []
   parents:
   - 9434
 2742350:
-  aliases: ['Myotis cf. davidii ZMB Mam 108359']
+  aliases: []
   parents:
   - 9434
 2742318:
-  aliases: ['Myotis cf. davidii ZMB Mam 108361']
+  aliases: []
   parents:
   - 9434
 2742351:
-  aliases: ['Myotis cf. davidii ZMB Mam 108362']
+  aliases: []
   parents:
   - 9434
 2742352:
-  aliases: ['Myotis cf. davidii ZMB Mam 108363']
+  aliases: []
   parents:
   - 9434
 2742353:
-  aliases: ['Myotis cf. davidii ZMB Mam 108364']
+  aliases: []
   parents:
   - 9434
 2742354:
-  aliases: ['Myotis cf. davidii ZMB Mam 108365']
+  aliases: []
   parents:
   - 9434
 2742355:
-  aliases: ['Myotis cf. davidii ZMB Mam 108366']
+  aliases: []
   parents:
   - 9434
 2742357:
-  aliases: ['Myotis cf. davidii ZMB Mam 108401']
+  aliases: []
   parents:
   - 9434
 2742359:
-  aliases: ['Myotis cf. davidii ZMB Mam 108406']
+  aliases: []
   parents:
   - 9434
 2742360:
-  aliases: ['Myotis cf. davidii ZMB Mam 108407']
+  aliases: []
   parents:
   - 9434
 2742361:
-  aliases: ['Myotis cf. davidii ZMB Mam 108408']
+  aliases: []
   parents:
   - 9434
 2742362:
-  aliases: ['Myotis cf. davidii ZMB Mam 108410']
+  aliases: []
   parents:
   - 9434
 2742363:
-  aliases: ['Myotis cf. davidii ZMB Mam 108411']
+  aliases: []
   parents:
   - 9434
 2742364:
-  aliases: ['Myotis cf. davidii ZMB Mam 108412']
+  aliases: []
   parents:
   - 9434
 2742365:
-  aliases: ['Myotis cf. davidii ZMB Mam 108413']
+  aliases: []
   parents:
   - 9434
 2742366:
-  aliases: ['Myotis cf. davidii ZMB Mam 108414']
+  aliases: []
   parents:
   - 9434
 2742367:
-  aliases: ['Myotis cf. davidii ZMB Mam 108415']
+  aliases: []
   parents:
   - 9434
 2742368:
-  aliases: ['Myotis cf. davidii ZMB Mam 108416']
+  aliases: []
   parents:
   - 9434
 2742369:
-  aliases: ['Myotis cf. davidii ZMB Mam 108417']
+  aliases: []
   parents:
   - 9434
 2742370:
-  aliases: ['Myotis cf. davidii ZMB Mam 108418']
+  aliases: []
   parents:
   - 9434
 2742371:
-  aliases: ['Myotis cf. davidii ZMB Mam 108419']
+  aliases: []
   parents:
   - 9434
 2742331:
-  aliases: ['Myotis cf. davidii ZMB Mam 108423']
+  aliases: []
   parents:
   - 9434
 2742332:
-  aliases: ['Myotis cf. davidii ZMB Mam 108424']
+  aliases: []
   parents:
   - 9434
 2742372:
-  aliases: ['Myotis cf. davidii ZMB Mam 108427']
+  aliases: []
   parents:
   - 9434
 2742374:
-  aliases: ['Myotis cf. davidii ZMB Mam 108467']
+  aliases: []
   parents:
   - 9434
 2742375:
-  aliases: ['Myotis cf. davidii ZMB Mam 108471']
+  aliases: []
   parents:
   - 9434
 2742376:
-  aliases: ['Myotis cf. davidii ZMB Mam 108472']
+  aliases: []
   parents:
   - 9434
 2742379:
-  aliases: ['Myotis cf. davidii ZMB Mam 108507']
+  aliases: []
   parents:
   - 9434
 2742384:
-  aliases: ['Myotis cf. davidii ZMB Mam 108517']
+  aliases: []
   parents:
   - 9434
 2742385:
-  aliases: ['Myotis cf. davidii ZMB Mam 108518']
+  aliases: []
   parents:
   - 9434
 2742387:
-  aliases: ['Myotis cf. davidii ZMB Mam 108522']
+  aliases: []
   parents:
   - 9434
 2742388:
-  aliases: ['Myotis cf. davidii ZMB Mam 108523']
+  aliases: []
   parents:
   - 9434
 2742389:
-  aliases: ['Myotis cf. davidii ZMB Mam 108524']
+  aliases: []
   parents:
   - 9434
 2742324:
-  aliases: ['Myotis cf. davidii ZMB Mam 108525']
+  aliases: []
   parents:
   - 9434
 2742390:
-  aliases: ['Myotis cf. davidii ZMB Mam 108527']
+  aliases: []
   parents:
   - 9434
 2742391:
-  aliases: ['Myotis cf. davidii ZMB Mam 108528']
+  aliases: []
   parents:
   - 9434
 2742392:
-  aliases: ['Myotis cf. davidii ZMB Mam 108529']
+  aliases: []
   parents:
   - 9434
 2742393:
-  aliases: ['Myotis cf. davidii ZMB Mam 108530']
+  aliases: []
   parents:
   - 9434
 2742411:
-  aliases: ['Myotis cf. davidii ZMB Mam 108556']
+  aliases: []
   parents:
   - 9434
 2742412:
-  aliases: ['Myotis cf. davidii ZMB Mam 108558']
+  aliases: []
   parents:
   - 9434
 2742321:
-  aliases: ['Myotis cf. davidii ZMB Mam 108559']
+  aliases: []
   parents:
   - 9434
 2742333:
-  aliases: ['Myotis cf. davidii ZMB Mam 108582']
+  aliases: []
   parents:
   - 9434
 2742322:
-  aliases: ['Myotis cf. davidii ZMB Mam 108584']
+  aliases: []
   parents:
   - 9434
 2742323:
-  aliases: ['Myotis cf. davidii ZMB Mam 108586']
+  aliases: []
   parents:
   - 9434
 2742334:
-  aliases: ['Myotis cf. davidii ZMB Mam 108603']
+  aliases: []
   parents:
   - 9434
 2923480:
-  aliases: ['Myotis cf. elegans QCAZ Mamm9168']
+  aliases: []
   parents:
   - 9434
 2923481:
-  aliases: ['Myotis cf. elegans QCAZ Mamm9169']
+  aliases: []
   parents:
   - 9434
 1393938:
-  aliases: ['Myotis cf. formosus MR-2013']
+  aliases: []
   parents:
   - 9434
 2748576:
-  aliases: ['Myotis cf. frater MNR-2020']
+  aliases: []
   parents:
   - 9434
 2785031:
-  aliases: ['Myotis cf. ikonnikovi CC-2020']
+  aliases: []
   parents:
   - 9434
 1239425:
-  aliases: ['Myotis cf. keaysi']
+  aliases: []
   parents:
   - 9434
 867856:
-  aliases: ['Myotis cf. laniger CMF-2010']
+  aliases: []
   parents:
   - 9434
 1393939:
-  aliases: ['Myotis cf. laniger MR-2013']
+  aliases: []
   parents:
   - 9434
 1393940:
-  aliases: ['Myotis cf. longipes MR-2013']
+  aliases: []
   parents:
   - 9434
 1393941:
-  aliases: ['Myotis cf. montivagus MR-2013']
+  aliases: []
   parents:
   - 9434
 386773:
-  aliases: ['Myotis cf. muricola']
+  aliases: []
   parents:
   - 9434
 1007699:
-  aliases: ['Myotis cf. muricola BOLD:AAA8747']
+  aliases: []
   parents:
   - 9434
 1007698:
-  aliases: ['Myotis cf. muricola BOLD:AAA8748']
+  aliases: []
   parents:
   - 9434
 2742336:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108329']
+  aliases: []
   parents:
   - 9434
 2742337:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108330']
+  aliases: []
   parents:
   - 9434
 2742356:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108389']
+  aliases: []
   parents:
   - 9434
 2742358:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108403']
+  aliases: []
   parents:
   - 9434
 2742373:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108460']
+  aliases: []
   parents:
   - 9434
 2742377:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108484']
+  aliases: []
   parents:
   - 9434
 2742378:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108485']
+  aliases: []
   parents:
   - 9434
 2742380:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108513']
+  aliases: []
   parents:
   - 9434
 2742381:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108514']
+  aliases: []
   parents:
   - 9434
 2742382:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108515']
+  aliases: []
   parents:
   - 9434
 2742383:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108516']
+  aliases: []
   parents:
   - 9434
 2742386:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108519']
+  aliases: []
   parents:
   - 9434
 2742394:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108532']
+  aliases: []
   parents:
   - 9434
 2742395:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108533']
+  aliases: []
   parents:
   - 9434
 2742319:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108534']
+  aliases: []
   parents:
   - 9434
 2742327:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108535']
+  aliases: []
   parents:
   - 9434
 2742328:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108536']
+  aliases: []
   parents:
   - 9434
 2742320:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108537']
+  aliases: []
   parents:
   - 9434
 2742329:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108538']
+  aliases: []
   parents:
   - 9434
 2742396:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108539']
+  aliases: []
   parents:
   - 9434
 2742397:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108540']
+  aliases: []
   parents:
   - 9434
 2742330:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108541']
+  aliases: []
   parents:
   - 9434
 2742398:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108542']
+  aliases: []
   parents:
   - 9434
 2742399:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108543']
+  aliases: []
   parents:
   - 9434
 2742400:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108544']
+  aliases: []
   parents:
   - 9434
 2742401:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108545']
+  aliases: []
   parents:
   - 9434
 2742402:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108546']
+  aliases: []
   parents:
   - 9434
 2742403:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108547']
+  aliases: []
   parents:
   - 9434
 2742404:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108548']
+  aliases: []
   parents:
   - 9434
 2742405:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108549']
+  aliases: []
   parents:
   - 9434
 2742406:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108550']
+  aliases: []
   parents:
   - 9434
 2742407:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108551']
+  aliases: []
   parents:
   - 9434
 2742408:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108552']
+  aliases: []
   parents:
   - 9434
 2742409:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108553']
+  aliases: []
   parents:
   - 9434
 2742410:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108554']
+  aliases: []
   parents:
   - 9434
 2742413:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108569']
+  aliases: []
   parents:
   - 9434
 2742325:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108588']
+  aliases: []
   parents:
   - 9434
 2742326:
-  aliases: ['Myotis cf. mystacinus ZMB Mam 108592']
+  aliases: []
   parents:
   - 9434
 1110707:
-  aliases: ['Myotis cf. nattereri IC-2011']
+  aliases: []
   parents:
   - 9434
 1342385:
-  aliases: ['Myotis cf. nattereri IS-2013']
+  aliases: []
   parents:
   - 9434
 1004919:
-  aliases: ['Myotis cf. nattereri TD-2011']
+  aliases: []
   parents:
   - 9434
 1239426:
-  aliases: ['Myotis cf. nigricans']
+  aliases: []
   parents:
   - 9434
 306063:
-  aliases: ['Myotis cf. nipalensis']
+  aliases: []
   parents:
   - 9434
 392005:
-  aliases: ['Myotis cf. pequinius']
+  aliases: []
   parents:
   - 9434
 126404:
-  aliases: ['Myotis cf. punicus']
+  aliases: []
   parents:
   - 9434
 1239427:
-  aliases: ['Myotis cf. riparius']
+  aliases: []
   parents:
   - 9434
 1239428:
-  aliases: ['Myotis cf. simus']
+  aliases: []
   parents:
   - 9434
 1239429:
-  aliases: ['Myotis cf. thysanodes']
+  aliases: []
   parents:
   - 9434
 2781042:
-  aliases: ['Myotis cf. tschuliensis PSU 914']
+  aliases: []
   parents:
   - 9434
 2781043:
-  aliases: ['Myotis cf. tschuliensis PSU 915']
+  aliases: []
   parents:
   - 9434
 2781044:
-  aliases: ['Myotis cf. tschuliensis PSU 918']
+  aliases: []
   parents:
   - 9434
 2781045:
-  aliases: ['Myotis cf. tschuliensis PSU 946']
+  aliases: []
   parents:
   - 9434
 2781046:
-  aliases: ['Myotis cf. tschuliensis PSU 947']
+  aliases: []
   parents:
   - 9434
 2781047:
-  aliases: ['Myotis cf. tschuliensis PSU 948']
+  aliases: []
   parents:
   - 9434
 2781048:
-  aliases: ['Myotis cf. tschuliensis PSU 953']
+  aliases: []
   parents:
   - 9434
 1239430:
-  aliases: ['Myotis cf. yumanensis']
+  aliases: []
   parents:
   - 9434
 384634:
-  aliases: ['Myotis chiloensis']
+  aliases: []
   parents:
   - 9434
 225399:
-  aliases: ['Myotis chinensis']
+  aliases: []
   parents:
   - 9434
 257884:
-  aliases: ['Myotis ciliolabrum']
+  aliases: []
   parents:
   - 9434
 2940078:
-  aliases: ['Myotis clydejonesi']
+  aliases: []
   parents:
   - 9434
 2528591:
-  aliases: ['Myotis crypticus']
+  aliases: []
   parents:
   - 9434
 633646:
-  aliases: ['Myotis csorbai']
+  aliases: []
   parents:
   - 9434
 159324:
-  aliases: ['Myotis dasycneme']
+  aliases: []
   parents:
   - 9434
 98922:
-  aliases: ['Myotis daubentonii']
+  aliases: []
   parents:
   - 9434
 225400:
-  aliases: ['Myotis davidii']
+  aliases: []
   parents:
   - 9434
 2916631:
-  aliases: ['Myotis diminutus']
+  aliases: []
   parents:
   - 9434
 2940079:
-  aliases: ['Myotis dinellii']
+  aliases: []
   parents:
   - 9434
 159325:
-  aliases: ['Myotis dominicensis']
+  aliases: []
   parents:
   - 9434
 258937:
-  aliases: ['Myotis elegans']
+  aliases: []
   parents:
   - 9434
 109480:
-  aliases: ['Myotis emarginatus']
+  aliases: []
   parents:
   - 9434
 508772:
-  aliases: ['Myotis escalerai']
+  aliases: []
   parents:
   - 9434
 257883:
-  aliases: ['Myotis evotis']
+  aliases: []
   parents:
   - 9434
 3086133:
-  aliases: ['Myotis federatus']
+  aliases: []
   parents:
   - 9434
 452653:
-  aliases: ['Myotis fimbriatus']
+  aliases: []
   parents:
   - 9434
 3085897:
-  aliases: ['Myotis findleyi']
+  aliases: []
   parents:
   - 9434
 519446:
-  aliases: ['Myotis flavus']
+  aliases: []
   parents:
   - 9434
 225401:
-  aliases: ['Myotis formosus']
+  aliases: []
   parents:
   - 9434
 258938:
-  aliases: ['Myotis fortidens']
+  aliases: []
   parents:
   - 9434
 187012:
-  aliases: ['Myotis frater']
+  aliases: []
   parents:
   - 9434
 867857:
-  aliases: ['Myotis gomantongensis']
+  aliases: []
   parents:
   - 9434
 203698:
-  aliases: ['Myotis goudotii']
+  aliases: []
   parents:
   - 9434
 384635:
-  aliases: ['Myotis grisescens']
+  aliases: []
   parents:
   - 9434
 2986393:
-  aliases: ['Myotis handleyi']
+  aliases: []
   parents:
   - 9434
 159326:
-  aliases: ['Myotis hasseltii']
+  aliases: []
   parents:
   - 9434
 138977:
-  aliases: ['Myotis horsfieldii']
+  aliases: []
   parents:
   - 9434
 2510967:
-  aliases: ['Myotis hoveli']
+  aliases: []
   parents:
   - 9434
 2974270:
-  aliases: ['Myotis huariorum']
+  aliases: []
   parents:
   - 9434
 1849040:
-  aliases: ['Myotis hyrcanicus']
+  aliases: []
   parents:
   - 9434
 155915:
-  aliases: ['Myotis ikonnikovi']
+  aliases: []
   parents:
   - 9434
 1890223:
-  aliases: ['Myotis indochinensis']
+  aliases: []
   parents:
   - 9434
 2771586:
-  aliases: ['Myotis izecksohni']
+  aliases: []
   parents:
   - 9434
 159327:
-  aliases: ['Myotis keaysi']
+  aliases: []
   parents:
   - 9434
 257881:
-  aliases: ['Myotis keenii']
+  aliases: []
   parents:
   - 9434
 452654:
-  aliases: ['Myotis laniger']
+  aliases: []
   parents:
   - 9434
 2940080:
-  aliases: ['Myotis larensis']
+  aliases: []
   parents:
   - 9434
 2294180:
-  aliases: ['Myotis lavali']
+  aliases: []
   parents:
   - 9434
 27668:
-  aliases: ['Myotis leibii']
+  aliases: []
   parents:
   - 9434
 153285:
-  aliases: ['Myotis levis']
+  aliases: []
   parents:
   - 9434
 2794210:
-  aliases: ['Myotis longicaudatus']
+  aliases: []
   parents:
   - 9434
 587652:
-  aliases: ['Myotis longipes']
+  aliases: []
   parents:
   - 9434
 59463:
-  aliases: ['Myotis lucifugus']
+  aliases: []
   parents:
   - 9434
 187014:
-  aliases: ['Myotis macrodactylus']
+  aliases: []
   parents:
   - 9434
 138979:
-  aliases: ['Myotis macropus']
+  aliases: []
   parents:
   - 9434
 159328:
-  aliases: ['Myotis macrotarsus']
+  aliases: []
   parents:
   - 9434
 385035:
-  aliases: ['Myotis martiniquensis']
+  aliases: []
   parents:
   - 9434
 1442609:
-  aliases: ['Myotis melanorhinus']
+  aliases: []
   parents:
   - 9434
 2910750:
-  aliases: ['Myotis midastactus']
+  aliases: []
   parents:
   - 9434
 712103:
-  aliases: ['Myotis moluccarum']
+  aliases: []
   parents:
   - 9434
 159329:
-  aliases: ['Myotis montivagus']
+  aliases: []
   parents:
   - 9434
 2910751:
-  aliases: ['Myotis moratellii']
+  aliases: []
   parents:
   - 9434
 159330:
-  aliases: ['Myotis muricola']
+  aliases: []
   parents:
   - 9434
 51298:
-  aliases: ['Myotis myotis']
+  aliases: []
   parents:
   - 9434
 1507424:
-  aliases: ['Myotis myotis/blythii']
+  aliases: []
   parents:
   - 9434
 109479:
-  aliases: ['Myotis mystacinus']
+  aliases: []
   parents:
   - 9434
 109481:
-  aliases: ['Myotis nattereri']
+  aliases: []
   parents:
   - 9434
 1163727:
-  aliases: ['Myotis nesopolus']
+  aliases: []
   parents:
   - 9434
 153286:
-  aliases: ['Myotis nigricans']
+  aliases: []
   parents:
   - 9434
 1053984:
-  aliases: ['Myotis nigricans PS1']
+  aliases: []
   parents:
   - 9434
 1158978:
-  aliases: ['Myotis nigricans PS2']
+  aliases: []
   parents:
   - 9434
 2804329:
-  aliases: ['Myotis nimbaensis']
+  aliases: []
   parents:
   - 9434
 306062:
-  aliases: ['Myotis nipalensis']
+  aliases: []
   parents:
   - 9434
 3115248:
-  aliases: ['Myotis nustrale']
+  aliases: []
   parents:
   - 9434
 2497118:
-  aliases: ['Myotis occultus']
+  aliases: []
   parents:
   - 9434
 412095:
-  aliases: ['Myotis oxygnathus']
+  aliases: []
   parents:
   - 9434
 159332:
-  aliases: ['Myotis oxyotus']
+  aliases: []
   parents:
   - 9434
 2890400:
-  aliases: ['Myotis peninsularis']
+  aliases: []
   parents:
   - 9434
 392004:
-  aliases: ['Myotis pequinius']
+  aliases: []
   parents:
   - 9434
 526407:
-  aliases: ['Myotis petax']
+  aliases: []
   parents:
   - 9434
 2291616:
-  aliases: ['Myotis peytoni']
+  aliases: []
   parents:
   - 9434
 572313:
-  aliases: ['Myotis phanluongi']
+  aliases: []
   parents:
   - 9434
 2940081:
-  aliases: ['Myotis pilosatibialis']
+  aliases: []
   parents:
   - 9434
 203696:
-  aliases: ['Myotis pilosus']
+  aliases: []
   parents:
   - 9434
 1209081:
-  aliases: ['Myotis planiceps']
+  aliases: []
   parents:
   - 9434
 196298:
-  aliases: ['Myotis pruinosus']
+  aliases: []
   parents:
   - 9434
 386774:
-  aliases: ['Myotis punicus']
+  aliases: []
   parents:
   - 9434
 258939:
-  aliases: ['Myotis ridleyi']
+  aliases: []
   parents:
   - 9434
 124752:
-  aliases: ['Myotis riparius']
+  aliases: []
   parents:
   - 9434
 409037:
-  aliases: ['Myotis riparius PS1']
+  aliases: []
   parents:
   - 9434
 409038:
-  aliases: ['Myotis riparius PS2']
+  aliases: []
   parents:
   - 9434
 409039:
-  aliases: ['Myotis riparius PS3']
+  aliases: []
   parents:
   - 9434
 633647:
-  aliases: ['Myotis rosseti']
+  aliases: []
   parents:
   - 9434
 159333:
-  aliases: ['Myotis ruber']
+  aliases: []
   parents:
   - 9434
 1633875:
-  aliases: ['Myotis rufoniger']
+  aliases: []
   parents:
   - 9434
 159334:
-  aliases: ['Myotis schaubi']
+  aliases: []
   parents:
   - 9434
 294648:
-  aliases: ['Myotis scotti']
+  aliases: []
   parents:
   - 9434
 1633780:
-  aliases: ['Myotis secundus']
+  aliases: []
   parents:
   - 9434
 258941:
-  aliases: ['Myotis septentrionalis']
+  aliases: []
   parents:
   - 9434
 3380546:
-  aliases: ['Myotis sibiricus']
+  aliases: []
   parents:
   - 9434
 294649:
-  aliases: ['Myotis sicarius']
+  aliases: []
   parents:
   - 9434
 258940:
-  aliases: ['Myotis siligorensis']
+  aliases: []
   parents:
   - 9434
 270776:
-  aliases: ['Myotis simus']
+  aliases: []
   parents:
   - 9434
 385036:
-  aliases: ['Myotis sodalis']
+  aliases: []
   parents:
   - 9434
 1633781:
-  aliases: ['Myotis soror']
+  aliases: []
   parents:
   - 9434
 153287:
-  aliases: ['Myotis thysanodes']
+  aliases: []
   parents:
   - 9434
 233765:
-  aliases: ['Myotis tricolor']
+  aliases: []
   parents:
   - 9434
 2510970:
-  aliases: ['Myotis tschuliensis']
+  aliases: []
   parents:
   - 9434
 9435:
-  aliases: ['Myotis velifer']
+  aliases: []
   parents:
   - 9434
 233766:
-  aliases: ['Myotis vivesi']
+  aliases: []
   parents:
   - 9434
 159335:
-  aliases: ['Myotis volans']
+  aliases: []
   parents:
   - 9434
 519445:
-  aliases: ['Myotis watasei']
+  aliases: []
   parents:
   - 9434
 160974:
-  aliases: ['Myotis welwitschii']
+  aliases: []
   parents:
   - 9434
 187015:
-  aliases: ['Myotis yanbarensis']
+  aliases: []
   parents:
   - 9434
 159337:
-  aliases: ['Myotis yumanensis']
+  aliases: []
   parents:
   - 9434
 2528592:
-  aliases: ['Myotis zenatius']
+  aliases: []
   parents:
   - 9434
 94961:
-  aliases: ['Mystacina tuberculata']
+  aliases: []
   parents:
   - 94960
 155038:
-  aliases: ['Myzopoda aurita']
+  aliases: []
   parents:
   - 155037
 344224:
-  aliases: ['Myzopoda schliemanni']
+  aliases: []
   parents:
   - 155037
 290563:
-  aliases: ['Natalus jamaicensis']
+  aliases: []
   parents:
   - 59486
 2907237:
-  aliases: ['Natalus macrourus']
+  aliases: []
   parents:
   - 59486
 290562:
-  aliases: ['Natalus major']
+  aliases: []
   parents:
   - 59486
 1051665:
-  aliases: ['Natalus mexicanus']
+  aliases: []
   parents:
   - 59486
 290564:
-  aliases: ['Natalus saturatus']
+  aliases: []
   parents:
   - 59486
 155040:
-  aliases: ['Natalus stramineus']
+  aliases: []
   parents:
   - 59486
 59487:
-  aliases: ['Natalus tumidirostris']
+  aliases: []
   parents:
   - 59486
 3371119:
-  aliases: ['Neoeptesicus andinus']
+  aliases: []
   parents:
   - 3371080
 3371120:
-  aliases: ['Neoeptesicus brasiliensis']
+  aliases: []
   parents:
   - 3371080
 3371121:
-  aliases: ['Neoeptesicus chiriquinus']
+  aliases: []
   parents:
   - 3371080
 3371122:
-  aliases: ['Neoeptesicus diminutus']
+  aliases: []
   parents:
   - 3371080
 3371123:
-  aliases: ['Neoeptesicus furinalis']
+  aliases: []
   parents:
   - 3371080
 3371124:
-  aliases: ['Neoeptesicus innoxius']
+  aliases: []
   parents:
   - 3371080
 3371126:
-  aliases: ['Neoeptesicus orinocensis']
+  aliases: []
   parents:
   - 3371080
 3371128:
-  aliases: ['Neoeptesicus ulapesensis']
+  aliases: []
   parents:
   - 3371080
 2943202:
-  aliases: ['Neoromicia anchietae']
+  aliases: []
   parents:
   - 568926
 3370373:
-  aliases: ['Neoromicia bemainty']
+  aliases: []
   parents:
   - 568926
 3026396:
-  aliases: ['Neoromicia cf. anchietae Dom_M_07/UP14546']
+  aliases: []
   parents:
   - 568926
 3026397:
-  aliases: ['Neoromicia cf. anchietae Dom_M_23/UP14549']
+  aliases: []
   parents:
   - 568926
 2943210:
-  aliases: ['Neoromicia cf. anchietae ES-2022']
+  aliases: []
   parents:
   - 568926
 3026398:
-  aliases: ['Neoromicia cf. anchietae IYSIS_M_018/UP14538']
+  aliases: []
   parents:
   - 568926
 3026399:
-  aliases: ['Neoromicia cf. anchietae IYSIS_M_019/UP14539']
+  aliases: []
   parents:
   - 568926
 3026400:
-  aliases: ['Neoromicia cf. anchietae IYSIS_M_021/UP14541']
+  aliases: []
   parents:
   - 568926
 3026401:
-  aliases: ['Neoromicia cf. anchietae IYSIS_M_026/UP14542']
+  aliases: []
   parents:
   - 568926
 3026402:
-  aliases: ['Neoromicia cf. anchietae IYSIS_M_027/UP14543']
+  aliases: []
   parents:
   - 568926
 3026403:
-  aliases: ['Neoromicia cf. anchietae IYSIS_M_035/UP14544']
+  aliases: []
   parents:
   - 568926
 2448876:
-  aliases: ['Neoromicia cf. guineensisa DMR-2017']
+  aliases: []
   parents:
   - 568926
 1578730:
-  aliases: ['Neoromicia cf. melckorum KMN-2014']
+  aliases: []
   parents:
   - 568926
 1838144:
-  aliases: ['Neoromicia cf. somalica JA-2016a']
+  aliases: []
   parents:
   - 568926
 1332054:
-  aliases: ['Neoromicia guineensis']
+  aliases: []
   parents:
   - 568926
 1381466:
-  aliases: ['Neoromicia helios']
+  aliases: []
   parents:
   - 568926
 3076792:
-  aliases: ['Neoromicia hlandzeni']
+  aliases: []
   parents:
   - 568926
 258944:
-  aliases: ['Neoromicia somalicus']
+  aliases: []
   parents:
   - 568926
 1162377:
-  aliases: ['Neoromicia zuluensis']
+  aliases: []
   parents:
   - 568926
 3371070:
-  aliases: ['Nesonycteris']
+  aliases: []
   parents:
   - 9398
 94962:
-  aliases: ['Noctilio albiventris']
+  aliases: []
   parents:
   - 94958
 409040:
-  aliases: ['Noctilio albiventris PS1']
+  aliases: []
   parents:
   - 94958
 409042:
-  aliases: ['Noctilio albiventris PS2']
+  aliases: []
   parents:
   - 94958
 94963:
-  aliases: ['Noctilio leporinus']
+  aliases: []
   parents:
   - 94958
 187010:
-  aliases: ['Nyctalus aviator']
+  aliases: []
   parents:
   - 51299
 297253:
-  aliases: ['Nyctalus azoreum']
+  aliases: []
   parents:
   - 51299
 59464:
-  aliases: ['Nyctalus lasiopterus']
+  aliases: []
   parents:
   - 51299
 59465:
-  aliases: ['Nyctalus leisleri']
+  aliases: []
   parents:
   - 51299
 51300:
-  aliases: ['Nyctalus noctula']
+  aliases: []
   parents:
   - 51299
 375553:
-  aliases: ['Nyctalus plancyi']
+  aliases: []
   parents:
   - 51299
 249028:
-  aliases: ['Nycteris arge']
+  aliases: []
   parents:
   - 59466
 2596769:
-  aliases: ['Nycteris arge complex sp. 1 TD-2019']
+  aliases: []
   parents:
   - 59466
 2596770:
-  aliases: ['Nycteris arge complex sp. 2 TD-2019']
+  aliases: []
   parents:
   - 59466
 2596765:
-  aliases: ['Nycteris cf. hispida/aurita TD-2019']
+  aliases: []
   parents:
   - 59466
 2448878:
-  aliases: ['Nycteris cf. nana DMR-2017']
+  aliases: []
   parents:
   - 59466
 2596766:
-  aliases: ['Nycteris cf. thebaica 1 TD-2019']
+  aliases: []
   parents:
   - 59466
 2596767:
-  aliases: ['Nycteris cf. thebaica 2 TD-2019']
+  aliases: []
   parents:
   - 59466
 2596768:
-  aliases: ['Nycteris cf. thebaica 3 TD-2019']
+  aliases: []
   parents:
   - 59466
 178896:
-  aliases: ['Nycteris grandis']
+  aliases: []
   parents:
   - 59466
 270766:
-  aliases: ['Nycteris hispida']
+  aliases: []
   parents:
   - 59466
 2603853:
-  aliases: ['Nycteris hispida/aurita complex sp. TD-2019']
+  aliases: []
   parents:
   - 59466
 302404:
-  aliases: ['Nycteris javanica']
+  aliases: []
   parents:
   - 59466
 175523:
-  aliases: ['Nycteris macrotis']
+  aliases: []
   parents:
   - 59466
 2596771:
-  aliases: ['Nycteris macrotis complex sp. 1 TD-2019']
+  aliases: []
   parents:
   - 59466
 2596772:
-  aliases: ['Nycteris macrotis complex sp. 2 TD-2019']
+  aliases: []
   parents:
   - 59466
 2596773:
-  aliases: ['Nycteris macrotis complex sp. 3 TD-2019']
+  aliases: []
   parents:
   - 59466
 2860346:
-  aliases: ['Nycteris madagascariensis']
+  aliases: []
   parents:
   - 59466
 3370416:
-  aliases: ['Nycteris major']
+  aliases: []
   parents:
   - 59466
 2596774:
-  aliases: ['Nycteris nana complex sp. 1 TD-2019']
+  aliases: []
   parents:
   - 59466
 2596775:
-  aliases: ['Nycteris nana complex sp. 2 TD-2019']
+  aliases: []
   parents:
   - 59466
 59467:
-  aliases: ['Nycteris thebaica']
+  aliases: []
   parents:
   - 59466
 2603854:
-  aliases: ['Nycteris thebaica complex sp. 1 TD-2019']
+  aliases: []
   parents:
   - 59466
 2603855:
-  aliases: ['Nycteris thebaica complex sp. 2 TD-2019']
+  aliases: []
   parents:
   - 59466
 2596776:
-  aliases: ['Nycteris thebaica complex sp. 3 TD-2019']
+  aliases: []
   parents:
   - 59466
 2596777:
-  aliases: ['Nycteris thebaica complex sp. 4 TD-2019']
+  aliases: []
   parents:
   - 59466
 2596778:
-  aliases: ['Nycteris thebaica complex sp. 5 TD-2019']
+  aliases: []
   parents:
   - 59466
 2596779:
-  aliases: ['Nycteris thebaica complex sp. 6 TD-2019']
+  aliases: []
   parents:
   - 59466
 479723:
-  aliases: ['Nycteris tragata']
+  aliases: []
   parents:
   - 59466
 3370420:
-  aliases: ['Nycticeinops bellieri']
+  aliases: []
   parents:
   - 59468
 3416128:
-  aliases: ['Nycticeinops cf. crassulus']
+  aliases: []
   parents:
   - 59468
 2608643:
-  aliases: ['Nycticeinops cf. grandidieri JJA-2019']
+  aliases: []
   parents:
   - 59468
 3416123:
-  aliases: ['Nycticeinops cf. schlieffenii']
+  aliases: []
   parents:
   - 59468
 1286224:
-  aliases: ['Nycticeinops crassulus']
+  aliases: []
   parents:
   - 59468
 2778562:
-  aliases: ['Nycticeinops grandidieri']
+  aliases: []
   parents:
   - 59468
 3079008:
-  aliases: ['Nycticeinops macrocephalus']
+  aliases: []
   parents:
   - 59468
 153288:
-  aliases: ['Nycticeinops schlieffeni']
+  aliases: []
   parents:
   - 59468
 27670:
-  aliases: ['Nycticeius humeralis']
+  aliases: []
   parents:
   - 27669
 290566:
-  aliases: ['Nyctiellus lepidus']
+  aliases: []
   parents:
   - 290565
 3136026:
-  aliases: ['Nyctimeninae']
+  aliases: []
   parents:
   - 9398
 27626:
-  aliases: ['Nyctinomops aurispinosus']
+  aliases: []
   parents:
   - 27625
 258865:
-  aliases: ['Nyctinomops femorosaccus']
+  aliases: []
   parents:
   - 27625
 27627:
-  aliases: ['Nyctinomops laticaudatus']
+  aliases: []
   parents:
   - 27625
 124753:
-  aliases: ['Nyctinomops macrotis']
+  aliases: []
   parents:
   - 27625
 270777:
-  aliases: ['Nyctophilus arnhemensis']
+  aliases: []
   parents:
   - 59470
 2720893:
-  aliases: ['Nyctophilus bifax']
+  aliases: []
   parents:
   - 59470
 2720894:
-  aliases: ['Nyctophilus corbeni']
+  aliases: []
   parents:
   - 59470
 2720895:
-  aliases: ['Nyctophilus daedalus']
+  aliases: []
   parents:
   - 59470
 258945:
-  aliases: ['Nyctophilus geoffroyi']
+  aliases: []
   parents:
   - 59470
 59471:
-  aliases: ['Nyctophilus gouldi']
+  aliases: []
   parents:
   - 59470
 2720897:
-  aliases: ['Nyctophilus holtorum']
+  aliases: []
   parents:
   - 59470
 3079449:
-  aliases: ['Nyctophilus microdon']
+  aliases: []
   parents:
   - 59470
 3079505:
-  aliases: ['Nyctophilus microtis']
+  aliases: []
   parents:
   - 59470
 436904:
-  aliases: ['Otomops cf. formosus']
+  aliases: []
   parents:
   - 258866
 2218597:
-  aliases: ['Otomops harrisoni']
+  aliases: []
   parents:
   - 258866
 423244:
-  aliases: ['Otomops madagascariensis']
+  aliases: []
   parents:
   - 258866
 258867:
-  aliases: ['Otomops martiensseni']
+  aliases: []
   parents:
   - 258866
 436903:
-  aliases: ['Otomops wroughtoni']
+  aliases: []
   parents:
   - 258866
 153293:
-  aliases: ['Otonycteris hemprichii']
+  aliases: []
   parents:
   - 153292
 798163:
-  aliases: ['Otonycteris leucophaea']
+  aliases: []
   parents:
   - 153292
 3370473:
-  aliases: ['Ozimops beccarii']
+  aliases: []
   parents:
   - 2689069
 3370474:
-  aliases: ['Ozimops cobourgianus']
+  aliases: []
   parents:
   - 2689069
 3370475:
-  aliases: ['Ozimops halli']
+  aliases: []
   parents:
   - 2689069
 3370476:
-  aliases: ['Ozimops kitcheneri']
+  aliases: []
   parents:
   - 2689069
 3370477:
-  aliases: ['Ozimops loriae']
+  aliases: []
   parents:
   - 2689069
 3370478:
-  aliases: ['Ozimops lumsdenae']
+  aliases: []
   parents:
   - 2689069
 3056754:
-  aliases: ['Ozimops petersi']
+  aliases: []
   parents:
   - 2689069
 3370479:
-  aliases: ['Ozimops planiceps']
+  aliases: []
   parents:
   - 2689069
 3370480:
-  aliases: ['Ozimops ridei']
+  aliases: []
   parents:
   - 2689069
 712816:
-  aliases: ['Parastrellus hesperus']
+  aliases: []
   parents:
   - 712815
 1615588:
-  aliases: ['Paratriaenops']
+  aliases: []
   parents:
   - 1677019
 3371137:
-  aliases: ['Paremballonura atrata']
+  aliases: []
   parents:
   - 3371047
 3371138:
-  aliases: ['Paremballonura tiavato']
+  aliases: []
   parents:
   - 3371047
 27672:
-  aliases: ['Perimyotis subflavus']
+  aliases: []
   parents:
   - 2057181
 249013:
-  aliases: ['Peropteryx']
+  aliases: []
   parents:
   - 461394
 867864:
-  aliases: ['Philetor brachypterus']
+  aliases: []
   parents:
   - 867863
 867875:
-  aliases: ['Phoniscus jagorii']
+  aliases: []
   parents:
   - 867874
 148058:
-  aliases: ['Phylloderma']
+  aliases: []
   parents:
   - 40238
 138701:
-  aliases: ['Phyllonycteris']
+  aliases: []
   parents:
   - 138700
 148027:
-  aliases: ['Phyllops']
+  aliases: []
   parents:
   - 40234
 3242307:
-  aliases: ['Phyllostomidae sp.']
+  aliases: []
   parents:
   - 3242306
 9422:
-  aliases: ['Phyllostomus']
+  aliases: []
   parents:
   - 40238
 105295:
-  aliases: ['Pipistrellus abramus']
+  aliases: []
   parents:
   - 27671
 1081694:
-  aliases: ['Pipistrellus ceylonicus']
+  aliases: []
   parents:
   - 27671
 2748577:
-  aliases: ['Pipistrellus cf. ceylonicus MNR-2020']
+  aliases: []
   parents:
   - 27671
 867882:
-  aliases: ['Pipistrellus cf. coromandra CMF-2010']
+  aliases: []
   parents:
   - 27671
 2614833:
-  aliases: ['Pipistrellus cf. coromandra RM-2019']
+  aliases: []
   parents:
   - 27671
 203695:
-  aliases: ['Pipistrellus cf. javanicus']
+  aliases: []
   parents:
   - 27671
 1195385:
-  aliases: ['Pipistrellus cf. kuhlii']
+  aliases: []
   parents:
   - 27671
 1195386:
-  aliases: ['Pipistrellus cf. pygmaeus']
+  aliases: []
   parents:
   - 27671
 1007692:
-  aliases: ['Pipistrellus cf. tenuis BOLD:AAB2554']
+  aliases: []
   parents:
   - 27671
 258946:
-  aliases: ['Pipistrellus coromandra']
+  aliases: []
   parents:
   - 27671
 1928620:
-  aliases: ['Pipistrellus dhofarensis']
+  aliases: []
   parents:
   - 27671
 2902603:
-  aliases: ['Pipistrellus endoi']
+  aliases: []
   parents:
   - 27671
 412090:
-  aliases: ['Pipistrellus hanaki']
+  aliases: []
   parents:
   - 27671
 294653:
-  aliases: ['Pipistrellus hesperidus']
+  aliases: []
   parents:
   - 27671
 258947:
-  aliases: ['Pipistrellus javanicus']
+  aliases: []
   parents:
   - 27671
 270778:
-  aliases: ['Pipistrellus javanicus x tenuis']
+  aliases: []
   parents:
   - 27671
 59472:
-  aliases: ['Pipistrellus kuhlii']
+  aliases: []
   parents:
   - 27671
 183555:
-  aliases: ['Pipistrellus maderensis']
+  aliases: []
   parents:
   - 27671
 1001556:
-  aliases: ['Pipistrellus nanulus']
+  aliases: []
   parents:
   - 27671
 59473:
-  aliases: ['Pipistrellus nathusii']
+  aliases: []
   parents:
   - 27671
 867883:
-  aliases: ['Pipistrellus paterculus']
+  aliases: []
   parents:
   - 27671
 59474:
-  aliases: ['Pipistrellus pipistrellus']
+  aliases: []
   parents:
   - 27671
 246814:
-  aliases: ['Pipistrellus pygmaeus']
+  aliases: []
   parents:
   - 27671
 169058:
-  aliases: ['Pipistrellus pygmaeus x mediterraneus']
+  aliases: []
   parents:
   - 27671
 1578729:
-  aliases: ['Pipistrellus raceyi']
+  aliases: []
   parents:
   - 27671
 372076:
-  aliases: ['Pipistrellus rusticus']
+  aliases: []
   parents:
   - 27671
 526821:
-  aliases: ['Pipistrellus stenopterus']
+  aliases: []
   parents:
   - 27671
 258948:
-  aliases: ['Pipistrellus tenuis']
+  aliases: []
   parents:
   - 27671
 148085:
-  aliases: ['Platalina']
+  aliases: []
   parents:
   - 138703
 27657:
-  aliases: ['Platyrrhinus']
+  aliases: []
   parents:
   - 40234
 61862:
-  aliases: ['Plecotus auritus']
+  aliases: []
   parents:
   - 27673
 109483:
-  aliases: ['Plecotus austriacus']
+  aliases: []
   parents:
   - 27673
 196419:
-  aliases: ['Plecotus balensis']
+  aliases: []
   parents:
   - 27673
 231882:
-  aliases: ['Plecotus cf. kolombatovici']
+  aliases: []
   parents:
   - 27673
 1195387:
-  aliases: ['Plecotus cf. kozlovi']
+  aliases: []
   parents:
   - 27673
 272803:
-  aliases: ['Plecotus christii']
+  aliases: []
   parents:
   - 27673
 272799:
-  aliases: ['Plecotus gaisleri']
+  aliases: []
   parents:
   - 27673
 2918439:
-  aliases: ['Plecotus gobiensis']
+  aliases: []
   parents:
   - 27673
 360157:
-  aliases: ['Plecotus homochrous']
+  aliases: []
   parents:
   - 27673
 169060:
-  aliases: ['Plecotus kolombatovici']
+  aliases: []
   parents:
   - 27673
 360158:
-  aliases: ['Plecotus kozlovi']
+  aliases: []
   parents:
   - 27673
 242915:
-  aliases: ['Plecotus macrobullaris']
+  aliases: []
   parents:
   - 27673
 360160:
-  aliases: ['Plecotus ognevi']
+  aliases: []
   parents:
   - 27673
 360159:
-  aliases: ['Plecotus sacrimontis']
+  aliases: []
   parents:
   - 27673
 221272:
-  aliases: ['Plecotus sardus']
+  aliases: []
   parents:
   - 27673
 360163:
-  aliases: ['Plecotus strelkovi']
+  aliases: []
   parents:
   - 27673
 187391:
-  aliases: ['Plecotus teneriffae']
+  aliases: []
   parents:
   - 27673
 360161:
-  aliases: ['Plecotus turkmenicus']
+  aliases: []
   parents:
   - 27673
 231883:
-  aliases: ['Plecotus wardi']
+  aliases: []
   parents:
   - 27673
 27629:
-  aliases: ['Promops centralis']
+  aliases: []
   parents:
   - 27628
 2499806:
-  aliases: ['Promops davisoni']
+  aliases: []
   parents:
   - 27628
 1700841:
-  aliases: ['Promops nasutus']
+  aliases: []
   parents:
   - 27628
 2778567:
-  aliases: ['Pseudoromicia brunnea']
+  aliases: []
   parents:
   - 2778566
 1286221:
-  aliases: ['Pseudoromicia cf. rendalli SaSt-2013']
+  aliases: []
   parents:
   - 2778566
 3370647:
-  aliases: ['Pseudoromicia isabella']
+  aliases: []
   parents:
   - 2778566
 2778568:
-  aliases: ['Pseudoromicia kityoi']
+  aliases: []
   parents:
   - 2778566
 3024965:
-  aliases: ['Pseudoromicia mbamminkom']
+  aliases: []
   parents:
   - 2778566
 2778569:
-  aliases: ['Pseudoromicia nyanza']
+  aliases: []
   parents:
   - 2778566
 2911689:
-  aliases: ['Pseudoromicia principis']
+  aliases: []
   parents:
   - 2778566
 258943:
-  aliases: ['Pseudoromicia rendalli']
+  aliases: []
   parents:
   - 2778566
 1286220:
-  aliases: ['Pseudoromicia roseveari']
+  aliases: []
   parents:
   - 2778566
 3370648:
-  aliases: ['Pseudoromicia tenuipinnis']
+  aliases: []
   parents:
   - 2778566
 2203464:
-  aliases: ['Pteronotus alitonus']
+  aliases: []
   parents:
   - 59475
 94956:
-  aliases: ['Pteronotus davyi']
+  aliases: []
   parents:
   - 59475
 280979:
-  aliases: ['Pteronotus fuliginosus']
+  aliases: []
   parents:
   - 59475
 1884723:
-  aliases: ['Pteronotus fulvus']
+  aliases: []
   parents:
   - 59475
 118855:
-  aliases: ['Pteronotus gymnonotus']
+  aliases: []
   parents:
   - 59475
 118853:
-  aliases: ['Pteronotus macleayii']
+  aliases: []
   parents:
   - 59475
 1884717:
-  aliases: ['Pteronotus mesoamericanus']
+  aliases: []
   parents:
   - 59475
 59476:
-  aliases: ['Pteronotus parnellii']
+  aliases: []
   parents:
   - 59475
 118856:
-  aliases: ['Pteronotus personatus']
+  aliases: []
   parents:
   - 59475
 1884722:
-  aliases: ['Pteronotus psilotis']
+  aliases: []
   parents:
   - 59475
 280975:
-  aliases: ['Pteronotus pusillus']
+  aliases: []
   parents:
   - 59475
 118854:
-  aliases: ['Pteronotus quadridens']
+  aliases: []
   parents:
   - 59475
 280976:
-  aliases: ['Pteronotus rubiginosus']
+  aliases: []
   parents:
   - 59475
 77225:
-  aliases: ['Pteropodinae']
+  aliases: []
   parents:
   - 9398
 148028:
-  aliases: ['Pygoderma']
+  aliases: []
   parents:
   - 40234
 186995:
-  aliases: ['Rhinolophinae']
+  aliases: []
   parents:
   - 58055
 271602:
-  aliases: ['Rhinonicteris']
+  aliases: []
   parents:
   - 1677019
 138698:
-  aliases: ['Rhinophylla']
+  aliases: []
   parents:
   - 40231
 124755:
-  aliases: ['Rhinopoma']
+  aliases: []
   parents:
   - 124754
 2933650:
-  aliases: ['Rhogeessa aenea']
+  aliases: []
   parents:
   - 153294
 1905273:
-  aliases: ['Rhogeessa bickhami']
+  aliases: []
   parents:
   - 153294
 433358:
-  aliases: ['Rhogeessa genowaysi']
+  aliases: []
   parents:
   - 153294
 261758:
-  aliases: ['Rhogeessa io']
+  aliases: []
   parents:
   - 153294
 3072823:
-  aliases: ['Rhogeessa menchuae']
+  aliases: []
   parents:
   - 153294
 258949:
-  aliases: ['Rhogeessa mira']
+  aliases: []
   parents:
   - 153294
 153298:
-  aliases: ['Rhogeessa parvula']
+  aliases: []
   parents:
   - 153294
 3072452:
-  aliases: ['Rhogeessa permutandis']
+  aliases: []
   parents:
   - 153294
 153299:
-  aliases: ['Rhogeessa tumida']
+  aliases: []
   parents:
   - 153294
 433360:
-  aliases: ['Rhogeessa velilla']
+  aliases: []
   parents:
   - 153294
 249016:
-  aliases: ['Rhynchonycteris']
+  aliases: []
   parents:
   - 461394
 568178:
-  aliases: ['Rhyneptesicus nasutus']
+  aliases: []
   parents:
   - 3411094
 3136029:
-  aliases: ['Rousettinae']
+  aliases: []
   parents:
   - 9398
 446909:
-  aliases: ['Saccolaimus']
+  aliases: []
   parents:
   - 461395
 59481:
-  aliases: ['Saccopteryx']
+  aliases: []
   parents:
   - 461394
 258869:
-  aliases: ['Sauromys petrophilus']
+  aliases: []
   parents:
   - 999965
 2448838:
-  aliases: ['Scotoecus albofuscus']
+  aliases: []
   parents:
   - 258954
 1975661:
-  aliases: ['Scotoecus cf. hirundo AN-2017']
+  aliases: []
   parents:
   - 258954
 2664495:
-  aliases: ['Scotoecus hindei']
+  aliases: []
   parents:
   - 258954
 258955:
-  aliases: ['Scotoecus hirundo']
+  aliases: []
   parents:
   - 258954
 258957:
-  aliases: ['Scotomanes ornatus']
+  aliases: []
   parents:
   - 258956
 2559805:
-  aliases: ['Scotophilus andrewreborii']
+  aliases: []
   parents:
   - 153296
 258951:
-  aliases: ['Scotophilus borbonicus']
+  aliases: []
   parents:
   - 153296
 258952:
-  aliases: ['Scotophilus dinganii']
+  aliases: []
   parents:
   - 153296
 159339:
-  aliases: ['Scotophilus heathii']
+  aliases: []
   parents:
   - 153296
 153297:
-  aliases: ['Scotophilus kuhlii']
+  aliases: []
   parents:
   - 153296
 249034:
-  aliases: ['Scotophilus leucogaster']
+  aliases: []
   parents:
   - 153296
 2559806:
-  aliases: ['Scotophilus livingstonii']
+  aliases: []
   parents:
   - 153296
 565071:
-  aliases: ['Scotophilus marovaza']
+  aliases: []
   parents:
   - 153296
 380359:
-  aliases: ['Scotophilus nigrita']
+  aliases: []
   parents:
   - 153296
 1850281:
-  aliases: ['Scotophilus nucella']
+  aliases: []
   parents:
   - 153296
 258953:
-  aliases: ['Scotophilus nux']
+  aliases: []
   parents:
   - 153296
 565068:
-  aliases: ['Scotophilus robustus']
+  aliases: []
   parents:
   - 153296
 565070:
-  aliases: ['Scotophilus tandrefana']
+  aliases: []
   parents:
   - 153296
 2559807:
-  aliases: ['Scotophilus trujilloi']
+  aliases: []
   parents:
   - 153296
 312069:
-  aliases: ['Scotophilus viridis']
+  aliases: []
   parents:
   - 153296
 2830904:
-  aliases: ['Scotozous dormeri']
+  aliases: []
   parents:
   - 2830903
 3371159:
-  aliases: ['Setirostris eleryi']
+  aliases: []
   parents:
   - 3371055
 148029:
-  aliases: ['Sphaeronycteris']
+  aliases: []
   parents:
   - 40234
 148030:
-  aliases: ['Stenoderma']
+  aliases: []
   parents:
   - 40234
 27659:
-  aliases: ['Sturnira']
+  aliases: []
   parents:
   - 40234
 2783556:
-  aliases: ['Submyotodon caliginosus']
+  aliases: []
   parents:
   - 1636536
 385037:
-  aliases: ['Submyotodon latirostris']
+  aliases: []
   parents:
   - 1636536
 2783555:
-  aliases: ['Submyotodon moupinensis']
+  aliases: []
   parents:
   - 1636536
 302412:
-  aliases: ['Tadarida aegyptiaca']
+  aliases: []
   parents:
   - 9437
 1582105:
-  aliases: ['Tadarida australis']
+  aliases: []
   parents:
   - 9437
 9438:
-  aliases: ['Tadarida brasiliensis']
+  aliases: []
   parents:
   - 9437
 565237:
-  aliases: ['Tadarida fulminans']
+  aliases: []
   parents:
   - 9437
 187006:
-  aliases: ['Tadarida insignis']
+  aliases: []
   parents:
   - 9437
 2049285:
-  aliases: ['Tadarida latouchei']
+  aliases: []
   parents:
   - 9437
 59483:
-  aliases: ['Tadarida teniotis']
+  aliases: []
   parents:
   - 9437
 13280:
-  aliases: ['Taphozous']
+  aliases: []
   parents:
   - 461395
 867897:
-  aliases: ['Thainycteris aureocollaris']
+  aliases: []
   parents:
   - 3371075
 3371162:
-  aliases: ['Thainycteris torquata']
+  aliases: []
   parents:
   - 3371075
 155041:
-  aliases: ['Thyroptera discifera']
+  aliases: []
   parents:
   - 124758
 302413:
-  aliases: ['Thyroptera lavali']
+  aliases: []
   parents:
   - 124758
 124759:
-  aliases: ['Thyroptera tricolor']
+  aliases: []
   parents:
   - 124758
 1945625:
-  aliases: ['Thyroptera wynneae']
+  aliases: []
   parents:
   - 124758
 3370919:
-  aliases: ['Tomopeas ravum']
+  aliases: []
   parents:
   - 27631
 9425:
-  aliases: ['Tonatia']
+  aliases: []
   parents:
   - 40238
 148059:
-  aliases: ['Trachops']
+  aliases: []
   parents:
   - 40238
 258842:
-  aliases: ['Triaenops']
+  aliases: []
   parents:
   - 1677019
 3477446:
-  aliases: ['Trinycteris']
+  aliases: []
   parents:
   - 40238
 1964258:
-  aliases: ['Tylonycteris fulvida']
+  aliases: []
   parents:
   - 258958
 1964257:
-  aliases: ['Tylonycteris malayana']
+  aliases: []
   parents:
   - 258958
 258959:
-  aliases: ['Tylonycteris pachypus']
+  aliases: []
   parents:
   - 258958
 526822:
-  aliases: ['Tylonycteris robustula']
+  aliases: []
   parents:
   - 258958
 1964259:
-  aliases: ['Tylonycteris tonkinensis']
+  aliases: []
   parents:
   - 258958
 27662:
-  aliases: ['Uroderma']
+  aliases: []
   parents:
   - 40234
 148031:
-  aliases: ['Vampyressa']
+  aliases: []
   parents:
   - 40234
 148032:
-  aliases: ['Vampyrodes']
+  aliases: []
   parents:
   - 40234
 148060:
-  aliases: ['Vampyrum']
+  aliases: []
   parents:
   - 40238
 3416124:
-  aliases: ['Vansonia cf. rueppellii']
+  aliases: []
   parents:
   - 2778577
 412089:
-  aliases: ['Vansonia rueppellii']
+  aliases: []
   parents:
   - 2778577
 2720888:
-  aliases: ['Vespadelus darlingtoni']
+  aliases: []
   parents:
   - 2689072
 2720889:
-  aliases: ['Vespadelus finlaysoni']
+  aliases: []
   parents:
   - 2689072
 2720890:
-  aliases: ['Vespadelus pumilus']
+  aliases: []
   parents:
   - 2689072
 138978:
-  aliases: ['Vespadelus regulus']
+  aliases: []
   parents:
   - 2689072
 2765311:
-  aliases: ['Vespadelus troughtoni']
+  aliases: []
   parents:
   - 2689072
 258942:
-  aliases: ['Vespadelus vulturnus']
+  aliases: []
   parents:
   - 2689072
 59485:
-  aliases: ['Vespertilio murinus']
+  aliases: []
   parents:
   - 59484
 105273:
-  aliases: ['Vespertilio sinensis']
+  aliases: []
   parents:
   - 59484
 3117228:
-  aliases: ['Vespertilionidae sp.']
+  aliases: []
   parents:
   - 1296580
 1296583:
-  aliases: ['Vespertilionidae sp. BOLD:AAC0445']
+  aliases: []
   parents:
   - 1296580
 1296581:
-  aliases: ['Vespertilionidae sp. BOLD:AAH8358']
+  aliases: []
   parents:
   - 1296580
 1296582:
-  aliases: ['Vespertilionidae sp. SMM103-12']
+  aliases: []
   parents:
   - 1296580
 1470992:
-  aliases: ['Xeronycteris']
+  aliases: []
   parents:
   - 138703
 2648285:
-  aliases: ['unclassified Arielulus']
+  aliases: []
   parents:
   - 526815
 2677011:
-  aliases: ['unclassified Barbastella']
+  aliases: []
   parents:
   - 59448
 3411095:
-  aliases: ['unclassified Cnephaeus']
+  aliases: []
   parents:
   - 29077
 2648417:
-  aliases: ['unclassified Cynomops']
+  aliases: []
   parents:
   - 303306
 2643748:
-  aliases: ['unclassified Eptesicus']
+  aliases: []
   parents:
   - 3371007
 2619363:
-  aliases: ['unclassified Eumops']
+  aliases: []
   parents:
   - 27618
 2634626:
-  aliases: ['unclassified Glauconycteris']
+  aliases: []
   parents:
   - 909366
 2969770:
-  aliases: ['unclassified Histiotus']
+  aliases: []
   parents:
   - 258918
 2620613:
-  aliases: ['unclassified Hypsugo']
+  aliases: []
   parents:
   - 109484
 2618055:
-  aliases: ['unclassified Kerivoula']
+  aliases: []
   parents:
   - 59454
 2778580:
-  aliases: ['unclassified Laephotis']
+  aliases: []
   parents:
   - 258926
 2688611:
-  aliases: ['unclassified Lasiurus (in: bats)']
+  aliases: []
   parents:
   - 72130
 2645810:
-  aliases: ['unclassified Miniopterus']
+  aliases: []
   parents:
   - 9432
 2737245:
-  aliases: ['unclassified Molossops']
+  aliases: []
   parents:
   - 249031
 2625157:
-  aliases: ['unclassified Molossus']
+  aliases: []
   parents:
   - 27621
 2632858:
-  aliases: ['unclassified Mops']
+  aliases: []
   parents:
   - 258862
 2646271:
-  aliases: ['unclassified Mormopterus']
+  aliases: []
   parents:
   - 27623
 2685208:
-  aliases: ['unclassified Murina']
+  aliases: []
   parents:
   - 59488
 867169:
-  aliases: ['unclassified Myotis']
+  aliases: []
   parents:
   - 9434
 2625265:
-  aliases: ['unclassified Natalus']
+  aliases: []
   parents:
   - 59486
 3111556:
-  aliases: ['unclassified Neoplatymops']
+  aliases: []
   parents:
   - 3111555
 2636793:
-  aliases: ['unclassified Neoromicia']
+  aliases: []
   parents:
   - 568926
 2618540:
-  aliases: ['unclassified Nyctalus']
+  aliases: []
   parents:
   - 51299
 2623095:
-  aliases: ['unclassified Nycteris']
+  aliases: []
   parents:
   - 59466
 2968822:
-  aliases: ['unclassified Nyctinomops']
+  aliases: []
   parents:
   - 27625
 2720896:
-  aliases: ['unclassified Nyctophilus']
+  aliases: []
   parents:
   - 59470
 1032380:
-  aliases: ['unclassified Pipistrellus']
+  aliases: []
   parents:
   - 27671
 1032398:
-  aliases: ['unclassified Plecotus']
+  aliases: []
   parents:
   - 27673
 2907245:
-  aliases: ['unclassified Promops']
+  aliases: []
   parents:
   - 27628
 2778575:
-  aliases: ['unclassified Pseudoromicia']
+  aliases: []
   parents:
   - 2778566
 2632027:
-  aliases: ['unclassified Pteronotus']
+  aliases: []
   parents:
   - 59475
 3136031:
-  aliases: ['unclassified Pteropodidae']
+  aliases: []
   parents:
   - 9398
 1296575:
-  aliases: ['unclassified Rhinolophidae']
+  aliases: []
   parents:
   - 58055
 2622910:
-  aliases: ['unclassified Rhogeessa']
+  aliases: []
   parents:
   - 153294
 2636109:
-  aliases: ['unclassified Scotoecus']
+  aliases: []
   parents:
   - 258954
 2645158:
-  aliases: ['unclassified Scotophilus']
+  aliases: []
   parents:
   - 153296
 2636263:
-  aliases: ['unclassified Scotorepens']
+  aliases: []
   parents:
   - 270779
 2951462:
-  aliases: ['unclassified Submyotodon']
+  aliases: []
   parents:
   - 1636536
 2636308:
-  aliases: ['unclassified Tadarida']
+  aliases: []
   parents:
   - 9437
 58056:
-  aliases: ['Acerodon']
+  aliases: []
   parents:
   - 77225
 77226:
-  aliases: ['Aethalops']
+  aliases: []
   parents:
   - 3136027
 662936:
-  aliases: ['Alionycteris']
+  aliases: []
   parents:
   - 3136027
 148033:
-  aliases: ['Ametrida centurio']
+  aliases: []
   parents:
   - 148022
 3045830:
-  aliases: ['Anoura aequatoris']
+  aliases: []
   parents:
   - 27641
 2563022:
-  aliases: ['Anoura cadenai']
+  aliases: []
   parents:
   - 27641
 27642:
-  aliases: ['Anoura caudifer']
+  aliases: []
   parents:
   - 27641
 999941:
-  aliases: ['Anoura cultrata']
+  aliases: []
   parents:
   - 27641
 2563023:
-  aliases: ['Anoura fistulata']
+  aliases: []
   parents:
   - 27641
 148021:
-  aliases: ['Anoura geoffroyi']
+  aliases: []
   parents:
   - 27641
 409016:
-  aliases: ['Anoura latidens']
+  aliases: []
   parents:
   - 27641
 2563024:
-  aliases: ['Anoura luismanueli']
+  aliases: []
   parents:
   - 27641
 2718989:
-  aliases: ['Anoura peruana']
+  aliases: []
   parents:
   - 27641
 302397:
-  aliases: ['Anthops ornatus']
+  aliases: []
   parents:
   - 302396
 2980641:
-  aliases: ['Antrozous pallidus pacificus']
+  aliases: []
   parents:
   - 9440
 2980642:
-  aliases: ['Antrozous pallidus pallidus']
+  aliases: []
   parents:
   - 9440
 58058:
-  aliases: ['Aproteles']
+  aliases: []
   parents:
   - 77225
 148034:
-  aliases: ['Ardops nichollsi']
+  aliases: []
   parents:
   - 148023
 2093339:
-  aliases: ['Arielulus sp. GS16483']
+  aliases: []
   parents:
   - 2648285
 3425205:
-  aliases: ['Arielulus sp. j RL-2025']
+  aliases: []
   parents:
   - 2648285
 148035:
-  aliases: ['Ariteus flavescens']
+  aliases: []
   parents:
   - 148024
 3369720:
-  aliases: ['Artibeus aequatorialis']
+  aliases: []
   parents:
   - 9416
 283491:
-  aliases: ['Artibeus amplus']
+  aliases: []
   parents:
   - 9416
 51015:
-  aliases: ['Artibeus anderseni']
+  aliases: []
   parents:
   - 9416
 40239:
-  aliases: ['Artibeus aztecus']
+  aliases: []
   parents:
   - 9416
 416809:
-  aliases: ['Artibeus cf. jamaicensis']
+  aliases: []
   parents:
   - 9416
 410850:
-  aliases: ['Artibeus cf. obscurus']
+  aliases: []
   parents:
   - 9416
 40224:
-  aliases: ['Artibeus cinereus']
+  aliases: []
   parents:
   - 9416
 40225:
-  aliases: ['Artibeus concolor']
+  aliases: []
   parents:
   - 9416
 51010:
-  aliases: ['Artibeus fimbriatus']
+  aliases: []
   parents:
   - 9416
 51011:
-  aliases: ['Artibeus fraterculus']
+  aliases: []
   parents:
   - 9416
 40226:
-  aliases: ['Artibeus glaucus']
+  aliases: []
   parents:
   - 9416
 27654:
-  aliases: ['Artibeus hartii']
+  aliases: []
   parents:
   - 9416
 51012:
-  aliases: ['Artibeus hirsutus']
+  aliases: []
   parents:
   - 9416
 51013:
-  aliases: ['Artibeus inopinatus']
+  aliases: []
   parents:
   - 9416
 51014:
-  aliases: ['Artibeus intermedius']
+  aliases: []
   parents:
   - 9416
 9417:
-  aliases: ['Artibeus jamaicensis']
+  aliases: []
   parents:
   - 9416
 27634:
-  aliases: ['Artibeus lituratus']
+  aliases: []
   parents:
   - 9416
 40228:
-  aliases: ['Artibeus obscurus']
+  aliases: []
   parents:
   - 9416
 40230:
-  aliases: ['Artibeus planirostris']
+  aliases: []
   parents:
   - 9416
 406813:
-  aliases: ['Artibeus schwartzi']
+  aliases: []
   parents:
   - 9416
 40240:
-  aliases: ['Artibeus toltecus']
+  aliases: []
   parents:
   - 9416
 1932780:
-  aliases: ['Asellia arabica']
+  aliases: []
   parents:
   - 578339
 1932781:
-  aliases: ['Asellia italosomalica']
+  aliases: []
   parents:
   - 578339
 578340:
-  aliases: ['Asellia tridens']
+  aliases: []
   parents:
   - 578339
 1873076:
-  aliases: ['Aselliscus dongbacanus']
+  aliases: []
   parents:
   - 188567
 188568:
-  aliases: ['Aselliscus stoliczkanus']
+  aliases: []
   parents:
   - 188567
 409885:
-  aliases: ['Aselliscus tricuspidatus']
+  aliases: []
   parents:
   - 188567
 463802:
-  aliases: ['Balantiopteryx infusca']
+  aliases: []
   parents:
   - 148079
 463801:
-  aliases: ['Balantiopteryx io']
+  aliases: []
   parents:
   - 148079
 249010:
-  aliases: ['Balantiopteryx plicata']
+  aliases: []
   parents:
   - 148079
 77228:
-  aliases: ['Balionycteris']
+  aliases: []
   parents:
   - 3136027
 187022:
-  aliases: ['Barbastella sp. 7184']
+  aliases: []
   parents:
   - 2677011
 270781:
-  aliases: ['Boneia']
+  aliases: []
   parents:
   - 77225
 9421:
-  aliases: ['Brachyphylla cavernarum']
+  aliases: []
   parents:
   - 9420
 290570:
-  aliases: ['Brachyphylla nana']
+  aliases: []
   parents:
   - 9420
 270764:
-  aliases: ['Cardioderma cor']
+  aliases: []
   parents:
   - 270763
 348608:
-  aliases: ['Carollia benkeithi']
+  aliases: []
   parents:
   - 40232
 138695:
-  aliases: ['Carollia brevicauda']
+  aliases: []
   parents:
   - 40232
 409058:
-  aliases: ['Carollia brevicauda PS1']
+  aliases: []
   parents:
   - 40232
 409059:
-  aliases: ['Carollia brevicauda PS2']
+  aliases: []
   parents:
   - 40232
 138696:
-  aliases: ['Carollia castanea']
+  aliases: []
   parents:
   - 40232
 1331094:
-  aliases: ['Carollia manu']
+  aliases: []
   parents:
   - 40232
 40233:
-  aliases: ['Carollia perspicillata']
+  aliases: []
   parents:
   - 40232
 208969:
-  aliases: ['Carollia sowelli']
+  aliases: []
   parents:
   - 40232
 138697:
-  aliases: ['Carollia subrufa']
+  aliases: []
   parents:
   - 40232
 1091508:
-  aliases: ['Casinycteris']
+  aliases: []
   parents:
   - 3136029
 463805:
-  aliases: ['Centronycteris centralis']
+  aliases: []
   parents:
   - 461396
 461398:
-  aliases: ['Centronycteris maximiliani']
+  aliases: []
   parents:
   - 461396
 27644:
-  aliases: ['Centurio senex']
+  aliases: []
   parents:
   - 27643
 33544:
-  aliases: ['Chiroderma doriae']
+  aliases: []
   parents:
   - 27645
 2723912:
-  aliases: ['Chiroderma gorgasi']
+  aliases: []
   parents:
   - 27645
 33545:
-  aliases: ['Chiroderma improvisum']
+  aliases: []
   parents:
   - 27645
 27646:
-  aliases: ['Chiroderma salvini']
+  aliases: []
   parents:
   - 27645
 2771405:
-  aliases: ['Chiroderma scopaeum']
+  aliases: []
   parents:
   - 27645
 27647:
-  aliases: ['Chiroderma trinitatum']
+  aliases: []
   parents:
   - 27645
 33546:
-  aliases: ['Chiroderma villosum']
+  aliases: []
   parents:
   - 27645
 170235:
-  aliases: ['Chironax']
+  aliases: []
   parents:
   - 3136027
 148049:
-  aliases: ['Choeroniscus godmani']
+  aliases: []
   parents:
   - 148042
 249003:
-  aliases: ['Choeroniscus minor']
+  aliases: []
   parents:
   - 148042
 148050:
-  aliases: ['Choeronycteris mexicana']
+  aliases: []
   parents:
   - 148043
 148086:
-  aliases: ['Chrotopterus auritus']
+  aliases: []
   parents:
   - 148075
 302400:
-  aliases: ['Cloeotis percivali']
+  aliases: []
   parents:
   - 302399
 568167:
-  aliases: ['Cnephaeus bottae hingstoni']
+  aliases: []
   parents:
   - 3371009
 568166:
-  aliases: ['Cnephaeus bottae innesi']
+  aliases: []
   parents:
   - 3371009
 1332043:
-  aliases: ['Cnephaeus bottae omanensis']
+  aliases: []
   parents:
   - 3371009
 568165:
-  aliases: ['Cnephaeus bottae taftanimontis']
+  aliases: []
   parents:
   - 3371009
 1332047:
-  aliases: ['Cnephaeus hottentotus hottentotus']
+  aliases: []
   parents:
   - 3371012
 1332048:
-  aliases: ['Cnephaeus hottentotus pallidior']
+  aliases: []
   parents:
   - 3371012
 568169:
-  aliases: ['Cnephaeus isabellinus boscai']
+  aliases: []
   parents:
   - 3371013
 568168:
-  aliases: ['Cnephaeus isabellinus isabellinus']
+  aliases: []
   parents:
   - 3371013
 568173:
-  aliases: ['Cnephaeus serotinus andersoni']
+  aliases: []
   parents:
   - 3371021
 568171:
-  aliases: ['Cnephaeus serotinus mirza']
+  aliases: []
   parents:
   - 3371021
 1332050:
-  aliases: ['Cnephaeus serotinus pallens']
+  aliases: []
   parents:
   - 3371021
 568170:
-  aliases: ['Cnephaeus serotinus turcomanus']
+  aliases: []
   parents:
   - 3371021
 867837:
-  aliases: ['Cnephaeus sp. A JLE-2010']
+  aliases: []
   parents:
   - 3411095
 3043885:
-  aliases: ['Cnephaeus sp. AMNH M-183876']
+  aliases: []
   parents:
   - 3411095
 2662407:
-  aliases: ['Cnephaeus sp. AMNH M-278521']
+  aliases: []
   parents:
   - 3411095
 2662408:
-  aliases: ['Cnephaeus sp. AMNH M-278524']
+  aliases: []
   parents:
   - 3411095
 2801925:
-  aliases: ['Cnephaeus sp. Culul134']
+  aliases: []
   parents:
   - 3411095
 2801926:
-  aliases: ['Cnephaeus sp. Culul140']
+  aliases: []
   parents:
   - 3411095
 2801927:
-  aliases: ['Cnephaeus sp. Culul142']
+  aliases: []
   parents:
   - 3411095
 3043883:
-  aliases: ['Cnephaeus sp. FMNH 174918']
+  aliases: []
   parents:
   - 3411095
 2871750:
-  aliases: ['Cnephaeus sp. MNKM-5584']
+  aliases: []
   parents:
   - 3411095
 2871754:
-  aliases: ['Cnephaeus sp. MNKM-5585']
+  aliases: []
   parents:
   - 3411095
 2871752:
-  aliases: ['Cnephaeus sp. MNKM-5587']
+  aliases: []
   parents:
   - 3411095
 2871753:
-  aliases: ['Cnephaeus sp. MNKM-5588']
+  aliases: []
   parents:
   - 3411095
 2871751:
-  aliases: ['Cnephaeus sp. MNKM-5592']
+  aliases: []
   parents:
   - 3411095
 2801933:
-  aliases: ['Cnephaeus sp. Santa Fe195']
+  aliases: []
   parents:
   - 3411095
 3043884:
-  aliases: ['Cnephaeus sp. USNM 548682']
+  aliases: []
   parents:
   - 3411095
 3043886:
-  aliases: ['Cnephaeus sp. USNM 548683']
+  aliases: []
   parents:
   - 3411095
 1964285:
-  aliases: ['Cnephaeus sp. VN11-0076']
+  aliases: []
   parents:
   - 3411095
 3042451:
-  aliases: ['Cnephaeus sp. i XY-2023']
+  aliases: []
   parents:
   - 3411095
 1332053:
-  aliases: ['Cnephaues serotinus serotinus']
+  aliases: []
   parents:
   - 3371021
 187002:
-  aliases: ['Coelops frithii']
+  aliases: []
   parents:
   - 187001
 1116470:
-  aliases: ['Coelops robinsoni']
+  aliases: []
   parents:
   - 187001
 907075:
-  aliases: ['Coleura afra']
+  aliases: []
   parents:
   - 461397
 1244808:
-  aliases: ['Coleura kibomalandy']
+  aliases: []
   parents:
   - 461397
 1116479:
-  aliases: ['Coleura seychellensis']
+  aliases: []
   parents:
   - 461397
 249012:
-  aliases: ['Cormura brevirostris']
+  aliases: []
   parents:
   - 249011
 1282260:
-  aliases: ['Corynorhinus townsendii australis']
+  aliases: []
   parents:
   - 124745
 1684320:
-  aliases: ['Corynorhinus townsendii ingens']
+  aliases: []
   parents:
   - 124745
 451111:
-  aliases: ['Corynorhinus townsendii pallescens']
+  aliases: []
   parents:
   - 124745
 451110:
-  aliases: ['Corynorhinus townsendii townsendii']
+  aliases: []
   parents:
   - 124745
 3079487:
-  aliases: ['Corynorhinus townsendii virginianus']
+  aliases: []
   parents:
   - 124745
 208972:
-  aliases: ['Craseonycteris thonglongyai']
+  aliases: []
   parents:
   - 208971
 1833836:
-  aliases: ['Cynomops abrasus mastivus']
+  aliases: []
   parents:
   - 748910
 1833840:
-  aliases: ['Cynomops paranus milleri']
+  aliases: []
   parents:
   - 303307
 1833841:
-  aliases: ['Cynomops sp. PN181']
+  aliases: []
   parents:
   - 2648417
 1833842:
-  aliases: ['Cynomops sp. PN293']
+  aliases: []
   parents:
   - 2648417
 1833843:
-  aliases: ['Cynomops sp. PN299']
+  aliases: []
   parents:
   - 2648417
 1833844:
-  aliases: ['Cynomops sp. PN305']
+  aliases: []
   parents:
   - 2648417
 1833845:
-  aliases: ['Cynomops sp. PN310']
+  aliases: []
   parents:
   - 2648417
 1833846:
-  aliases: ['Cynomops sp. PN316']
+  aliases: []
   parents:
   - 2648417
 1833847:
-  aliases: ['Cynomops sp. PN73']
+  aliases: []
   parents:
   - 2648417
 1833848:
-  aliases: ['Cynomops sp. PN73B']
+  aliases: []
   parents:
   - 2648417
 1833849:
-  aliases: ['Cynomops sp. PN88']
+  aliases: []
   parents:
   - 2648417
 1848985:
-  aliases: ['Cynomops sp. USNM 319084']
+  aliases: []
   parents:
   - 2648417
 9399:
-  aliases: ['Cynopterus']
+  aliases: []
   parents:
   - 3136027
 409020:
-  aliases: ['Cyttarops alecto']
+  aliases: []
   parents:
   - 409019
 2066583:
-  aliases: ['Dasypterus intermedius floridanus']
+  aliases: []
   parents:
   - 592573
 2738915:
-  aliases: ['Dasypterus intermedius intermedius']
+  aliases: []
   parents:
   - 592573
 409017:
-  aliases: ['Dermanura bogotensis']
+  aliases: []
   parents:
   - 563992
 3369931:
-  aliases: ['Dermanura gnomus']
+  aliases: []
   parents:
   - 563992
 594609:
-  aliases: ['Dermanura incomitata']
+  aliases: []
   parents:
   - 563992
 40229:
-  aliases: ['Dermanura phaeotis']
+  aliases: []
   parents:
   - 563992
 563994:
-  aliases: ['Dermanura rava']
+  aliases: []
   parents:
   - 563992
 515994:
-  aliases: ['Desmalopex']
+  aliases: []
   parents:
   - 77225
 9430:
-  aliases: ['Desmodus rotundus']
+  aliases: []
   parents:
   - 9429
 148087:
-  aliases: ['Diaemus youngi']
+  aliases: []
   parents:
   - 148076
 148088:
-  aliases: ['Diclidurus albus']
+  aliases: []
   parents:
   - 148078
 463803:
-  aliases: ['Diclidurus ingens']
+  aliases: []
   parents:
   - 148078
 409021:
-  aliases: ['Diclidurus isabella']
+  aliases: []
   parents:
   - 148078
 210810:
-  aliases: ['Diclidurus scutatus']
+  aliases: []
   parents:
   - 148078
 148089:
-  aliases: ['Diphylla ecaudata']
+  aliases: []
   parents:
   - 148077
 42146:
-  aliases: ['Dobsonia']
+  aliases: []
   parents:
   - 77225
 2664497:
-  aliases: ['Doryrhina camerunensis']
+  aliases: []
   parents:
   - 2664496
 2735189:
-  aliases: ['Doryrhina cf. camerunensis TD-2020']
+  aliases: []
   parents:
   - 2664496
 249021:
-  aliases: ['Doryrhina cyclops']
+  aliases: []
   parents:
   - 2664496
 2735198:
-  aliases: ['Doryrhina cyclops complex sp. lineage 2']
+  aliases: []
   parents:
   - 2664496
 326080:
-  aliases: ['Dyacopterus']
+  aliases: []
   parents:
   - 3136027
 148036:
-  aliases: ['Ectophylla alba']
+  aliases: []
   parents:
   - 148025
 58062:
-  aliases: ['Eidolon']
+  aliases: []
   parents:
   - 77225
 187004:
-  aliases: ['Emballonura alecto']
+  aliases: []
   parents:
   - 110939
 446907:
-  aliases: ['Emballonura beccarii']
+  aliases: []
   parents:
   - 110939
 1116478:
-  aliases: ['Emballonura dianae']
+  aliases: []
   parents:
   - 110939
 175525:
-  aliases: ['Emballonura monticola']
+  aliases: []
   parents:
   - 110939
 446908:
-  aliases: ['Emballonura raffrayana']
+  aliases: []
   parents:
   - 110939
 170234:
-  aliases: ['Emballonura semicaudata']
+  aliases: []
   parents:
   - 110939
 450945:
-  aliases: ['Emballonura serii']
+  aliases: []
   parents:
   - 110939
 58064:
-  aliases: ['Eonycteris']
+  aliases: []
   parents:
   - 3136029
 1246964:
-  aliases: ['Epomophorini']
+  aliases: []
   parents:
   - 3136030
 3079504:
-  aliases: ['Eptesicus fuscus bernardinus']
+  aliases: []
   parents:
   - 29078
 2871749:
-  aliases: ['Eptesicus fuscus fuscus']
+  aliases: []
   parents:
   - 29078
 2871748:
-  aliases: ['Eptesicus fuscus miradorensis']
+  aliases: []
   parents:
   - 29078
 3242296:
-  aliases: ['Eptesicus fuscus wetmorei']
+  aliases: []
   parents:
   - 29078
 3042450:
-  aliases: ['Eptesicus sp.']
+  aliases: []
   parents:
   - 2643748
 290569:
-  aliases: ['Erophylla bombifrons']
+  aliases: []
   parents:
   - 148091
 148092:
-  aliases: ['Erophylla sezekorni']
+  aliases: []
   parents:
   - 148091
 507607:
-  aliases: ['Eumops glaucinus floridanus']
+  aliases: []
   parents:
   - 27619
 1504290:
-  aliases: ['Eumops sp. LMM-2014a']
+  aliases: []
   parents:
   - 2619363
 507608:
-  aliases: ['Eumops sp. MMM-2008']
+  aliases: []
   parents:
   - 2619363
 148071:
-  aliases: ['Gardnerycteris crenulata']
+  aliases: []
   parents:
   - 1920523
 2358194:
-  aliases: ['Gardnerycteris keenani']
+  aliases: []
   parents:
   - 1920523
 2358195:
-  aliases: ['Gardnerycteris koepckeae']
+  aliases: []
   parents:
   - 1920523
 3465175:
-  aliases: ['Glauconycteris sp.']
+  aliases: []
   parents:
   - 2634626
 2448870:
-  aliases: ['Glauconycteris sp. DMR-2017']
+  aliases: []
   parents:
   - 2634626
 177159:
-  aliases: ['Glossophaga commissarisi']
+  aliases: []
   parents:
   - 27637
 177160:
-  aliases: ['Glossophaga leachii']
+  aliases: []
   parents:
   - 27637
 177161:
-  aliases: ['Glossophaga longirostris']
+  aliases: []
   parents:
   - 27637
 177162:
-  aliases: ['Glossophaga morenoi']
+  aliases: []
   parents:
   - 27637
 2994998:
-  aliases: ['Glossophaga mutica']
+  aliases: []
   parents:
   - 27637
 27638:
-  aliases: ['Glossophaga soricina']
+  aliases: []
   parents:
   - 27637
 148064:
-  aliases: ['Glyphonycteris daviesi']
+  aliases: []
   parents:
   - 409028
 409029:
-  aliases: ['Glyphonycteris sylvestris']
+  aliases: []
   parents:
   - 409028
 301157:
-  aliases: ['Haplonycteris']
+  aliases: []
   parents:
   - 3136027
 378749:
-  aliases: ['Harpyionycteris']
+  aliases: []
   parents:
   - 3136028
 249020:
-  aliases: ['Hipposideros abae']
+  aliases: []
   parents:
   - 58068
 1001821:
-  aliases: ['Hipposideros aff. ruber']
+  aliases: []
   parents:
   - 58068
 1197849:
-  aliases: ['Hipposideros alongensis']
+  aliases: []
   parents:
   - 58068
 186990:
-  aliases: ['Hipposideros armiger']
+  aliases: []
   parents:
   - 58068
 279184:
-  aliases: ['Hipposideros ater']
+  aliases: []
   parents:
   - 58068
 635128:
-  aliases: ['Hipposideros beatus']
+  aliases: []
   parents:
   - 58068
 2735199:
-  aliases: ['Hipposideros beatus complex sp. lineage 2']
+  aliases: []
   parents:
   - 58068
 157961:
-  aliases: ['Hipposideros bicolor']
+  aliases: []
   parents:
   - 58068
 869068:
-  aliases: ["Hipposideros bicolor '131 KHz'"]
+  aliases: []
   parents:
   - 58068
 869067:
-  aliases: ["Hipposideros bicolor '142 KHz'"]
+  aliases: []
   parents:
   - 58068
 1116360:
-  aliases: ['Hipposideros boeadii']
+  aliases: []
   parents:
   - 58068
 302402:
-  aliases: ['Hipposideros caffer']
+  aliases: []
   parents:
   - 58068
 2735201:
-  aliases: ['Hipposideros caffer complex sp. lineage 1']
+  aliases: []
   parents:
   - 58068
 2735202:
-  aliases: ['Hipposideros caffer complex sp. lineage 2']
+  aliases: []
   parents:
   - 58068
 2735203:
-  aliases: ['Hipposideros caffer complex sp. lineage 3']
+  aliases: []
   parents:
   - 58068
 2735204:
-  aliases: ['Hipposideros caffer complex sp. lineage 5']
+  aliases: []
   parents:
   - 58068
 2735205:
-  aliases: ['Hipposideros caffer complex sp. lineage 6']
+  aliases: []
   parents:
   - 58068
 2735206:
-  aliases: ['Hipposideros caffer complex sp. lineage 7']
+  aliases: []
   parents:
   - 58068
 2735207:
-  aliases: ['Hipposideros caffer complex sp. lineage 8']
+  aliases: []
   parents:
   - 58068
 334198:
-  aliases: ['Hipposideros calcaratus']
+  aliases: []
   parents:
   - 58068
 170233:
-  aliases: ['Hipposideros cervinus']
+  aliases: []
   parents:
   - 58068
 2974923:
-  aliases: ['Hipposideros cf. abae ZMMU S-189528']
+  aliases: []
   parents:
   - 58068
 2973845:
-  aliases: ['Hipposideros cf. armiger ZMMU S-167159']
+  aliases: []
   parents:
   - 58068
 867823:
-  aliases: ['Hipposideros cf. ater CMF-2010']
+  aliases: []
   parents:
   - 58068
 2735190:
-  aliases: ['Hipposideros cf. bicolor TD-2020']
+  aliases: []
   parents:
   - 58068
 2735191:
-  aliases: ['Hipposideros cf. cervinus TD-2020']
+  aliases: []
   parents:
   - 58068
 867825:
-  aliases: ['Hipposideros cf. cineraceus CMF-2010']
+  aliases: []
   parents:
   - 58068
 3025977:
-  aliases: ['Hipposideros cf. grandis S-195419']
+  aliases: []
   parents:
   - 58068
 3025978:
-  aliases: ['Hipposideros cf. grandis S-195420']
+  aliases: []
   parents:
   - 58068
 2973841:
-  aliases: ['Hipposideros cf. grandis ZMMU S-195421']
+  aliases: []
   parents:
   - 58068
 2973842:
-  aliases: ['Hipposideros cf. griffini ZMMU S-195483']
+  aliases: []
   parents:
   - 58068
 3117227:
-  aliases: ['Hipposideros cf. larvatus']
+  aliases: []
   parents:
   - 58068
 2821768:
-  aliases: ['Hipposideros cf. larvatus BM.2019.05.07']
+  aliases: []
   parents:
   - 58068
 3025988:
-  aliases: ['Hipposideros cf. larvatus CLC17']
+  aliases: []
   parents:
   - 58068
 3025967:
-  aliases: ['Hipposideros cf. larvatus CLC18']
+  aliases: []
   parents:
   - 58068
 3025971:
-  aliases: ['Hipposideros cf. larvatus NTS14']
+  aliases: []
   parents:
   - 58068
 3025972:
-  aliases: ['Hipposideros cf. larvatus NTS15']
+  aliases: []
   parents:
   - 58068
 3025987:
-  aliases: ['Hipposideros cf. larvatus NTS23']
+  aliases: []
   parents:
   - 58068
 3025973:
-  aliases: ['Hipposideros cf. larvatus NTS51']
+  aliases: []
   parents:
   - 58068
 3025991:
-  aliases: ['Hipposideros cf. larvatus S-195977']
+  aliases: []
   parents:
   - 58068
 3025992:
-  aliases: ['Hipposideros cf. larvatus S-195978']
+  aliases: []
   parents:
   - 58068
 3025993:
-  aliases: ['Hipposideros cf. larvatus VN17-278']
+  aliases: []
   parents:
   - 58068
 3025994:
-  aliases: ['Hipposideros cf. larvatus VN17-279']
+  aliases: []
   parents:
   - 58068
 3025974:
-  aliases: ['Hipposideros cf. larvatus Y1']
+  aliases: []
   parents:
   - 58068
 3025985:
-  aliases: ['Hipposideros cf. larvatus Y2']
+  aliases: []
   parents:
   - 58068
 3025986:
-  aliases: ['Hipposideros cf. larvatus Y22']
+  aliases: []
   parents:
   - 58068
 2528455:
-  aliases: ['Hipposideros cf. obscurus MRMD2479']
+  aliases: []
   parents:
   - 58068
 1007696:
-  aliases: ['Hipposideros cf. pomona BOLD:AAS6441']
+  aliases: []
   parents:
   - 58068
 3025965:
-  aliases: ['Hipposideros cf. poutensis BTL65']
+  aliases: []
   parents:
   - 58068
 3025966:
-  aliases: ['Hipposideros cf. poutensis BTL71']
+  aliases: []
   parents:
   - 58068
 3025975:
-  aliases: ['Hipposideros cf. poutensis M100']
+  aliases: []
   parents:
   - 58068
 3025976:
-  aliases: ['Hipposideros cf. poutensis M107']
+  aliases: []
   parents:
   - 58068
 3025968:
-  aliases: ['Hipposideros cf. poutensis NTS135']
+  aliases: []
   parents:
   - 58068
 3025969:
-  aliases: ['Hipposideros cf. poutensis NTS136']
+  aliases: []
   parents:
   - 58068
 3025970:
-  aliases: ['Hipposideros cf. poutensis NTS137']
+  aliases: []
   parents:
   - 58068
 3025989:
-  aliases: ['Hipposideros cf. poutensis S-190295']
+  aliases: []
   parents:
   - 58068
 3025990:
-  aliases: ['Hipposideros cf. poutensis S-190297']
+  aliases: []
   parents:
   - 58068
 3025980:
-  aliases: ['Hipposideros cf. poutensis SVK-18-069']
+  aliases: []
   parents:
   - 58068
 3025981:
-  aliases: ['Hipposideros cf. poutensis SVK-18-070']
+  aliases: []
   parents:
   - 58068
 3025982:
-  aliases: ['Hipposideros cf. poutensis SVK-18-073']
+  aliases: []
   parents:
   - 58068
 3025983:
-  aliases: ['Hipposideros cf. poutensis SVK-18-077']
+  aliases: []
   parents:
   - 58068
 1536428:
-  aliases: ['Hipposideros cf. ruber']
+  aliases: []
   parents:
   - 58068
 2973844:
-  aliases: ['Hipposideros cf. ruber ZMMU S-192897']
+  aliases: []
   parents:
   - 58068
 270698:
-  aliases: ['Hipposideros cineraceus']
+  aliases: []
   parents:
   - 58068
 1207988:
-  aliases: ['Hipposideros coronatus']
+  aliases: []
   parents:
   - 58068
 279183:
-  aliases: ['Hipposideros coxi']
+  aliases: []
   parents:
   - 58068
 1539854:
-  aliases: ['Hipposideros demissus']
+  aliases: []
   parents:
   - 58068
 59453:
-  aliases: ['Hipposideros diadema']
+  aliases: []
   parents:
   - 58068
 270735:
-  aliases: ['Hipposideros dinops']
+  aliases: []
   parents:
   - 58068
 646525:
-  aliases: ['Hipposideros doriae']
+  aliases: []
   parents:
   - 58068
 1980583:
-  aliases: ['Hipposideros durgadasi']
+  aliases: []
   parents:
   - 58068
 279182:
-  aliases: ['Hipposideros dyacorum']
+  aliases: []
   parents:
   - 58068
 3030809:
-  aliases: ['Hipposideros einnaythu']
+  aliases: []
   parents:
   - 58068
 584995:
-  aliases: ['Hipposideros fuliginosus']
+  aliases: []
   parents:
   - 58068
 599854:
-  aliases: ['Hipposideros fulvus']
+  aliases: []
   parents:
   - 58068
 58069:
-  aliases: ['Hipposideros galeritus']
+  aliases: []
   parents:
   - 58068
 2921318:
-  aliases: ['Hipposideros gentilis']
+  aliases: []
   parents:
   - 58068
 1197857:
-  aliases: ['Hipposideros griffini']
+  aliases: []
   parents:
   - 58068
 867827:
-  aliases: ['Hipposideros halophyllus']
+  aliases: []
   parents:
   - 58068
 1548708:
-  aliases: ['Hipposideros hypophyllus']
+  aliases: []
   parents:
   - 58068
 584997:
-  aliases: ['Hipposideros jonesi']
+  aliases: []
   parents:
   - 58068
 334199:
-  aliases: ['Hipposideros khaokhouayensis']
+  aliases: []
   parents:
   - 58068
 3030810:
-  aliases: ['Hipposideros kingstonae']
+  aliases: []
   parents:
   - 58068
 2448887:
-  aliases: ['Hipposideros kunzi']
+  aliases: []
   parents:
   - 58068
 1536425:
-  aliases: ['Hipposideros lamottei']
+  aliases: []
   parents:
   - 58068
 867828:
-  aliases: ['Hipposideros lankadiva']
+  aliases: []
   parents:
   - 58068
 354741:
-  aliases: ['Hipposideros larvatus sensu lato']
+  aliases: []
   parents:
   - 58068
 1207989:
-  aliases: ['Hipposideros lekaguli']
+  aliases: []
   parents:
   - 58068
 867829:
-  aliases: ['Hipposideros lylei']
+  aliases: []
   parents:
   - 58068
 1536426:
-  aliases: ['Hipposideros marisae']
+  aliases: []
   parents:
   - 58068
 3037311:
-  aliases: ['Hipposideros nicobarulae']
+  aliases: []
   parents:
   - 58068
 1116357:
-  aliases: ['Hipposideros obscurus']
+  aliases: []
   parents:
   - 58068
 1116358:
-  aliases: ['Hipposideros pelingensis']
+  aliases: []
   parents:
   - 58068
 867831:
-  aliases: ['Hipposideros pendleburyi']
+  aliases: []
   parents:
   - 58068
 334201:
-  aliases: ['Hipposideros pomona']
+  aliases: []
   parents:
   - 58068
 2970948:
-  aliases: ['Hipposideros poutensis']
+  aliases: []
   parents:
   - 58068
 188569:
-  aliases: ['Hipposideros pratti']
+  aliases: []
   parents:
   - 58068
 1207990:
-  aliases: ['Hipposideros pygmaeus']
+  aliases: []
   parents:
   - 58068
 279181:
-  aliases: ['Hipposideros ridleyi']
+  aliases: []
   parents:
   - 58068
 334200:
-  aliases: ['Hipposideros rotalis']
+  aliases: []
   parents:
   - 58068
 463808:
-  aliases: ['Hipposideros ruber']
+  aliases: []
   parents:
   - 58068
 2735208:
-  aliases: ['Hipposideros ruber complex sp. lineage 1']
+  aliases: []
   parents:
   - 58068
 2735209:
-  aliases: ['Hipposideros ruber complex sp. lineage 2']
+  aliases: []
   parents:
   - 58068
 2735210:
-  aliases: ['Hipposideros ruber complex sp. lineage 4']
+  aliases: []
   parents:
   - 58068
 1116359:
-  aliases: ['Hipposideros scutinares']
+  aliases: []
   parents:
   - 58068
 394056:
-  aliases: ['Hipposideros speoris']
+  aliases: []
   parents:
   - 58068
 185215:
-  aliases: ['Hipposideros turpis']
+  aliases: []
   parents:
   - 58068
 3043887:
-  aliases: ['Histiotus montanus inambarus']
+  aliases: []
   parents:
   - 1161940
 3044320:
-  aliases: ['Histiotus sp.']
+  aliases: []
   parents:
   - 2969770
 1470804:
-  aliases: ['Hsunycteris cadenai']
+  aliases: []
   parents:
   - 1470803
 2161707:
-  aliases: ['Hsunycteris dashe']
+  aliases: []
   parents:
   - 1470803
 1470994:
-  aliases: ['Hsunycteris pattoni']
+  aliases: []
   parents:
   - 1470803
 138705:
-  aliases: ['Hsunycteris thomasi']
+  aliases: []
   parents:
   - 1470803
 148051:
-  aliases: ['Hylonycteris underwoodi']
+  aliases: []
   parents:
   - 148044
 867833:
-  aliases: ['Hypsugo sp. A CMF-2010']
+  aliases: []
   parents:
   - 2620613
 509027:
-  aliases: ['Hypsugo sp. C1']
+  aliases: []
   parents:
   - 2620613
 509028:
-  aliases: ['Hypsugo sp. C2']
+  aliases: []
   parents:
   - 2620613
 509029:
-  aliases: ['Hypsugo sp. C4']
+  aliases: []
   parents:
   - 2620613
 412093:
-  aliases: ['Hypsugo sp. FFM-2006A']
+  aliases: []
   parents:
   - 2620613
 412092:
-  aliases: ['Hypsugo sp. FFM-2006B']
+  aliases: []
   parents:
   - 2620613
 1048812:
-  aliases: ['Hypsugo sp. Hsav-III-1']
+  aliases: []
   parents:
   - 2620613
 1838143:
-  aliases: ['Hypsugo sp. JA-2016a']
+  aliases: []
   parents:
   - 2620613
 509030:
-  aliases: ['Hypsugo sp. N1']
+  aliases: []
   parents:
   - 2620613
 509031:
-  aliases: ['Hypsugo sp. N2']
+  aliases: []
   parents:
   - 2620613
 509032:
-  aliases: ['Hypsugo sp. N7']
+  aliases: []
   parents:
   - 2620613
 509033:
-  aliases: ['Hypsugo sp. R1']
+  aliases: []
   parents:
   - 2620613
 2991276:
-  aliases: ['Hypsugo sp. SD-2022']
+  aliases: []
   parents:
   - 2620613
 3572148:
-  aliases: ['Kerivoula sp.']
+  aliases: []
   parents:
   - 2618055
 910446:
-  aliases: ['Kerivoula sp. FAK-2010']
+  aliases: []
   parents:
   - 2618055
 2069574:
-  aliases: ['Kerivoula sp. FMNH 190110']
+  aliases: []
   parents:
   - 2618055
 2069576:
-  aliases: ['Kerivoula sp. T017154']
+  aliases: []
   parents:
   - 2618055
 1691934:
-  aliases: ['Lasiurus blossevillii salinae']
+  aliases: []
   parents:
   - 258932
 1673613:
-  aliases: ['Lasiurus cinereus cinereus']
+  aliases: []
   parents:
   - 257879
 160977:
-  aliases: ['Lasiurus sp. (in: bats)']
+  aliases: []
   parents:
   - 2688611
 159319:
-  aliases: ['Lasiurus sp. MVZ_AD522']
+  aliases: []
   parents:
   - 2688611
 556918:
-  aliases: ['Latidens']
+  aliases: []
   parents:
   - 3136027
 1582325:
-  aliases: ['Lavia frons']
+  aliases: []
   parents:
   - 1582324
 55054:
-  aliases: ['Leptonycteris curasoae']
+  aliases: []
   parents:
   - 55053
 59456:
-  aliases: ['Leptonycteris nivalis']
+  aliases: []
   parents:
   - 55053
 700936:
-  aliases: ['Leptonycteris yerbabuenae']
+  aliases: []
   parents:
   - 55053
 1001577:
-  aliases: ['Lichonycteris obscura']
+  aliases: []
   parents:
   - 148045
 148090:
-  aliases: ['Lionycteris spurrelli']
+  aliases: []
   parents:
   - 148084
 237984:
-  aliases: ['Lonchophylla chocoana']
+  aliases: []
   parents:
   - 138704
 1303335:
-  aliases: ['Lonchophylla concava']
+  aliases: []
   parents:
   - 138704
 1654710:
-  aliases: ['Lonchophylla dekeyseri']
+  aliases: []
   parents:
   - 138704
 190507:
-  aliases: ['Lonchophylla handleyi']
+  aliases: []
   parents:
   - 138704
 1470801:
-  aliases: ['Lonchophylla hesperia']
+  aliases: []
   parents:
   - 138704
 190508:
-  aliases: ['Lonchophylla mordax']
+  aliases: []
   parents:
   - 138704
 1470802:
-  aliases: ['Lonchophylla orienticollina']
+  aliases: []
   parents:
   - 138704
 190509:
-  aliases: ['Lonchophylla robusta']
+  aliases: []
   parents:
   - 138704
 148061:
-  aliases: ['Lonchorhina aurita']
+  aliases: []
   parents:
   - 148054
 409030:
-  aliases: ['Lonchorhina inusitata']
+  aliases: []
   parents:
   - 148054
 249006:
-  aliases: ['Lonchorhina orinocensis']
+  aliases: []
   parents:
   - 148054
 409031:
-  aliases: ['Lophostoma brasiliense']
+  aliases: []
   parents:
   - 263450
 409032:
-  aliases: ['Lophostoma carrikeri']
+  aliases: []
   parents:
   - 263450
 3370176:
-  aliases: ['Lophostoma evote']
+  aliases: []
   parents:
   - 263450
 3370179:
-  aliases: ['Lophostoma occidentale']
+  aliases: []
   parents:
   - 263450
 409033:
-  aliases: ['Lophostoma schulzi']
+  aliases: []
   parents:
   - 263450
 3370180:
-  aliases: ['Lophostoma silvicola']
+  aliases: []
   parents:
   - 263450
 3371112:
-  aliases: ['Lyroderma lyra']
+  aliases: []
   parents:
   - 3371052
 3381542:
-  aliases: ['Lyroderma sinense']
+  aliases: []
   parents:
   - 3371052
 9411:
-  aliases: ['Macroderma gigas']
+  aliases: []
   parents:
   - 9410
 29075:
-  aliases: ['Macroglossus']
+  aliases: []
   parents:
   - 77241
 110941:
-  aliases: ['Macronycteris commersonii']
+  aliases: []
   parents:
   - 2603868
 2735188:
-  aliases: ['Macronycteris cryptovalorona']
+  aliases: []
   parents:
   - 2603868
 584996:
-  aliases: ['Macronycteris gigas']
+  aliases: []
   parents:
   - 2603868
 2603869:
-  aliases: ['Macronycteris vittatus']
+  aliases: []
   parents:
   - 2603868
 148062:
-  aliases: ['Macrophyllum macrophyllum']
+  aliases: []
   parents:
   - 148055
 9419:
-  aliases: ['Macrotus californicus']
+  aliases: []
   parents:
   - 9418
 124750:
-  aliases: ['Macrotus waterhousii']
+  aliases: []
   parents:
   - 9418
 9414:
-  aliases: ['Megaderma spasma']
+  aliases: []
   parents:
   - 9412
 77232:
-  aliases: ['Megaerops']
+  aliases: []
   parents:
   - 3136027
 58074:
-  aliases: ['Melonycteris']
+  aliases: []
   parents:
   - 77241
 148094:
-  aliases: ['Mesophylla macconnelli']
+  aliases: []
   parents:
   - 148026
 148063:
-  aliases: ['Micronycteris brachyotis']
+  aliases: []
   parents:
   - 148056
 257473:
-  aliases: ['Micronycteris brosseti']
+  aliases: []
   parents:
   - 148056
 948073:
-  aliases: ['Micronycteris buriri']
+  aliases: []
   parents:
   - 148056
 338418:
-  aliases: ['Micronycteris cf. schmidtorum']
+  aliases: []
   parents:
   - 148056
 260821:
-  aliases: ['Micronycteris giovanniae']
+  aliases: []
   parents:
   - 148056
 148065:
-  aliases: ['Micronycteris hirsuta']
+  aliases: []
   parents:
   - 148056
 249007:
-  aliases: ['Micronycteris homezi']
+  aliases: []
   parents:
   - 148056
 338419:
-  aliases: ['Micronycteris matses']
+  aliases: []
   parents:
   - 148056
 148066:
-  aliases: ['Micronycteris megalotis']
+  aliases: []
   parents:
   - 148056
 249008:
-  aliases: ['Micronycteris microtis']
+  aliases: []
   parents:
   - 148056
 148067:
-  aliases: ['Micronycteris minuta']
+  aliases: []
   parents:
   - 148056
 2294179:
-  aliases: ['Micronycteris sanborni']
+  aliases: []
   parents:
   - 148056
 148069:
-  aliases: ['Micronycteris schmidtorum']
+  aliases: []
   parents:
   - 148056
 2748164:
-  aliases: ['Micronycteris simmonsae']
+  aliases: []
   parents:
   - 148056
 2748165:
-  aliases: ['Micronycteris tresamici']
+  aliases: []
   parents:
   - 148056
 1365274:
-  aliases: ['Micronycteris yatesi']
+  aliases: []
   parents:
   - 148056
 410851:
-  aliases: ['Mimon bennettii']
+  aliases: []
   parents:
   - 148057
 999935:
-  aliases: ['Mimon cozumelae']
+  aliases: []
   parents:
   - 148057
 645311:
-  aliases: ['Miniopterus griveaudi griveaudi']
+  aliases: []
   parents:
   - 568717
 1715694:
-  aliases: ['Miniopterus inflatus rufus']
+  aliases: []
   parents:
   - 221087
 1286218:
-  aliases: ['Miniopterus natalensis arenarius']
+  aliases: []
   parents:
   - 291302
 117601:
-  aliases: ['Miniopterus orianae bassanii']
+  aliases: []
   parents:
   - 2291841
 117603:
-  aliases: ['Miniopterus orianae oceanensis']
+  aliases: []
   parents:
   - 2291841
 117602:
-  aliases: ['Miniopterus schreibersii blepotis']
+  aliases: []
   parents:
   - 9433
 291299:
-  aliases: ['Miniopterus schreibersii pallidus']
+  aliases: []
   parents:
   - 9433
 559842:
-  aliases: ['Miniopterus schreibersii schreibersii']
+  aliases: []
   parents:
   - 9433
 3075049:
-  aliases: ['Miniopterus sp.']
+  aliases: []
   parents:
   - 2645810
 3062232:
-  aliases: ['Miniopterus sp. A TD-2023']
+  aliases: []
   parents:
   - 2645810
 3062233:
-  aliases: ['Miniopterus sp. B TD-2023']
+  aliases: []
   parents:
   - 2645810
 1975658:
-  aliases: ['Miniopterus sp. B165']
+  aliases: []
   parents:
   - 2645810
 1975654:
-  aliases: ['Miniopterus sp. B76']
+  aliases: []
   parents:
   - 2645810
 1975655:
-  aliases: ['Miniopterus sp. B96']
+  aliases: []
   parents:
   - 2645810
 221090:
-  aliases: ['Miniopterus sp. BBRA-2002']
+  aliases: []
   parents:
   - 2645810
 3062234:
-  aliases: ['Miniopterus sp. C TD-2023']
+  aliases: []
   parents:
   - 2645810
 581158:
-  aliases: ['Miniopterus sp. Comoros clade 2']
+  aliases: []
   parents:
   - 2645810
 3062235:
-  aliases: ['Miniopterus sp. D TD-2023']
+  aliases: []
   parents:
   - 2645810
 2448874:
-  aliases: ['Miniopterus sp. DMR-2017']
+  aliases: []
   parents:
   - 2645810
 3062236:
-  aliases: ['Miniopterus sp. E TD-2023']
+  aliases: []
   parents:
   - 2645810
 645309:
-  aliases: ['Miniopterus sp. FMNH 167450']
+  aliases: []
   parents:
   - 2645810
 645310:
-  aliases: ['Miniopterus sp. FMNH 172602']
+  aliases: []
   parents:
   - 2645810
 1002346:
-  aliases: ['Miniopterus sp. IVK-2011']
+  aliases: []
   parents:
   - 2645810
 1477906:
-  aliases: ['Miniopterus sp. P3']
+  aliases: []
   parents:
   - 2645810
 1477907:
-  aliases: ['Miniopterus sp. P4']
+  aliases: []
   parents:
   - 2645810
 1477908:
-  aliases: ['Miniopterus sp. P5']
+  aliases: []
   parents:
   - 2645810
 1477909:
-  aliases: ['Miniopterus sp. P6']
+  aliases: []
   parents:
   - 2645810
 1477910:
-  aliases: ['Miniopterus sp. P7']
+  aliases: []
   parents:
   - 2645810
 1574125:
-  aliases: ['Miniopterus sp. SMG-2014a']
+  aliases: []
   parents:
   - 2645810
 1477911:
-  aliases: ['Miniopterus sp. X3']
+  aliases: []
   parents:
   - 2645810
 2715948:
-  aliases: ['Miniopterus sp. clade 1 TD-2020']
+  aliases: []
   parents:
   - 2645810
 2715949:
-  aliases: ['Miniopterus sp. clade 10 TD-2020']
+  aliases: []
   parents:
   - 2645810
 2715950:
-  aliases: ['Miniopterus sp. clade 2 TD-2020']
+  aliases: []
   parents:
   - 2645810
 2715951:
-  aliases: ['Miniopterus sp. clade 3 TD-2020']
+  aliases: []
   parents:
   - 2645810
 2715952:
-  aliases: ['Miniopterus sp. clade 4 TD-2020']
+  aliases: []
   parents:
   - 2645810
 2715953:
-  aliases: ['Miniopterus sp. clade 5 TD-2020']
+  aliases: []
   parents:
   - 2645810
 2715954:
-  aliases: ['Miniopterus sp. clade 6 TD-2020']
+  aliases: []
   parents:
   - 2645810
 2715955:
-  aliases: ['Miniopterus sp. clade 7 TD-2020']
+  aliases: []
   parents:
   - 2645810
 2715956:
-  aliases: ['Miniopterus sp. clade 8 TD-2020']
+  aliases: []
   parents:
   - 2645810
 2715957:
-  aliases: ['Miniopterus sp. clade 9 TD-2020']
+  aliases: []
   parents:
   - 2645810
 2768032:
-  aliases: ['Miniopterus sp. n. TM-2020']
+  aliases: []
   parents:
   - 2645810
 2899231:
-  aliases: ['Miniopterus sp. p KDU-2021']
+  aliases: []
   parents:
   - 2645810
 3043828:
-  aliases: ['Miniopterus sp. s BS-2023']
+  aliases: []
   parents:
   - 2645810
 409374:
-  aliases: ['Miniopterus sp. sororculus']
+  aliases: []
   parents:
   - 2645810
 1496136:
-  aliases: ['Mirimiri']
+  aliases: []
   parents:
   - 77225
 2737246:
-  aliases: ['Molossops sp. MN1']
+  aliases: []
   parents:
   - 2737245
 1554505:
-  aliases: ['Molossus currentium bondae']
+  aliases: []
   parents:
   - 1269259
 1554504:
-  aliases: ['Molossus molossus daulensis']
+  aliases: []
   parents:
   - 27622
 1552296:
-  aliases: ['Molossus molossus molossus']
+  aliases: []
   parents:
   - 27622
 1554503:
-  aliases: ['Molossus molossus tropidorhynchus']
+  aliases: []
   parents:
   - 27622
 3041509:
-  aliases: ['Molossus sp.']
+  aliases: []
   parents:
   - 2625157
 409060:
-  aliases: ['Molossus sp. BOLD:AAX4787']
+  aliases: []
   parents:
   - 2625157
 245180:
-  aliases: ['Molossus sp. CRB2031']
+  aliases: []
   parents:
   - 2625157
 2801923:
-  aliases: ['Molossus sp. Esperanza129']
+  aliases: []
   parents:
   - 2625157
 2801924:
-  aliases: ['Molossus sp. Esperanza130']
+  aliases: []
   parents:
   - 2625157
 1920528:
-  aliases: ['Molossus sp. LL-2016']
+  aliases: []
   parents:
   - 2625157
 2801928:
-  aliases: ['Molossus sp. Santa Fe177']
+  aliases: []
   parents:
   - 2625157
 2801929:
-  aliases: ['Molossus sp. Santa Fe190']
+  aliases: []
   parents:
   - 2625157
 2801930:
-  aliases: ['Molossus sp. Santa Fe192']
+  aliases: []
   parents:
   - 2625157
 2801931:
-  aliases: ['Molossus sp. Santa Fe193']
+  aliases: []
   parents:
   - 2625157
 2801932:
-  aliases: ['Molossus sp. Santa Fe194']
+  aliases: []
   parents:
   - 2625157
 2801934:
-  aliases: ['Molossus sp. Santa Fe196']
+  aliases: []
   parents:
   - 2625157
 2801935:
-  aliases: ['Molossus sp. Santa Fe197']
+  aliases: []
   parents:
   - 2625157
 2801936:
-  aliases: ['Molossus sp. Santa Fe198']
+  aliases: []
   parents:
   - 2625157
 2801937:
-  aliases: ['Molossus sp. Santa Fe199']
+  aliases: []
   parents:
   - 2625157
 177163:
-  aliases: ['Monophyllus plethodon']
+  aliases: []
   parents:
   - 148046
 148052:
-  aliases: ['Monophyllus redmani']
+  aliases: []
   parents:
   - 148046
 3392088:
-  aliases: ['Mops brachypterus leonis']
+  aliases: []
   parents:
   - 3370274
 1495468:
-  aliases: ['Mops pumilus elphicki']
+  aliases: []
   parents:
   - 242384
 1495466:
-  aliases: ['Mops pumilus langi']
+  aliases: []
   parents:
   - 242384
 1495464:
-  aliases: ['Mops pumilus limbata']
+  aliases: []
   parents:
   - 242384
 1495465:
-  aliases: ['Mops pumilus naivashae']
+  aliases: []
   parents:
   - 242384
 3075048:
-  aliases: ['Mops sp.']
+  aliases: []
   parents:
   - 2632858
 2448866:
-  aliases: ['Mops sp. DMR-2017']
+  aliases: []
   parents:
   - 2632858
 1002343:
-  aliases: ['Mops sp. IVK-2011']
+  aliases: []
   parents:
   - 2632858
 2952391:
-  aliases: ['Mops sp. NG010_NGR']
+  aliases: []
   parents:
   - 2632858
 2952392:
-  aliases: ['Mops sp. NG014_NGR']
+  aliases: []
   parents:
   - 2632858
 2952393:
-  aliases: ['Mops sp. NG017_NGR']
+  aliases: []
   parents:
   - 2632858
 2952394:
-  aliases: ['Mops sp. NG019_NGR']
+  aliases: []
   parents:
   - 2632858
 2952395:
-  aliases: ['Mops sp. NG020_NGR']
+  aliases: []
   parents:
   - 2632858
 2952396:
-  aliases: ['Mops sp. NG022_NGR']
+  aliases: []
   parents:
   - 2632858
 2952389:
-  aliases: ['Mops sp. NG05_NGR']
+  aliases: []
   parents:
   - 2632858
 2952390:
-  aliases: ['Mops sp. NG07_NGR']
+  aliases: []
   parents:
   - 2632858
 2952397:
-  aliases: ['Mops sp. NGB024_NGR']
+  aliases: []
   parents:
   - 2632858
 450944:
-  aliases: ['Mosia nigrescens']
+  aliases: []
   parents:
   - 450943
 1837108:
-  aliases: ['Murina huttoni rubella']
+  aliases: []
   parents:
   - 258935
 3412428:
-  aliases: ['Murina huttonii rubella']
+  aliases: []
   parents:
   - 2933636
 3412434:
-  aliases: ['Murina sp.']
+  aliases: []
   parents:
   - 2685208
 3375539:
-  aliases: ['Murina sp. 2 PL-2024']
+  aliases: []
   parents:
   - 2685208
 3375540:
-  aliases: ['Murina sp. 3 PL-2024']
+  aliases: []
   parents:
   - 2685208
 187020:
-  aliases: ['Murina sp. 7386']
+  aliases: []
   parents:
   - 2685208
 2856836:
-  aliases: ['Murina sp. A BL-2021']
+  aliases: []
   parents:
   - 2685208
 867846:
-  aliases: ['Murina sp. A CMF-2010']
+  aliases: []
   parents:
   - 2685208
 1167678:
-  aliases: ['Murina sp. A MR-2012']
+  aliases: []
   parents:
   - 2685208
 1986511:
-  aliases: ['Murina sp. APBL060517-04']
+  aliases: []
   parents:
   - 2685208
 2856837:
-  aliases: ['Murina sp. B BL-2021']
+  aliases: []
   parents:
   - 2685208
 867847:
-  aliases: ['Murina sp. B CMF-2010']
+  aliases: []
   parents:
   - 2685208
 867848:
-  aliases: ['Murina sp. D CMF-2010']
+  aliases: []
   parents:
   - 2685208
 867849:
-  aliases: ['Murina sp. E JLE-2010']
+  aliases: []
   parents:
   - 2685208
 867850:
-  aliases: ['Murina sp. F JLE-2010']
+  aliases: []
   parents:
   - 2685208
 2069575:
-  aliases: ['Murina sp. FMNH 177476']
+  aliases: []
   parents:
   - 2685208
 3477260:
-  aliases: ['Murina sp. G BL-2025']
+  aliases: []
   parents:
   - 2685208
 375554:
-  aliases: ['Murina sp. GGJ-2006']
+  aliases: []
   parents:
   - 2685208
 479479:
-  aliases: ['Murina sp. GGL-2007']
+  aliases: []
   parents:
   - 2685208
 584771:
-  aliases: ['Murina sp. HZ-2008']
+  aliases: []
   parents:
   - 2685208
 479725:
-  aliases: ['Murina sp. V4']
+  aliases: []
   parents:
   - 2685208
 1453895:
-  aliases: ['Murina sp. VTT-2014a']
+  aliases: []
   parents:
   - 2685208
 3412431:
-  aliases: ['Murina sp. b TL-2025']
+  aliases: []
   parents:
   - 2685208
 3375541:
-  aliases: ['Murina sp. c PL-2024']
+  aliases: []
   parents:
   - 2685208
 3425207:
-  aliases: ['Murina sp. d RL-2025']
+  aliases: []
   parents:
   - 2685208
 460136:
-  aliases: ['Murina sp. hn1151']
+  aliases: []
   parents:
   - 2685208
 3390067:
-  aliases: ['Murina sp. l XM-2024']
+  aliases: []
   parents:
   - 2685208
 3425206:
-  aliases: ['Murina sp. m RL-2025']
+  aliases: []
   parents:
   - 2685208
 3412432:
-  aliases: ['Murina sp. me TL-2025']
+  aliases: []
   parents:
   - 2685208
 3412433:
-  aliases: ['Murina sp. mi TL-2025']
+  aliases: []
   parents:
   - 2685208
 3412430:
-  aliases: ['Murina sp. y TL-2025']
+  aliases: []
   parents:
   - 2685208
 3242755:
-  aliases: ['Murina sp. y XM-2024']
+  aliases: []
   parents:
   - 2685208
 3108934:
-  aliases: ['Murina sp. y XW-2023']
+  aliases: []
   parents:
   - 2685208
 148053:
-  aliases: ['Musonycteris harrisoni']
+  aliases: []
   parents:
   - 148047
 1246961:
-  aliases: ['Myonycterini']
+  aliases: []
   parents:
   - 3136030
 941652:
-  aliases: ['Myotis adversus adversus']
+  aliases: []
   parents:
   - 59461
 867861:
-  aliases: ['Myotis adversus taiwanensis']
+  aliases: []
   parents:
   - 59461
 941653:
-  aliases: ['Myotis adversus tanimbarensis']
+  aliases: []
   parents:
   - 59461
 392007:
-  aliases: ['Myotis blythii ancilla']
+  aliases: []
   parents:
   - 109482
 126576:
-  aliases: ['Myotis blythii blythii']
+  aliases: []
   parents:
   - 109482
 359394:
-  aliases: ['Myotis blythii omari']
+  aliases: []
   parents:
   - 109482
 1393934:
-  aliases: ['Myotis bocagii cupreolus']
+  aliases: []
   parents:
   - 153284
 392319:
-  aliases: ['Myotis bombinus amurensis']
+  aliases: []
   parents:
   - 392318
 2516278:
-  aliases: ['Myotis brandtii brandtii']
+  aliases: []
   parents:
   - 109478
 306064:
-  aliases: ['Myotis cf. nipalensis kukunorensis']
+  aliases: []
   parents:
   - 306063
 2980668:
-  aliases: ['Myotis ciliolabrum melanorhinus']
+  aliases: []
   parents:
   - 257884
 478518:
-  aliases: ['Myotis daubentonii daubentonii']
+  aliases: []
   parents:
   - 98922
 159318:
-  aliases: ['Myotis daubentonii nathalinae']
+  aliases: []
   parents:
   - 98922
 2510965:
-  aliases: ['Myotis escalerai cabrerae']
+  aliases: []
   parents:
   - 508772
 2510966:
-  aliases: ['Myotis escalerai escalerai']
+  aliases: []
   parents:
   - 508772
 1442610:
-  aliases: ['Myotis evotis milleri']
+  aliases: []
   parents:
   - 257883
 1393935:
-  aliases: ['Myotis horsfieldii deignani']
+  aliases: []
   parents:
   - 138977
 1393936:
-  aliases: ['Myotis horsfieldii horsfieldii']
+  aliases: []
   parents:
   - 138977
 384940:
-  aliases: ['Myotis lucifugus alascensis']
+  aliases: []
   parents:
   - 59463
 164660:
-  aliases: ['Myotis lucifugus carissima']
+  aliases: []
   parents:
   - 59463
 384942:
-  aliases: ['Myotis lucifugus lucifugus']
+  aliases: []
   parents:
   - 59463
 384941:
-  aliases: ['Myotis lucifugus relictus']
+  aliases: []
   parents:
   - 59463
 1163725:
-  aliases: ['Myotis martiniquensis nyctor']
+  aliases: []
   parents:
   - 385035
 159331:
-  aliases: ['Myotis muricola browni']
+  aliases: []
   parents:
   - 159330
 126574:
-  aliases: ['Myotis myotis myotis']
+  aliases: []
   parents:
   - 51298
 2510968:
-  aliases: ['Myotis nattereri helverseni']
+  aliases: []
   parents:
   - 109481
 2510969:
-  aliases: ['Myotis nattereri nattereri']
+  aliases: []
   parents:
   - 109481
 1163729:
-  aliases: ['Myotis nesopolus nesopolus']
+  aliases: []
   parents:
   - 1163727
 2976338:
-  aliases: ['Myotis nigricans osculatii']
+  aliases: []
   parents:
   - 153286
 1908665:
-  aliases: ['Myotis oxyotus gardneri']
+  aliases: []
   parents:
   - 159332
 572371:
-  aliases: ['Myotis siligorensis alticraniatus']
+  aliases: []
   parents:
   - 258940
 1911917:
-  aliases: ['Myotis sp.']
+  aliases: []
   parents:
   - 867169
 887567:
-  aliases: ['Myotis sp. 07BC0899YU']
+  aliases: []
   parents:
   - 867169
 670388:
-  aliases: ['Myotis sp. 1 HEN0826']
+  aliases: []
   parents:
   - 867169
 1393942:
-  aliases: ['Myotis sp. 1 MR-2013']
+  aliases: []
   parents:
   - 867169
 1239993:
-  aliases: ['Myotis sp. 1 Venezuela']
+  aliases: []
   parents:
   - 867169
 631201:
-  aliases: ['Myotis sp. 1 ZZ-2009']
+  aliases: []
   parents:
   - 867169
 2926351:
-  aliases: ['Myotis sp. 1031/20_CAS']
+  aliases: []
   parents:
   - 867169
 2926352:
-  aliases: ['Myotis sp. 1038/20_CAS']
+  aliases: []
   parents:
   - 867169
 2926353:
-  aliases: ['Myotis sp. 1040/20_CAS']
+  aliases: []
   parents:
   - 867169
 2926354:
-  aliases: ['Myotis sp. 1138/20_SOC']
+  aliases: []
   parents:
   - 867169
 2926355:
-  aliases: ['Myotis sp. 1145/20_SP']
+  aliases: []
   parents:
   - 867169
 2926356:
-  aliases: ['Myotis sp. 1256/20_JAI']
+  aliases: []
   parents:
   - 867169
 2926357:
-  aliases: ['Myotis sp. 1267/20_CAS']
+  aliases: []
   parents:
   - 867169
 2926358:
-  aliases: ['Myotis sp. 1272/20_CAS']
+  aliases: []
   parents:
   - 867169
 2926359:
-  aliases: ['Myotis sp. 1315/20_CAS']
+  aliases: []
   parents:
   - 867169
 2926360:
-  aliases: ['Myotis sp. 1354/20_ASO']
+  aliases: []
   parents:
   - 867169
 2926361:
-  aliases: ['Myotis sp. 1399/20_SP']
+  aliases: []
   parents:
   - 867169
 2926362:
-  aliases: ['Myotis sp. 1586/20_PAA']
+  aliases: []
   parents:
   - 867169
 1239994:
-  aliases: ['Myotis sp. 2 E Ecuador']
+  aliases: []
   parents:
   - 867169
 1393943:
-  aliases: ['Myotis sp. 2 MR-2013']
+  aliases: []
   parents:
   - 867169
 1239434:
-  aliases: ['Myotis sp. 2 RJL-2012']
+  aliases: []
   parents:
   - 867169
 1239995:
-  aliases: ['Myotis sp. 2 W Ecuador']
+  aliases: []
   parents:
   - 867169
 631203:
-  aliases: ['Myotis sp. 2 ZZ-2009']
+  aliases: []
   parents:
   - 867169
 2094007:
-  aliases: ['Myotis sp. 20130819_553']
+  aliases: []
   parents:
   - 867169
 2094006:
-  aliases: ['Myotis sp. 20130819_554']
+  aliases: []
   parents:
   - 867169
 2094004:
-  aliases: ['Myotis sp. 20130819_555']
+  aliases: []
   parents:
   - 867169
 2094005:
-  aliases: ['Myotis sp. 20130819_556']
+  aliases: []
   parents:
   - 867169
 2926363:
-  aliases: ['Myotis sp. 2276/21_SOC']
+  aliases: []
   parents:
   - 867169
 2926364:
-  aliases: ['Myotis sp. 2373/21_SP']
+  aliases: []
   parents:
   - 867169
 2926365:
-  aliases: ['Myotis sp. 2384/21_PAA']
+  aliases: []
   parents:
   - 867169
 2926366:
-  aliases: ['Myotis sp. 2615/21_SOC']
+  aliases: []
   parents:
   - 867169
 2926367:
-  aliases: ['Myotis sp. 2738/21_JAI']
+  aliases: []
   parents:
   - 867169
 2926368:
-  aliases: ['Myotis sp. 2825/21_SOC']
+  aliases: []
   parents:
   - 867169
 2926369:
-  aliases: ['Myotis sp. 2853/21_JAI']
+  aliases: []
   parents:
   - 867169
 1393944:
-  aliases: ['Myotis sp. 3 MR-2013']
+  aliases: []
   parents:
   - 867169
 1239996:
-  aliases: ['Myotis sp. 3 W Ecuador']
+  aliases: []
   parents:
   - 867169
 3049286:
-  aliases: ['Myotis sp. 4 CC-2023']
+  aliases: []
   parents:
   - 867169
 1393945:
-  aliases: ['Myotis sp. 4 MR-2013']
+  aliases: []
   parents:
   - 867169
 1239997:
-  aliases: ['Myotis sp. 4 W Ecuador']
+  aliases: []
   parents:
   - 867169
 1239998:
-  aliases: ['Myotis sp. 5 Mexico']
+  aliases: []
   parents:
   - 867169
 2924044:
-  aliases: ['Myotis sp. 56_My']
+  aliases: []
   parents:
   - 867169
 1239999:
-  aliases: ['Myotis sp. 6 Paraguay']
+  aliases: []
   parents:
   - 867169
 1240000:
-  aliases: ['Myotis sp. 6 Peru']
+  aliases: []
   parents:
   - 867169
 2924043:
-  aliases: ['Myotis sp. 61_My']
+  aliases: []
   parents:
   - 867169
 1240001:
-  aliases: ['Myotis sp. 7 W Ecuador']
+  aliases: []
   parents:
   - 867169
 1240002:
-  aliases: ['Myotis sp. 8 W Ecuador']
+  aliases: []
   parents:
   - 867169
 2926350:
-  aliases: ['Myotis sp. 927/20_JAI']
+  aliases: []
   parents:
   - 867169
 138980:
-  aliases: ['Myotis sp. AM_M15111']
+  aliases: []
   parents:
   - 867169
 138981:
-  aliases: ['Myotis sp. AM_M21963']
+  aliases: []
   parents:
   - 867169
 1002701:
-  aliases: ['Myotis sp. AVB-2011']
+  aliases: []
   parents:
   - 867169
 2942954:
-  aliases: ['Myotis sp. B12']
+  aliases: []
   parents:
   - 867169
 2942955:
-  aliases: ['Myotis sp. B13']
+  aliases: []
   parents:
   - 867169
 2942952:
-  aliases: ['Myotis sp. B60']
+  aliases: []
   parents:
   - 867169
 2942953:
-  aliases: ['Myotis sp. B64']
+  aliases: []
   parents:
   - 867169
 509034:
-  aliases: ['Myotis sp. C1']
+  aliases: []
   parents:
   - 867169
 509035:
-  aliases: ['Myotis sp. C2']
+  aliases: []
   parents:
   - 867169
 509036:
-  aliases: ['Myotis sp. C3']
+  aliases: []
   parents:
   - 867169
 509037:
-  aliases: ['Myotis sp. C4']
+  aliases: []
   parents:
   - 867169
 509038:
-  aliases: ['Myotis sp. C5']
+  aliases: []
   parents:
   - 867169
 245070:
-  aliases: ['Myotis sp. CRB1612']
+  aliases: []
   parents:
   - 867169
 867854:
-  aliases: ['Myotis sp. E CMF-2010']
+  aliases: []
   parents:
   - 867169
 412096:
-  aliases: ['Myotis sp. FFM-2006']
+  aliases: []
   parents:
   - 867169
 415935:
-  aliases: ['Myotis sp. GZNU200306']
+  aliases: []
   parents:
   - 867169
 187013:
-  aliases: ['Myotis sp. KK0005']
+  aliases: []
   parents:
   - 867169
 1032363:
-  aliases: ['Myotis sp. MIBZPL01211']
+  aliases: []
   parents:
   - 867169
 1032364:
-  aliases: ['Myotis sp. MIBZPL01214']
+  aliases: []
   parents:
   - 867169
 1032365:
-  aliases: ['Myotis sp. MIBZPL01216']
+  aliases: []
   parents:
   - 867169
 1032366:
-  aliases: ['Myotis sp. MIBZPL01221']
+  aliases: []
   parents:
   - 867169
 1032367:
-  aliases: ['Myotis sp. MIBZPL01222']
+  aliases: []
   parents:
   - 867169
 1032368:
-  aliases: ['Myotis sp. MIBZPL01223']
+  aliases: []
   parents:
   - 867169
 1032378:
-  aliases: ['Myotis sp. MIBZPL01228']
+  aliases: []
   parents:
   - 867169
 1032379:
-  aliases: ['Myotis sp. MIBZPL01230']
+  aliases: []
   parents:
   - 867169
 1032369:
-  aliases: ['Myotis sp. MIBZPL01235']
+  aliases: []
   parents:
   - 867169
 1032370:
-  aliases: ['Myotis sp. MIBZPL01256']
+  aliases: []
   parents:
   - 867169
 1032371:
-  aliases: ['Myotis sp. MIBZPL01281']
+  aliases: []
   parents:
   - 867169
 1032372:
-  aliases: ['Myotis sp. MIBZPL01287']
+  aliases: []
   parents:
   - 867169
 1032373:
-  aliases: ['Myotis sp. MIBZPL01289']
+  aliases: []
   parents:
   - 867169
 1032374:
-  aliases: ['Myotis sp. MIBZPL01301']
+  aliases: []
   parents:
   - 867169
 1032375:
-  aliases: ['Myotis sp. MIBZPL01302']
+  aliases: []
   parents:
   - 867169
 1032376:
-  aliases: ['Myotis sp. MIBZPL01303']
+  aliases: []
   parents:
   - 867169
 1032377:
-  aliases: ['Myotis sp. MIBZPL01319']
+  aliases: []
   parents:
   - 867169
 999958:
-  aliases: ['Myotis sp. MMMD-2011']
+  aliases: []
   parents:
   - 867169
 2785032:
-  aliases: ['Myotis sp. MSB Mamm 42790']
+  aliases: []
   parents:
   - 867169
 2969769:
-  aliases: ['Myotis sp. MVZ Mamm 224796']
+  aliases: []
   parents:
   - 867169
 2785034:
-  aliases: ['Myotis sp. MVZ Mamm 226977']
+  aliases: []
   parents:
   - 867169
 2924045:
-  aliases: ['Myotis sp. Muestra11_My']
+  aliases: []
   parents:
   - 867169
 509039:
-  aliases: ['Myotis sp. N1']
+  aliases: []
   parents:
   - 867169
 509040:
-  aliases: ['Myotis sp. N2']
+  aliases: []
   parents:
   - 867169
 509041:
-  aliases: ['Myotis sp. N3']
+  aliases: []
   parents:
   - 867169
 364774:
-  aliases: ['Myotis sp. PH-2006']
+  aliases: []
   parents:
   - 867169
 2923478:
-  aliases: ['Myotis sp. QCAZ Mamm9159']
+  aliases: []
   parents:
   - 867169
 2923479:
-  aliases: ['Myotis sp. QCAZ Mamm9623']
+  aliases: []
   parents:
   - 867169
 509042:
-  aliases: ['Myotis sp. R1']
+  aliases: []
   parents:
   - 867169
 1163723:
-  aliases: ['Myotis sp. RJL-2012']
+  aliases: []
   parents:
   - 867169
 3456272:
-  aliases: ['Myotis sp. T72096-1']
+  aliases: []
   parents:
   - 867169
 3456273:
-  aliases: ['Myotis sp. T72096-2']
+  aliases: []
   parents:
   - 867169
 258961:
-  aliases: ['Myotis sp. TK 48587']
+  aliases: []
   parents:
   - 867169
 2785033:
-  aliases: ['Myotis sp. TTU Mamm 47514']
+  aliases: []
   parents:
   - 867169
 3238590:
-  aliases: ['Myotis sp. g NB-2024']
+  aliases: []
   parents:
   - 867169
 3387500:
-  aliases: ['Myotis sp. h MR-2024']
+  aliases: []
   parents:
   - 867169
 2980669:
-  aliases: ['Myotis yumanensis yumanensis']
+  aliases: []
   parents:
   - 159337
 1115701:
-  aliases: ['Natalus sp. LMGC-2011']
+  aliases: []
   parents:
   - 2625265
 3111557:
-  aliases: ['Neoplatymops sp.']
+  aliases: []
   parents:
   - 3111556
 2747555:
-  aliases: ['Neopteryx']
+  aliases: []
   parents:
   - 77225
 3075050:
-  aliases: ['Neoromicia sp.']
+  aliases: []
   parents:
   - 2636793
 1286222:
-  aliases: ['Neoromicia sp. 1 SaSt-2013']
+  aliases: []
   parents:
   - 2636793
 1975659:
-  aliases: ['Neoromicia sp. B168']
+  aliases: []
   parents:
   - 2636793
 1975660:
-  aliases: ['Neoromicia sp. B169']
+  aliases: []
   parents:
   - 2636793
 2448877:
-  aliases: ['Neoromicia sp. DMR-2017']
+  aliases: []
   parents:
   - 2636793
 1002347:
-  aliases: ['Neoromicia sp. IVK-2011']
+  aliases: []
   parents:
   - 2636793
 1838145:
-  aliases: ['Neoromicia sp. JA-2016a']
+  aliases: []
   parents:
   - 2636793
 3387231:
-  aliases: ['Nesonycteris ardoulisi']
+  aliases: []
   parents:
   - 3371070
 3371130:
-  aliases: ['Nesonycteris fardoulisi']
+  aliases: []
   parents:
   - 3371070
 3371131:
-  aliases: ['Nesonycteris maccoyi']
+  aliases: []
   parents:
   - 3371070
 3371132:
-  aliases: ['Nesonycteris mengermani']
+  aliases: []
   parents:
   - 3371070
 3401145:
-  aliases: ['Noctilio albiventris cabrerai']
+  aliases: []
   parents:
   - 94962
 3079500:
-  aliases: ['Noctilio albiventris minor']
+  aliases: []
   parents:
   - 94962
 3079474:
-  aliases: ['Noctilio leporinus mastivus']
+  aliases: []
   parents:
   - 94963
 58077:
-  aliases: ['Notopteris']
+  aliases: []
   parents:
   - 77241
 402030:
-  aliases: ['Nyctalus leisleri verrucosus']
+  aliases: []
   parents:
   - 59465
 187011:
-  aliases: ['Nyctalus plancyi velutinus']
+  aliases: []
   parents:
   - 375553
 867862:
-  aliases: ['Nyctalus sp. A JLE-2010']
+  aliases: []
   parents:
   - 2618540
 3242305:
-  aliases: ['Nycteris sp.']
+  aliases: []
   parents:
   - 2623095
 2448879:
-  aliases: ['Nycteris sp. DMR-2017']
+  aliases: []
   parents:
   - 2623095
 48987:
-  aliases: ['Nyctimene']
+  aliases: []
   parents:
   - 3136026
 3079460:
-  aliases: ['Nyctinomops laticaudatus europs']
+  aliases: []
   parents:
   - 27627
 2968823:
-  aliases: ['Nyctinomops sp. m IT-2022']
+  aliases: []
   parents:
   - 2968822
 328967:
-  aliases: ['Otopteropus']
+  aliases: []
   parents:
   - 3136027
 270784:
-  aliases: ['Paranyctimene']
+  aliases: []
   parents:
   - 3136026
 329872:
-  aliases: ['Paratriaenops auritus']
+  aliases: []
   parents:
   - 1615588
 3370493:
-  aliases: ['Paratriaenops furcula']
+  aliases: []
   parents:
   - 1615588
 326150:
-  aliases: ['Penthetor']
+  aliases: []
   parents:
   - 3136027
 3079465:
-  aliases: ['Perimyotis subflavus floridanus']
+  aliases: []
   parents:
   - 27672
 249014:
-  aliases: ['Peropteryx kappleri']
+  aliases: []
   parents:
   - 249013
 409046:
-  aliases: ['Peropteryx leucoptera']
+  aliases: []
   parents:
   - 249013
 249015:
-  aliases: ['Peropteryx macrotis']
+  aliases: []
   parents:
   - 249013
 3370519:
-  aliases: ['Peropteryx pallidoptera']
+  aliases: []
   parents:
   - 249013
 463804:
-  aliases: ['Peropteryx trinitatis']
+  aliases: []
   parents:
   - 249013
 148072:
-  aliases: ['Phylloderma stenops']
+  aliases: []
   parents:
   - 148058
 409047:
-  aliases: ['Phylloderma stenops PS1']
+  aliases: []
   parents:
   - 148058
 409048:
-  aliases: ['Phylloderma stenops PS2']
+  aliases: []
   parents:
   - 148058
 138702:
-  aliases: ['Phyllonycteris aphylla']
+  aliases: []
   parents:
   - 138701
 869459:
-  aliases: ['Phyllonycteris obtusa']
+  aliases: []
   parents:
   - 138701
 270774:
-  aliases: ['Phyllonycteris poeyi']
+  aliases: []
   parents:
   - 138701
 270772:
-  aliases: ['Phyllops falcatus']
+  aliases: []
   parents:
   - 148027
 89673:
-  aliases: ['Phyllostomus discolor']
+  aliases: []
   parents:
   - 9422
 187005:
-  aliases: ['Phyllostomus elongatus']
+  aliases: []
   parents:
   - 9422
 9423:
-  aliases: ['Phyllostomus hastatus']
+  aliases: []
   parents:
   - 9422
 999937:
-  aliases: ['Phyllostomus latifolius']
+  aliases: []
   parents:
   - 9422
 1838146:
-  aliases: ['Pipistrellus cf. grandidieri JA-2016a']
+  aliases: []
   parents:
   - 1032380
 2933643:
-  aliases: ['Pipistrellus hanaki creticus']
+  aliases: []
   parents:
   - 412090
 867881:
-  aliases: ['Pipistrellus javanicus babu']
+  aliases: []
   parents:
   - 258947
 1707946:
-  aliases: ['Pipistrellus kuhlii kuhlii']
+  aliases: []
   parents:
   - 59472
 983528:
-  aliases: ['Pipistrellus kuhlii lepidus']
+  aliases: []
   parents:
   - 59472
 3075051:
-  aliases: ['Pipistrellus sp.']
+  aliases: []
   parents:
   - 1032380
 1286223:
-  aliases: ['Pipistrellus sp. 1 SaSt-2013']
+  aliases: []
   parents:
   - 1032380
 2856838:
-  aliases: ['Pipistrellus sp. A BL-2021']
+  aliases: []
   parents:
   - 1032380
 1001580:
-  aliases: ['Pipistrellus sp. AVB-2011']
+  aliases: []
   parents:
   - 1032380
 2856839:
-  aliases: ['Pipistrellus sp. B BL-2021']
+  aliases: []
   parents:
   - 1032380
 246822:
-  aliases: ['Pipistrellus sp. Be_2129']
+  aliases: []
   parents:
   - 1032380
 258773:
-  aliases: ['Pipistrellus sp. Be_2136_8']
+  aliases: []
   parents:
   - 1032380
 258774:
-  aliases: ['Pipistrellus sp. Be_2137_9']
+  aliases: []
   parents:
   - 1032380
 258771:
-  aliases: ['Pipistrellus sp. Be_2142_10']
+  aliases: []
   parents:
   - 1032380
 246823:
-  aliases: ['Pipistrellus sp. Be_2145']
+  aliases: []
   parents:
   - 1032380
 258772:
-  aliases: ['Pipistrellus sp. Be_2151_13']
+  aliases: []
   parents:
   - 1032380
 246816:
-  aliases: ['Pipistrellus sp. Be_2152']
+  aliases: []
   parents:
   - 1032380
 515826:
-  aliases: ['Pipistrellus sp. CO1']
+  aliases: []
   parents:
   - 1032380
 515827:
-  aliases: ['Pipistrellus sp. CO2']
+  aliases: []
   parents:
   - 1032380
 515828:
-  aliases: ['Pipistrellus sp. CO3']
+  aliases: []
   parents:
   - 1032380
 2448880:
-  aliases: ['Pipistrellus sp. DMR-2017']
+  aliases: []
   parents:
   - 1032380
 1125842:
-  aliases: ['Pipistrellus sp. DR-2011']
+  aliases: []
   parents:
   - 1032380
 412091:
-  aliases: ['Pipistrellus sp. FFM-2006']
+  aliases: []
   parents:
   - 1032380
 867880:
-  aliases: ['Pipistrellus sp. G CMF-2010']
+  aliases: []
   parents:
   - 1032380
 3040052:
-  aliases: ['Pipistrellus sp. Guangxi 1046']
+  aliases: []
   parents:
   - 1032380
 3040053:
-  aliases: ['Pipistrellus sp. Guizhou 83']
+  aliases: []
   parents:
   - 1032380
 1002348:
-  aliases: ['Pipistrellus sp. IVK-2011']
+  aliases: []
   parents:
   - 1032380
 2661590:
-  aliases: ['Pipistrellus sp. LIK54']
+  aliases: []
   parents:
   - 1032380
 1032395:
-  aliases: ['Pipistrellus sp. MIBZPL01239']
+  aliases: []
   parents:
   - 1032380
 1032396:
-  aliases: ['Pipistrellus sp. MIBZPL01241']
+  aliases: []
   parents:
   - 1032380
 1032397:
-  aliases: ['Pipistrellus sp. MIBZPL02288']
+  aliases: []
   parents:
   - 1032380
 1032381:
-  aliases: ['Pipistrellus sp. MIBZPL03815']
+  aliases: []
   parents:
   - 1032380
 1032382:
-  aliases: ['Pipistrellus sp. MIBZPL03816']
+  aliases: []
   parents:
   - 1032380
 1032383:
-  aliases: ['Pipistrellus sp. MIBZPL03817']
+  aliases: []
   parents:
   - 1032380
 1032384:
-  aliases: ['Pipistrellus sp. MIBZPL03818']
+  aliases: []
   parents:
   - 1032380
 1032385:
-  aliases: ['Pipistrellus sp. MIBZPL03819']
+  aliases: []
   parents:
   - 1032380
 1032386:
-  aliases: ['Pipistrellus sp. MIBZPL03820']
+  aliases: []
   parents:
   - 1032380
 1032387:
-  aliases: ['Pipistrellus sp. MIBZPL03821']
+  aliases: []
   parents:
   - 1032380
 1032388:
-  aliases: ['Pipistrellus sp. MIBZPL03822']
+  aliases: []
   parents:
   - 1032380
 1032389:
-  aliases: ['Pipistrellus sp. MIBZPL03823']
+  aliases: []
   parents:
   - 1032380
 1032390:
-  aliases: ['Pipistrellus sp. MIBZPL03824']
+  aliases: []
   parents:
   - 1032380
 1032391:
-  aliases: ['Pipistrellus sp. MIBZPL03825']
+  aliases: []
   parents:
   - 1032380
 1032392:
-  aliases: ['Pipistrellus sp. MIBZPL03826']
+  aliases: []
   parents:
   - 1032380
 1032393:
-  aliases: ['Pipistrellus sp. MIBZPL03827']
+  aliases: []
   parents:
   - 1032380
 1032394:
-  aliases: ['Pipistrellus sp. MIBZPL03828']
+  aliases: []
   parents:
   - 1032380
 436908:
-  aliases: ['Pipistrellus sp. PH-2007']
+  aliases: []
   parents:
   - 1032380
 2678253:
-  aliases: ['Pipistrellus sp. PU 5_OR']
+  aliases: []
   parents:
   - 1032380
 1158136:
-  aliases: ['Pipistrellus sp. YPZ-2012']
+  aliases: []
   parents:
   - 1032380
 1079722:
-  aliases: ['Pipistrellus sp. kuhlii/deserti Pkuh-I']
+  aliases: []
   parents:
   - 1032380
 1079723:
-  aliases: ['Pipistrellus sp. kuhlii/deserti Pkuh-II']
+  aliases: []
   parents:
   - 1032380
 2748932:
-  aliases: ['Pipistrellus tenuis mimus']
+  aliases: []
   parents:
   - 258948
 190511:
-  aliases: ['Platalina genovensium']
+  aliases: []
   parents:
   - 148085
 574073:
-  aliases: ['Platyrrhinus albericoi']
+  aliases: []
   parents:
   - 27657
 679017:
-  aliases: ['Platyrrhinus angustirostris']
+  aliases: []
   parents:
   - 27657
 409049:
-  aliases: ['Platyrrhinus aurarius']
+  aliases: []
   parents:
   - 27657
 249009:
-  aliases: ['Platyrrhinus brachycephalus']
+  aliases: []
   parents:
   - 27657
 2772522:
-  aliases: ['Platyrrhinus chocoensis']
+  aliases: []
   parents:
   - 27657
 362823:
-  aliases: ['Platyrrhinus dorsalis']
+  aliases: []
   parents:
   - 27657
 679018:
-  aliases: ['Platyrrhinus fusciventris']
+  aliases: []
   parents:
   - 27657
 1505192:
-  aliases: ['Platyrrhinus guianensis']
+  aliases: []
   parents:
   - 27657
 27658:
-  aliases: ['Platyrrhinus helleri']
+  aliases: []
   parents:
   - 27657
 409050:
-  aliases: ['Platyrrhinus helleri PS1']
+  aliases: []
   parents:
   - 27657
 409051:
-  aliases: ['Platyrrhinus helleri PS2']
+  aliases: []
   parents:
   - 27657
 409052:
-  aliases: ['Platyrrhinus helleri PS3']
+  aliases: []
   parents:
   - 27657
 574072:
-  aliases: ['Platyrrhinus incarum']
+  aliases: []
   parents:
   - 27657
 574060:
-  aliases: ['Platyrrhinus infuscus']
+  aliases: []
   parents:
   - 27657
 574075:
-  aliases: ['Platyrrhinus ismaeli']
+  aliases: []
   parents:
   - 27657
 410852:
-  aliases: ['Platyrrhinus lineatus']
+  aliases: []
   parents:
   - 27657
 574080:
-  aliases: ['Platyrrhinus masu']
+  aliases: []
   parents:
   - 27657
 574081:
-  aliases: ['Platyrrhinus matapalensis']
+  aliases: []
   parents:
   - 27657
 574064:
-  aliases: ['Platyrrhinus recifinus']
+  aliases: []
   parents:
   - 27657
 2448888:
-  aliases: ['Platyrrhinus umbratus']
+  aliases: []
   parents:
   - 27657
 574065:
-  aliases: ['Platyrrhinus vittatus']
+  aliases: []
   parents:
   - 27657
 169059:
-  aliases: ['Plecotus austriacus austriacus']
+  aliases: []
   parents:
   - 109483
 272800:
-  aliases: ['Plecotus macrobullaris macrobullaris']
+  aliases: []
   parents:
   - 242915
 2917802:
-  aliases: ['Plecotus ognevi nomrogi']
+  aliases: []
   parents:
   - 360160
 232091:
-  aliases: ['Plecotus sp.']
+  aliases: []
   parents:
   - 1032398
 233183:
-  aliases: ['Plecotus sp. JJJ-2003']
+  aliases: []
   parents:
   - 1032398
 1032399:
-  aliases: ['Plecotus sp. MIBZPL00262']
+  aliases: []
   parents:
   - 1032398
 1032400:
-  aliases: ['Plecotus sp. MIBZPL00265']
+  aliases: []
   parents:
   - 1032398
 1032401:
-  aliases: ['Plecotus sp. MIBZPL00268']
+  aliases: []
   parents:
   - 1032398
 1032402:
-  aliases: ['Plecotus sp. MIBZPL00269']
+  aliases: []
   parents:
   - 1032398
 1032403:
-  aliases: ['Plecotus sp. MIBZPL00270']
+  aliases: []
   parents:
   - 1032398
 1032404:
-  aliases: ['Plecotus sp. MIBZPL01189']
+  aliases: []
   parents:
   - 1032398
 1032405:
-  aliases: ['Plecotus sp. MIBZPL03414']
+  aliases: []
   parents:
   - 1032398
 479724:
-  aliases: ['Plecotus sp. V3']
+  aliases: []
   parents:
   - 1032398
 1812309:
-  aliases: ['Plerotes']
+  aliases: []
   parents:
   - 3136029
 2907246:
-  aliases: ['Promops sp. IP1204/2015']
+  aliases: []
   parents:
   - 2907245
 3392253:
-  aliases: ['Pseudoromicia sp.']
+  aliases: []
   parents:
   - 2778575
 2778576:
-  aliases: ['Pseudoromicia sp. Tanzania']
+  aliases: []
   parents:
   - 2778575
 132906:
-  aliases: ['Ptenochirus']
+  aliases: []
   parents:
   - 3136027
 58080:
-  aliases: ['Pteralopex']
+  aliases: []
   parents:
   - 77225
 1884719:
-  aliases: ['Pteronotus parnellii fuscus']
+  aliases: []
   parents:
   - 59476
 1884721:
-  aliases: ['Pteronotus parnellii mexicanus']
+  aliases: []
   parents:
   - 59476
 1884718:
-  aliases: ['Pteronotus parnellii portoricensis']
+  aliases: []
   parents:
   - 59476
 1884720:
-  aliases: ['Pteronotus sp.']
+  aliases: []
   parents:
   - 2632027
 1769917:
-  aliases: ['Pteronotus sp. 3 BdT-2015']
+  aliases: []
   parents:
   - 2632027
 1921178:
-  aliases: ['Pteronotus sp. PV-RO-BRA']
+  aliases: []
   parents:
   - 2632027
 261759:
-  aliases: ['Pteropodidae sp. TTS-2004']
+  aliases: []
   parents:
   - 3136031
 9401:
-  aliases: ['Pteropus']
+  aliases: []
   parents:
   - 77225
 148037:
-  aliases: ['Pygoderma bilabiatum']
+  aliases: []
   parents:
   - 148028
 1296576:
-  aliases: ['Rhinolophidae sp. BOLD:AAB6249']
+  aliases: []
   parents:
   - 1296575
 1296578:
-  aliases: ['Rhinolophidae sp. BOLD:AAB9127']
+  aliases: []
   parents:
   - 1296575
 1296577:
-  aliases: ['Rhinolophidae sp. BOLD:AAD3329']
+  aliases: []
   parents:
   - 1296575
 1296579:
-  aliases: ['Rhinolophidae sp. SMM045-12']
+  aliases: []
   parents:
   - 1296575
 49442:
-  aliases: ['Rhinolophus']
+  aliases: []
   parents:
   - 186995
 270786:
-  aliases: ['Rhinonicteris aurantia']
+  aliases: []
   parents:
   - 271602
 138699:
-  aliases: ['Rhinophylla alethina']
+  aliases: []
   parents:
   - 138698
 138706:
-  aliases: ['Rhinophylla fischerae']
+  aliases: []
   parents:
   - 138698
 138707:
-  aliases: ['Rhinophylla pumilio']
+  aliases: []
   parents:
   - 138698
 1034335:
-  aliases: ['Rhinopoma cystops']
+  aliases: []
   parents:
   - 124755
 1436297:
-  aliases: ['Rhinopoma hadramauticum']
+  aliases: []
   parents:
   - 124755
 124756:
-  aliases: ['Rhinopoma hardwickii']
+  aliases: []
   parents:
   - 124755
 3370735:
-  aliases: ['Rhinopoma macinnesi']
+  aliases: []
   parents:
   - 124755
 173903:
-  aliases: ['Rhinopoma microphyllum']
+  aliases: []
   parents:
   - 124755
 173902:
-  aliases: ['Rhinopoma muscatellum']
+  aliases: []
   parents:
   - 124755
 2094008:
-  aliases: ['Rhogeessa sp. 20130222_359']
+  aliases: []
   parents:
   - 2622910
 249017:
-  aliases: ['Rhynchonycteris naso']
+  aliases: []
   parents:
   - 249016
 1332055:
-  aliases: ['Rhyneptesicus nasutus batinensis']
+  aliases: []
   parents:
   - 568178
 1332056:
-  aliases: ['Rhyneptesicus nasutus matschiei']
+  aliases: []
   parents:
   - 568178
 1332057:
-  aliases: ['Rhyneptesicus nasutus nasutus']
+  aliases: []
   parents:
   - 568178
 9406:
-  aliases: ['Rousettus']
+  aliases: []
   parents:
   - 3136029
 446910:
-  aliases: ['Saccolaimus flaviventris']
+  aliases: []
   parents:
   - 446909
 526813:
-  aliases: ['Saccolaimus saccolaimus']
+  aliases: []
   parents:
   - 446909
 59482:
-  aliases: ['Saccopteryx bilineata']
+  aliases: []
   parents:
   - 59481
 409053:
-  aliases: ['Saccopteryx canescens']
+  aliases: []
   parents:
   - 59481
 409054:
-  aliases: ['Saccopteryx gymnura']
+  aliases: []
   parents:
   - 59481
 249018:
-  aliases: ['Saccopteryx leptura']
+  aliases: []
   parents:
   - 59481
 3077733:
-  aliases: ['Scotoecus sp.']
+  aliases: []
   parents:
   - 2636109
 2448883:
-  aliases: ['Scotoecus sp. DMR-2017']
+  aliases: []
   parents:
   - 2636109
 1002350:
-  aliases: ['Scotoecus sp. IVK-2011']
+  aliases: []
   parents:
   - 2636109
 1001562:
-  aliases: ['Scotonycteris']
+  aliases: []
   parents:
   - 3136029
 3075053:
-  aliases: ['Scotophilus sp.']
+  aliases: []
   parents:
   - 2645158
 1975656:
-  aliases: ['Scotophilus sp. B115']
+  aliases: []
   parents:
   - 2645158
 1975657:
-  aliases: ['Scotophilus sp. B156']
+  aliases: []
   parents:
   - 2645158
 2448884:
-  aliases: ['Scotophilus sp. DMR-2017']
+  aliases: []
   parents:
   - 2645158
 1002351:
-  aliases: ['Scotophilus sp. IVK-2011']
+  aliases: []
   parents:
   - 2645158
 2591333:
-  aliases: ['Scotophilus sp. clade 1 TD-2019']
+  aliases: []
   parents:
   - 2645158
 2591334:
-  aliases: ['Scotophilus sp. clade 2 TD-2019']
+  aliases: []
   parents:
   - 2645158
 2591335:
-  aliases: ['Scotophilus sp. clade 3 TD-2019']
+  aliases: []
   parents:
   - 2645158
 2591336:
-  aliases: ['Scotophilus sp. clade 4 TD-2019']
+  aliases: []
   parents:
   - 2645158
 2591337:
-  aliases: ['Scotophilus sp. clade 5 TD-2019']
+  aliases: []
   parents:
   - 2645158
 2591338:
-  aliases: ['Scotophilus sp. clade 7 TD-2019']
+  aliases: []
   parents:
   - 2645158
 565069:
-  aliases: ['Scotophilus viridis nigritellus']
+  aliases: []
   parents:
   - 312069
 270780:
-  aliases: ['Scotorepens sp. JMW-2004']
+  aliases: []
   parents:
   - 2636263
 662897:
-  aliases: ['Sphaerias']
+  aliases: []
   parents:
   - 3136027
 148038:
-  aliases: ['Sphaeronycteris toxophyllum']
+  aliases: []
   parents:
   - 148029
 148093:
-  aliases: ['Stenoderma rufum']
+  aliases: []
   parents:
   - 148030
 1246967:
-  aliases: ['Stenonycterini']
+  aliases: []
   parents:
   - 3136030
 1983336:
-  aliases: ['Sturnira adrianae']
+  aliases: []
   parents:
   - 27659
 2737875:
-  aliases: ['Sturnira angeli']
+  aliases: []
   parents:
   - 27659
 192400:
-  aliases: ['Sturnira aratathomasi']
+  aliases: []
   parents:
   - 27659
 2019462:
-  aliases: ['Sturnira bakeri']
+  aliases: []
   parents:
   - 27659
 192401:
-  aliases: ['Sturnira bidens']
+  aliases: []
   parents:
   - 27659
 192402:
-  aliases: ['Sturnira bogotensis']
+  aliases: []
   parents:
   - 27659
 1908666:
-  aliases: ['Sturnira burtonlimi']
+  aliases: []
   parents:
   - 27659
 192403:
-  aliases: ['Sturnira erythromos']
+  aliases: []
   parents:
   - 27659
 3242989:
-  aliases: ['Sturnira giannae']
+  aliases: []
   parents:
   - 27659
 192404:
-  aliases: ['Sturnira hondurensis']
+  aliases: []
   parents:
   - 27659
 3370835:
-  aliases: ['Sturnira koopmanhilli']
+  aliases: []
   parents:
   - 27659
 27660:
-  aliases: ['Sturnira lilium']
+  aliases: []
   parents:
   - 27659
 192405:
-  aliases: ['Sturnira ludovici']
+  aliases: []
   parents:
   - 27659
 192406:
-  aliases: ['Sturnira luisi']
+  aliases: []
   parents:
   - 27659
 192407:
-  aliases: ['Sturnira magna']
+  aliases: []
   parents:
   - 27659
 192408:
-  aliases: ['Sturnira mordax']
+  aliases: []
   parents:
   - 27659
 192409:
-  aliases: ['Sturnira nana']
+  aliases: []
   parents:
   - 27659
 192410:
-  aliases: ['Sturnira oporaphilum']
+  aliases: []
   parents:
   - 27659
 196700:
-  aliases: ['Sturnira parvidens']
+  aliases: []
   parents:
   - 27659
 1092446:
-  aliases: ['Sturnira perla']
+  aliases: []
   parents:
   - 27659
 27661:
-  aliases: ['Sturnira tildae']
+  aliases: []
   parents:
   - 27659
 1091511:
-  aliases: ['Styloctenium']
+  aliases: []
   parents:
   - 77225
 2951463:
-  aliases: ['Submyotodon sp. m HF-2022']
+  aliases: []
   parents:
   - 2951462
 58084:
-  aliases: ['Syconycteris']
+  aliases: []
   parents:
   - 77241
 242194:
-  aliases: ['Tadarida brasiliensis brasiliensis']
+  aliases: []
   parents:
   - 9438
 242195:
-  aliases: ['Tadarida brasiliensis cynocephala']
+  aliases: []
   parents:
   - 9438
 242196:
-  aliases: ['Tadarida brasiliensis intermedia']
+  aliases: []
   parents:
   - 9438
 242197:
-  aliases: ['Tadarida brasiliensis mexicana']
+  aliases: []
   parents:
   - 9438
 556300:
-  aliases: ['Tadarida sp. 7070']
+  aliases: []
   parents:
   - 2636308
 446905:
-  aliases: ['Taphozous australis']
+  aliases: []
   parents:
   - 13280
 13281:
-  aliases: ['Taphozous georgianus']
+  aliases: []
   parents:
   - 13280
 1002354:
-  aliases: ['Taphozous hildegardeae']
+  aliases: []
   parents:
   - 13280
 446906:
-  aliases: ['Taphozous hilli']
+  aliases: []
   parents:
   - 13280
 463807:
-  aliases: ['Taphozous longimanus']
+  aliases: []
   parents:
   - 13280
 302395:
-  aliases: ['Taphozous mauritianus']
+  aliases: []
   parents:
   - 13280
 187003:
-  aliases: ['Taphozous melanopogon']
+  aliases: []
   parents:
   - 13280
 249019:
-  aliases: ['Taphozous nudiventris']
+  aliases: []
   parents:
   - 13280
 1381355:
-  aliases: ['Taphozous perforatus']
+  aliases: []
   parents:
   - 13280
 2029311:
-  aliases: ['Taphozous theobaldi']
+  aliases: []
   parents:
   - 13280
 58086:
-  aliases: ['Thoopterus']
+  aliases: []
   parents:
   - 3136027
 3079473:
-  aliases: ['Thyroptera tricolor albiventer']
+  aliases: []
   parents:
   - 124759
 2683044:
-  aliases: ['Tonatia bakeri']
+  aliases: []
   parents:
   - 9425
 9426:
-  aliases: ['Tonatia bidens']
+  aliases: []
   parents:
   - 9425
 2715937:
-  aliases: ['Tonatia maresi']
+  aliases: []
   parents:
   - 9425
 171122:
-  aliases: ['Tonatia saurophila']
+  aliases: []
   parents:
   - 9425
 148073:
-  aliases: ['Trachops cirrhosus']
+  aliases: []
   parents:
   - 148059
 409055:
-  aliases: ['Trachops cirrhosus PS1']
+  aliases: []
   parents:
   - 148059
 409056:
-  aliases: ['Trachops cirrhosus PS2']
+  aliases: []
   parents:
   - 148059
 409057:
-  aliases: ['Trachops cirrhosus PS3']
+  aliases: []
   parents:
   - 148059
 3370920:
-  aliases: ['Trachops coffini']
+  aliases: []
   parents:
   - 148059
 549403:
-  aliases: ['Triaenops afer']
+  aliases: []
   parents:
   - 258842
 1195082:
-  aliases: ['Triaenops menamena']
+  aliases: []
   parents:
   - 258842
 549400:
-  aliases: ['Triaenops parvus']
+  aliases: []
   parents:
   - 258842
 329870:
-  aliases: ['Triaenops persicus']
+  aliases: []
   parents:
   - 258842
 148068:
-  aliases: ['Trinycteris nicefori']
+  aliases: []
   parents:
   - 3477446
 27663:
-  aliases: ['Uroderma bilobatum']
+  aliases: []
   parents:
   - 27662
 2683985:
-  aliases: ['Uroderma convexum']
+  aliases: []
   parents:
   - 27662
 221446:
-  aliases: ['Uroderma magnirostrum']
+  aliases: []
   parents:
   - 27662
 148039:
-  aliases: ['Vampyressa bidens']
+  aliases: []
   parents:
   - 148031
 196701:
-  aliases: ['Vampyressa brocki']
+  aliases: []
   parents:
   - 148031
 2996699:
-  aliases: ['Vampyressa elisabethae']
+  aliases: []
   parents:
   - 148031
 362825:
-  aliases: ['Vampyressa melissa']
+  aliases: []
   parents:
   - 148031
 148040:
-  aliases: ['Vampyressa pusilla']
+  aliases: []
   parents:
   - 148031
 362826:
-  aliases: ['Vampyressa thyone']
+  aliases: []
   parents:
   - 148031
 3156175:
-  aliases: ['Vampyressa villai']
+  aliases: []
   parents:
   - 148031
 3370950:
-  aliases: ['Vampyriscus nymphaeus']
+  aliases: []
   parents:
   - 148031
 148041:
-  aliases: ['Vampyrodes caraccioli']
+  aliases: []
   parents:
   - 148032
 933072:
-  aliases: ['Vampyrodes major']
+  aliases: []
   parents:
   - 148032
 148074:
-  aliases: ['Vampyrum spectrum']
+  aliases: []
   parents:
   - 148060
 1470993:
-  aliases: ['Xeronycteris vieirai']
+  aliases: []
   parents:
   - 1470992
 2623340:
-  aliases: ['unclassified Anoura']
+  aliases: []
   parents:
   - 27641
 2625567:
-  aliases: ['unclassified Artibeus']
+  aliases: []
   parents:
   - 9416
 2645105:
-  aliases: ['unclassified Aselliscus']
+  aliases: []
   parents:
   - 188567
 2646434:
-  aliases: ['unclassified Carollia']
+  aliases: []
   parents:
   - 40232
 2627912:
-  aliases: ['unclassified Choeroniscus']
+  aliases: []
   parents:
   - 148042
 2630904:
-  aliases: ['unclassified Emballonura']
+  aliases: []
   parents:
   - 110939
 2646091:
-  aliases: ['unclassified Hipposideros']
+  aliases: []
   parents:
   - 58068
 3242302:
-  aliases: ['unclassified Megaderma']
+  aliases: []
   parents:
   - 9412
 2624502:
-  aliases: ['unclassified Micronycteris']
+  aliases: []
   parents:
   - 148056
 2640928:
-  aliases: ['unclassified Peropteryx']
+  aliases: []
   parents:
   - 249013
 2628851:
-  aliases: ['unclassified Phyllostomus']
+  aliases: []
   parents:
   - 9422
 2640664:
-  aliases: ['unclassified Platyrrhinus']
+  aliases: []
   parents:
   - 27657
 2633232:
-  aliases: ['unclassified Saccopteryx']
+  aliases: []
   parents:
   - 59481
 2631065:
-  aliases: ['unclassified Sturnira']
+  aliases: []
   parents:
   - 27659
 2622826:
-  aliases: ['unclassified Taphozous']
+  aliases: []
   parents:
   - 13280
 2633921:
-  aliases: ['unclassified Tonatia']
+  aliases: []
   parents:
   - 9425
 58057:
-  aliases: ['Acerodon celebensis']
+  aliases: []
   parents:
   - 58056
 505845:
-  aliases: ['Acerodon jubatus']
+  aliases: []
   parents:
   - 58056
 2933618:
-  aliases: ['Acerodon macklotii']
+  aliases: []
   parents:
   - 58056
 442846:
-  aliases: ['Aethalops aequalis']
+  aliases: []
   parents:
   - 77226
 77227:
-  aliases: ['Aethalops alecto']
+  aliases: []
   parents:
   - 77226
 662937:
-  aliases: ['Alionycteris paucidentata']
+  aliases: []
   parents:
   - 662936
 2563025:
-  aliases: ['Anoura sp. A CCA-2019']
+  aliases: []
   parents:
   - 2623340
 58059:
-  aliases: ['Aproteles bulmerae']
+  aliases: []
   parents:
   - 58058
 362872:
-  aliases: ['Artibeus glaucus rosenbergii']
+  aliases: []
   parents:
   - 40226
 51016:
-  aliases: ['Artibeus glaucus watsoni']
+  aliases: []
   parents:
   - 40226
 406806:
-  aliases: ['Artibeus jamaicensis jamaicensis']
+  aliases: []
   parents:
   - 9417
 406807:
-  aliases: ['Artibeus jamaicensis parvipes']
+  aliases: []
   parents:
   - 9417
 256420:
-  aliases: ['Artibeus jamaicensis paulus']
+  aliases: []
   parents:
   - 9417
 256419:
-  aliases: ['Artibeus jamaicensis richardsoni']
+  aliases: []
   parents:
   - 9417
 211472:
-  aliases: ['Artibeus jamaicensis triomylus']
+  aliases: []
   parents:
   - 9417
 211471:
-  aliases: ['Artibeus jamaicensis yucatanicus']
+  aliases: []
   parents:
   - 9417
 3079475:
-  aliases: ['Artibeus lituratus palmarum']
+  aliases: []
   parents:
   - 27634
 406808:
-  aliases: ['Artibeus planirostris fallax']
+  aliases: []
   parents:
   - 40230
 406809:
-  aliases: ['Artibeus planirostris grenadensis']
+  aliases: []
   parents:
   - 40230
 406810:
-  aliases: ['Artibeus planirostris hercules']
+  aliases: []
   parents:
   - 40230
 406811:
-  aliases: ['Artibeus planirostris planirostris']
+  aliases: []
   parents:
   - 40230
 406812:
-  aliases: ['Artibeus planirostris trinitatis']
+  aliases: []
   parents:
   - 40230
 1002695:
-  aliases: ['Artibeus sp. AVB-2011']
+  aliases: []
   parents:
   - 2625567
 1105487:
-  aliases: ['Artibeus sp. BOLD:AAA2159']
+  aliases: []
   parents:
   - 2625567
 1105488:
-  aliases: ['Artibeus sp. BOLD:AAA2160']
+  aliases: []
   parents:
   - 2625567
 1105489:
-  aliases: ['Artibeus sp. BOLD:AAA2332']
+  aliases: []
   parents:
   - 2625567
 416810:
-  aliases: ['Artibeus sp. FURB']
+  aliases: []
   parents:
   - 2625567
 887799:
-  aliases: ['Artibeus sp. JRA-2010']
+  aliases: []
   parents:
   - 2625567
 1882412:
-  aliases: ['Aselliscus sp. Zz-2016a']
+  aliases: []
   parents:
   - 2645105
 77229:
-  aliases: ['Balionycteris maculata']
+  aliases: []
   parents:
   - 77228
 270782:
-  aliases: ['Boneia bidens']
+  aliases: []
   parents:
   - 270781
 290571:
-  aliases: ['Brachyphylla nana pumila']
+  aliases: []
   parents:
   - 290570
 3114349:
-  aliases: ['Carollia sp.']
+  aliases: []
   parents:
   - 2646434
 1380313:
-  aliases: ['Carollia sp. 1 PMV-2013']
+  aliases: []
   parents:
   - 2646434
 1091509:
-  aliases: ['Casinycteris argynnis']
+  aliases: []
   parents:
   - 1091508
 1497437:
-  aliases: ['Casinycteris campomaanensis']
+  aliases: []
   parents:
   - 1091508
 1497438:
-  aliases: ['Casinycteris ophiodon']
+  aliases: []
   parents:
   - 1091508
 280973:
-  aliases: ['Centurio senex greenhalli']
+  aliases: []
   parents:
   - 27644
 2773073:
-  aliases: ['Chiroderma doriae vizottoi']
+  aliases: []
   parents:
   - 33544
 170236:
-  aliases: ['Chironax melanocephalus']
+  aliases: []
   parents:
   - 170235
 999943:
-  aliases: ['Choeroniscus sp. BOLD:AAC3416']
+  aliases: []
   parents:
   - 2627912
 58060:
-  aliases: ['Cynopterus brachyotis']
+  aliases: []
   parents:
   - 9399
 867815:
-  aliases: ['Cynopterus cf. brachyotis CMF-2010']
+  aliases: []
   parents:
   - 9399
 298109:
-  aliases: ['Cynopterus horsfieldii']
+  aliases: []
   parents:
   - 9399
 378216:
-  aliases: ['Cynopterus nusatenggara']
+  aliases: []
   parents:
   - 9399
 9400:
-  aliases: ['Cynopterus sphinx']
+  aliases: []
   parents:
   - 9399
 867816:
-  aliases: ['Cynopterus titthaecheilus']
+  aliases: []
   parents:
   - 9399
 505943:
-  aliases: ['Desmalopex leucoptera']
+  aliases: []
   parents:
   - 515994
 515995:
-  aliases: ['Desmalopex microleucoptera']
+  aliases: []
   parents:
   - 515994
 170213:
-  aliases: ['Dobsonia andersoni']
+  aliases: []
   parents:
   - 42146
 170214:
-  aliases: ['Dobsonia inermis']
+  aliases: []
   parents:
   - 42146
 522445:
-  aliases: ['Dobsonia magna']
+  aliases: []
   parents:
   - 42146
 170215:
-  aliases: ['Dobsonia minor']
+  aliases: []
   parents:
   - 42146
 42147:
-  aliases: ['Dobsonia moluccensis']
+  aliases: []
   parents:
   - 42146
 170216:
-  aliases: ['Dobsonia pannietensis']
+  aliases: []
   parents:
   - 42146
 170217:
-  aliases: ['Dobsonia praedatrix']
+  aliases: []
   parents:
   - 42146
 170218:
-  aliases: ['Dobsonia viridis']
+  aliases: []
   parents:
   - 42146
 2703642:
-  aliases: ['Dyacopterus rickarti']
+  aliases: []
   parents:
   - 326080
 326081:
-  aliases: ['Dyacopterus spadiceus']
+  aliases: []
   parents:
   - 326080
 58063:
-  aliases: ['Eidolon dupreanum']
+  aliases: []
   parents:
   - 58062
 77214:
-  aliases: ['Eidolon helvum']
+  aliases: []
   parents:
   - 58062
 1368311:
-  aliases: ['Emballonura semicaudata rotensis']
+  aliases: []
   parents:
   - 170234
 271461:
-  aliases: ['Emballonura sp. JMW-2004']
+  aliases: []
   parents:
   - 2630904
 1244809:
-  aliases: ['Emballonura sp. SJP-2012']
+  aliases: []
   parents:
   - 2630904
 526811:
-  aliases: ['Eonycteris major']
+  aliases: []
   parents:
   - 58064
 1091510:
-  aliases: ['Eonycteris robusta']
+  aliases: []
   parents:
   - 58064
 58065:
-  aliases: ['Eonycteris spelaea']
+  aliases: []
   parents:
   - 58064
 58066:
-  aliases: ['Epomophorus']
+  aliases: []
   parents:
   - 1246964
 77230:
-  aliases: ['Epomops']
+  aliases: []
   parents:
   - 1246964
 301158:
-  aliases: ['Haplonycteris fischeri']
+  aliases: []
   parents:
   - 301157
 584770:
-  aliases: ['Harpyionycteris celebensis']
+  aliases: []
   parents:
   - 378749
 378750:
-  aliases: ['Harpyionycteris whiteheadi']
+  aliases: []
   parents:
   - 378749
 1197850:
-  aliases: ['Hipposideros alongensis alongensis']
+  aliases: []
   parents:
   - 1197849
 1197851:
-  aliases: ['Hipposideros alongensis sungi']
+  aliases: []
   parents:
   - 1197849
 186991:
-  aliases: ['Hipposideros armiger terasensis']
+  aliases: []
   parents:
   - 186990
 343907:
-  aliases: ['Hipposideros ater gilberti']
+  aliases: []
   parents:
   - 279184
 635127:
-  aliases: ['Hipposideros caffer tephrus']
+  aliases: []
   parents:
   - 302402
 867826:
-  aliases: ['Hipposideros cf. larvatus CMF-2010']
+  aliases: []
   parents:
   - 354741
 2291615:
-  aliases: ['Hipposideros diadema masoni']
+  aliases: []
   parents:
   - 59453
 354743:
-  aliases: ['Hipposideros grandis']
+  aliases: []
   parents:
   - 354741
 354742:
-  aliases: ['Hipposideros khasiana']
+  aliases: []
   parents:
   - 354741
 175524:
-  aliases: ['Hipposideros larvatus']
+  aliases: []
   parents:
   - 354741
 1197856:
-  aliases: ['Hipposideros larvatus s.l. SJP-2012']
+  aliases: []
   parents:
   - 354741
 3457474:
-  aliases: ['Hipposideros larvatus sensu lato KP-2025']
+  aliases: []
   parents:
   - 354741
 3374061:
-  aliases: ['Hipposideros sp.']
+  aliases: []
   parents:
   - 2646091
 586238:
-  aliases: ['Hipposideros sp. 1 KS-2008']
+  aliases: []
   parents:
   - 2646091
 1391745:
-  aliases: ['Hipposideros sp. 1 LEP-2013']
+  aliases: []
   parents:
   - 2646091
 1116469:
-  aliases: ['Hipposideros sp. A SWM-2011']
+  aliases: []
   parents:
   - 2646091
 1699535:
-  aliases: ['Hipposideros sp. ARR-2015']
+  aliases: []
   parents:
   - 2646091
 1116468:
-  aliases: ['Hipposideros sp. B SWM-2011']
+  aliases: []
   parents:
   - 2646091
 867830:
-  aliases: ['Hipposideros sp. C CMF-2010']
+  aliases: []
   parents:
   - 2646091
 415934:
-  aliases: ['Hipposideros sp. GZNU200307']
+  aliases: []
   parents:
   - 2646091
 1002344:
-  aliases: ['Hipposideros sp. IVK-2011']
+  aliases: []
   parents:
   - 2646091
 1207991:
-  aliases: ['Hipposideros sp. JAE-2012']
+  aliases: []
   parents:
   - 2646091
 271462:
-  aliases: ['Hipposideros sp. JMW-2004a']
+  aliases: []
   parents:
   - 2646091
 271463:
-  aliases: ['Hipposideros sp. JMW-2004b']
+  aliases: []
   parents:
   - 2646091
 2448872:
-  aliases: ['Hipposideros sp. caffer-ruber DMR-2017']
+  aliases: []
   parents:
   - 2646091
 3384837:
-  aliases: ['Hipposideros sp. n. TK-2024']
+  aliases: []
   parents:
   - 2646091
 1197766:
-  aliases: ['Hipposideros turpis turpis']
+  aliases: []
   parents:
   - 185215
 448083:
-  aliases: ['Hypsignathus']
+  aliases: []
   parents:
   - 1246964
 556919:
-  aliases: ['Latidens salimalii']
+  aliases: []
   parents:
   - 556918
 29076:
-  aliases: ['Macroglossus minimus']
+  aliases: []
   parents:
   - 29075
 326083:
-  aliases: ['Macroglossus sobrinus']
+  aliases: []
   parents:
   - 29075
 3242303:
-  aliases: ['Megaderma sp.']
+  aliases: []
   parents:
   - 3242302
 298110:
-  aliases: ['Megaerops ecaudatus']
+  aliases: []
   parents:
   - 77232
 374419:
-  aliases: ['Megaerops kusnotoi']
+  aliases: []
   parents:
   - 77232
 77233:
-  aliases: ['Megaerops niphanae']
+  aliases: []
   parents:
   - 77232
 58072:
-  aliases: ['Megaloglossus']
+  aliases: []
   parents:
   - 1246961
 77215:
-  aliases: ['Melonycteris melanops']
+  aliases: []
   parents:
   - 58074
 319527:
-  aliases: ['Melonycteris woodfordi']
+  aliases: []
   parents:
   - 58074
 338420:
-  aliases: ['Micronycteris sp. TK136752']
+  aliases: []
   parents:
   - 2624502
 1496138:
-  aliases: ['Mirimiri acrodonta']
+  aliases: []
   parents:
   - 1496136
 77236:
-  aliases: ['Myonycteris']
+  aliases: []
   parents:
   - 1246961
 498219:
-  aliases: ['Nanonycteris']
+  aliases: []
   parents:
   - 1246964
 2747556:
-  aliases: ['Neopteryx frosti']
+  aliases: []
   parents:
   - 2747555
 3387232:
-  aliases: ['Nesonycteris ardoulisi schouteni']
+  aliases: []
   parents:
   - 3387231
 3387230:
-  aliases: ['Nesonycteris fardoulisi fardoulisi']
+  aliases: []
   parents:
   - 3371130
 58078:
-  aliases: ['Notopteris macdonaldii']
+  aliases: []
   parents:
   - 58077
 270783:
-  aliases: ['Nyctimene aello']
+  aliases: []
   parents:
   - 48987
 48988:
-  aliases: ['Nyctimene albiventer']
+  aliases: []
   parents:
   - 48987
 170209:
-  aliases: ['Nyctimene cephalotes']
+  aliases: []
   parents:
   - 48987
 170210:
-  aliases: ['Nyctimene certans']
+  aliases: []
   parents:
   - 48987
 77240:
-  aliases: ['Nyctimene major']
+  aliases: []
   parents:
   - 48987
 2703643:
-  aliases: ['Nyctimene rabori']
+  aliases: []
   parents:
   - 48987
 58079:
-  aliases: ['Nyctimene robinsoni']
+  aliases: []
   parents:
   - 48987
 170211:
-  aliases: ['Nyctimene vizcaccia']
+  aliases: []
   parents:
   - 48987
 328968:
-  aliases: ['Otopteropus cartilagonodus']
+  aliases: []
   parents:
   - 328967
 270785:
-  aliases: ['Paranyctimene raptor']
+  aliases: []
   parents:
   - 270784
 326151:
-  aliases: ['Penthetor lucasii']
+  aliases: []
   parents:
   - 326150
 1158974:
-  aliases: ['Peropteryx sp. BOLD:AAI2457']
+  aliases: []
   parents:
   - 2640928
 463810:
-  aliases: ['Peropteryx sp. ROM 104396']
+  aliases: []
   parents:
   - 2640928
 463811:
-  aliases: ['Peropteryx sp. RSV 2330']
+  aliases: []
   parents:
   - 2640928
 2737247:
-  aliases: ['Phyllostomus sp. PHH3']
+  aliases: []
   parents:
   - 2628851
 3076788:
-  aliases: ['Platyrrhinus incarum incarum']
+  aliases: []
   parents:
   - 574072
 574066:
-  aliases: ['Platyrrhinus lineatus nigellus']
+  aliases: []
   parents:
   - 410852
 1684764:
-  aliases: ['Platyrrhinus sp. MH-2015']
+  aliases: []
   parents:
   - 2640664
 1812310:
-  aliases: ['Plerotes anchietae']
+  aliases: []
   parents:
   - 1812309
 2933645:
-  aliases: ['Ptenochirus jagorii']
+  aliases: []
   parents:
   - 132906
 328961:
-  aliases: ['Ptenochirus minor']
+  aliases: []
   parents:
   - 132906
 414524:
-  aliases: ['Ptenochirus wetmorei']
+  aliases: []
   parents:
   - 132906
 58081:
-  aliases: ['Pteralopex atrata']
+  aliases: []
   parents:
   - 58080
 1496134:
-  aliases: ['Pteralopex taki']
+  aliases: []
   parents:
   - 58080
 58082:
-  aliases: ['Pteropus admiralitatum']
+  aliases: []
   parents:
   - 9401
 589507:
-  aliases: ['Pteropus aldabrensis']
+  aliases: []
   parents:
   - 9401
 9402:
-  aliases: ['Pteropus alecto']
+  aliases: []
   parents:
   - 9401
 170220:
-  aliases: ['Pteropus anetianus']
+  aliases: []
   parents:
   - 9401
 2721786:
-  aliases: ['Pteropus caniceps']
+  aliases: []
   parents:
   - 9401
 1291037:
-  aliases: ['Pteropus capistratus']
+  aliases: []
   parents:
   - 9401
 2721787:
-  aliases: ['Pteropus chrysoproctus']
+  aliases: []
   parents:
   - 9401
 170222:
-  aliases: ['Pteropus cognatus']
+  aliases: []
   parents:
   - 9401
 328804:
-  aliases: ['Pteropus conspicillatus']
+  aliases: []
   parents:
   - 9401
 126282:
-  aliases: ['Pteropus dasymallus']
+  aliases: []
   parents:
   - 9401
 1288886:
-  aliases: ['Pteropus faunulus']
+  aliases: []
   parents:
   - 9401
 170223:
-  aliases: ['Pteropus fundatus']
+  aliases: []
   parents:
   - 9401
 3370656:
-  aliases: ['Pteropus gilliardi']
+  aliases: []
   parents:
   - 9401
 1495907:
-  aliases: ['Pteropus griseus']
+  aliases: []
   parents:
   - 9401
 9405:
-  aliases: ['Pteropus hypomelanus']
+  aliases: []
   parents:
   - 9401
 589508:
-  aliases: ['Pteropus livingstonii']
+  aliases: []
   parents:
   - 9401
 1495904:
-  aliases: ['Pteropus lombocensis']
+  aliases: []
   parents:
   - 9401
 166054:
-  aliases: ['Pteropus lylei']
+  aliases: []
   parents:
   - 9401
 448077:
-  aliases: ['Pteropus macrotis']
+  aliases: []
   parents:
   - 9401
 1496129:
-  aliases: ['Pteropus mahaganus']
+  aliases: []
   parents:
   - 9401
 522447:
-  aliases: ['Pteropus mariannus']
+  aliases: []
   parents:
   - 9401
 143291:
-  aliases: ['Pteropus medius']
+  aliases: []
   parents:
   - 9401
 2721788:
-  aliases: ['Pteropus melanopogon']
+  aliases: []
   parents:
   - 9401
 1562755:
-  aliases: ['Pteropus melanotus']
+  aliases: []
   parents:
   - 9401
 522446:
-  aliases: ['Pteropus molossinus']
+  aliases: []
   parents:
   - 9401
 170224:
-  aliases: ['Pteropus neohibernicus']
+  aliases: []
   parents:
   - 9401
 170225:
-  aliases: ['Pteropus niger']
+  aliases: []
   parents:
   - 9401
 1496128:
-  aliases: ['Pteropus nitendiensis']
+  aliases: []
   parents:
   - 9401
 170226:
-  aliases: ['Pteropus ocularis']
+  aliases: []
   parents:
   - 9401
 170227:
-  aliases: ['Pteropus ornatus']
+  aliases: []
   parents:
   - 9401
 1495906:
-  aliases: ['Pteropus pelagicus']
+  aliases: []
   parents:
   - 9401
 1495877:
-  aliases: ['Pteropus pelewensis']
+  aliases: []
   parents:
   - 9401
 170228:
-  aliases: ['Pteropus personatus']
+  aliases: []
   parents:
   - 9401
 170229:
-  aliases: ['Pteropus pohlei']
+  aliases: []
   parents:
   - 9401
 9403:
-  aliases: ['Pteropus poliocephalus']
+  aliases: []
   parents:
   - 9401
 1496133:
-  aliases: ['Pteropus pselaphon']
+  aliases: []
   parents:
   - 9401
 161598:
-  aliases: ['Pteropus pumilus']
+  aliases: []
   parents:
   - 9401
 110942:
-  aliases: ['Pteropus rayneri']
+  aliases: []
   parents:
   - 9401
 2747553:
-  aliases: ['Pteropus rennelli']
+  aliases: []
   parents:
   - 9401
 77216:
-  aliases: ['Pteropus rodricensis']
+  aliases: []
   parents:
   - 9401
 196297:
-  aliases: ['Pteropus rufus']
+  aliases: []
   parents:
   - 9401
 170230:
-  aliases: ['Pteropus samoensis']
+  aliases: []
   parents:
   - 9401
 94117:
-  aliases: ['Pteropus scapulatus']
+  aliases: []
   parents:
   - 9401
 589506:
-  aliases: ['Pteropus seychellensis']
+  aliases: []
   parents:
   - 9401
 161599:
-  aliases: ['Pteropus speciosus']
+  aliases: []
   parents:
   - 9401
 9404:
-  aliases: ['Pteropus temminckii']
+  aliases: []
   parents:
   - 9401
 1496132:
-  aliases: ['Pteropus tokudae']
+  aliases: []
   parents:
   - 9401
 77217:
-  aliases: ['Pteropus tonganus']
+  aliases: []
   parents:
   - 9401
 1496131:
-  aliases: ['Pteropus tuberculatus']
+  aliases: []
   parents:
   - 9401
 1495879:
-  aliases: ['Pteropus ualanus']
+  aliases: []
   parents:
   - 9401
 132908:
-  aliases: ['Pteropus vampyrus']
+  aliases: []
   parents:
   - 9401
 170231:
-  aliases: ['Pteropus vetulus']
+  aliases: []
   parents:
   - 9401
 589509:
-  aliases: ['Pteropus voeltzkowi']
+  aliases: []
   parents:
   - 9401
 170232:
-  aliases: ['Pteropus woodfordi']
+  aliases: []
   parents:
   - 9401
 320431:
-  aliases: ['Rhinolophus acuminatus']
+  aliases: []
   parents:
   - 49442
 59477:
-  aliases: ['Rhinolophus affinis']
+  aliases: []
   parents:
   - 49442
 249024:
-  aliases: ['Rhinolophus alcyone']
+  aliases: []
   parents:
   - 49442
 2291617:
-  aliases: ['Rhinolophus andamanensis']
+  aliases: []
   parents:
   - 49442
 76834:
-  aliases: ['Rhinolophus arcuatus']
+  aliases: []
   parents:
   - 49442
 556920:
-  aliases: ['Rhinolophus beddomei']
+  aliases: []
   parents:
   - 49442
 519037:
-  aliases: ['Rhinolophus blasii']
+  aliases: []
   parents:
   - 49442
 2603870:
-  aliases: ['Rhinolophus blasii complex sp. 1 TD-2019']
+  aliases: []
   parents:
   - 49442
 3068536:
-  aliases: ['Rhinolophus bocharicus']
+  aliases: []
   parents:
   - 49442
 337452:
-  aliases: ['Rhinolophus borneensis']
+  aliases: []
   parents:
   - 49442
 302408:
-  aliases: ['Rhinolophus capensis']
+  aliases: []
   parents:
   - 49442
 1078801:
-  aliases: ['Rhinolophus celebensis']
+  aliases: []
   parents:
   - 49442
 1007694:
-  aliases: ['Rhinolophus cf. chaseni BOLD:AAB4878']
+  aliases: []
   parents:
   - 49442
 1154687:
-  aliases: ['Rhinolophus cf. chaseni SVK-2012']
+  aliases: []
   parents:
   - 49442
 2603859:
-  aliases: ['Rhinolophus cf. denti TD-2019']
+  aliases: []
   parents:
   - 49442
 2603860:
-  aliases: ['Rhinolophus cf. denti/simulator TD-2019']
+  aliases: []
   parents:
   - 49442
 2448881:
-  aliases: ['Rhinolophus cf. eloquens DMR-2017']
+  aliases: []
   parents:
   - 49442
 867886:
-  aliases: ['Rhinolophus cf. ferrumequinum CMF-2010']
+  aliases: []
   parents:
   - 49442
 1232899:
-  aliases: ['Rhinolophus cf. hildebrandti']
+  aliases: []
   parents:
   - 49442
 2528448:
-  aliases: ['Rhinolophus cf. inops MRMD1747']
+  aliases: []
   parents:
   - 49442
 2528452:
-  aliases: ['Rhinolophus cf. inops MRMD1818']
+  aliases: []
   parents:
   - 49442
 3449228:
-  aliases: ['Rhinolophus cf. landeri']
+  aliases: []
   parents:
   - 49442
 2603861:
-  aliases: ['Rhinolophus cf. landeri TD-2019']
+  aliases: []
   parents:
   - 49442
 1001579:
-  aliases: ['Rhinolophus cf. lepidus']
+  aliases: []
   parents:
   - 49442
 867887:
-  aliases: ['Rhinolophus cf. lepidus CMF-2010']
+  aliases: []
   parents:
   - 49442
 2304489:
-  aliases: ['Rhinolophus cf. macrotis LZ-2018']
+  aliases: []
   parents:
   - 49442
 1964314:
-  aliases: ['Rhinolophus cf. macrotis Phia Oac VTT-2017']
+  aliases: []
   parents:
   - 49442
 2590849:
-  aliases: ['Rhinolophus cf. macrotis TL-2019']
+  aliases: []
   parents:
   - 49442
 1964313:
-  aliases: ['Rhinolophus cf. macrotis VTT-2017']
+  aliases: []
   parents:
   - 49442
 2916559:
-  aliases: ['Rhinolophus cf. macrotis sensu Tu et al. 2017']
+  aliases: []
   parents:
   - 49442
 2528453:
-  aliases: ['Rhinolophus cf. philippinensis AMF0074']
+  aliases: []
   parents:
   - 49442
 2528449:
-  aliases: ['Rhinolophus cf. philippinensis AMF0075']
+  aliases: []
   parents:
   - 49442
 2528447:
-  aliases: ['Rhinolophus cf. philippinensis AMF0076']
+  aliases: []
   parents:
   - 49442
 1007695:
-  aliases: ['Rhinolophus cf. pusillus BOLD:AAB9127']
+  aliases: []
   parents:
   - 49442
 867888:
-  aliases: ['Rhinolophus cf. pusillus CMF-2010']
+  aliases: []
   parents:
   - 49442
 2304488:
-  aliases: ['Rhinolophus cf. siamensis LZ-2018']
+  aliases: []
   parents:
   - 49442
 1964315:
-  aliases: ['Rhinolophus cf. siamensis VTT-2017']
+  aliases: []
   parents:
   - 49442
 2916560:
-  aliases: ['Rhinolophus cf. siamensis sensu Tu et al. 2017']
+  aliases: []
   parents:
   - 49442
 1939661:
-  aliases: ['Rhinolophus cf. simulator SJP-2016']
+  aliases: []
   parents:
   - 49442
 2528451:
-  aliases: ['Rhinolophus cf. subrufus AMF0068']
+  aliases: []
   parents:
   - 49442
 2528446:
-  aliases: ['Rhinolophus cf. subrufus AMF0069']
+  aliases: []
   parents:
   - 49442
 2528450:
-  aliases: ['Rhinolophus cf. subrufus DMP124']
+  aliases: []
   parents:
   - 49442
 2528454:
-  aliases: ['Rhinolophus cf. subrufus MGP0605']
+  aliases: []
   parents:
   - 49442
 867889:
-  aliases: ['Rhinolophus cf. thomasi CMF-2010']
+  aliases: []
   parents:
   - 49442
 867890:
-  aliases: ['Rhinolophus chaseni']
+  aliases: []
   parents:
   - 49442
 2510767:
-  aliases: ['Rhinolophus chiewkweeae']
+  aliases: []
   parents:
   - 49442
 59478:
-  aliases: ['Rhinolophus clivosus']
+  aliases: []
   parents:
   - 49442
 2603871:
-  aliases: ['Rhinolophus clivosus complex sp. 1 TD-2019']
+  aliases: []
   parents:
   - 49442
 2603872:
-  aliases: ['Rhinolophus clivosus complex sp. 2 TD-2019']
+  aliases: []
   parents:
   - 49442
 2603873:
-  aliases: ['Rhinolophus clivosus complex sp. 3 TD-2019']
+  aliases: []
   parents:
   - 49442
 2603875:
-  aliases: ['Rhinolophus clivosus complex sp. 6 TD-2019']
+  aliases: []
   parents:
   - 49442
 867891:
-  aliases: ['Rhinolophus coelophyllus']
+  aliases: []
   parents:
   - 49442
 1548709:
-  aliases: ['Rhinolophus cognatus']
+  aliases: []
   parents:
   - 49442
 196296:
-  aliases: ['Rhinolophus cornutus']
+  aliases: []
   parents:
   - 49442
 178895:
-  aliases: ['Rhinolophus creaghi']
+  aliases: []
   parents:
   - 49442
 1434703:
-  aliases: ['Rhinolophus damarensis']
+  aliases: []
   parents:
   - 49442
 49443:
-  aliases: ['Rhinolophus darlingi']
+  aliases: []
   parents:
   - 49442
 2603862:
-  aliases: ['Rhinolophus deckenii']
+  aliases: []
   parents:
   - 49442
 608656:
-  aliases: ['Rhinolophus denti']
+  aliases: []
   parents:
   - 49442
 3449238:
-  aliases: ['Rhinolophus dobsoni']
+  aliases: []
   parents:
   - 49442
 519038:
-  aliases: ['Rhinolophus eloquens']
+  aliases: []
   parents:
   - 49442
 109476:
-  aliases: ['Rhinolophus euryale']
+  aliases: []
   parents:
   - 49442
 76835:
-  aliases: ['Rhinolophus euryotis']
+  aliases: []
   parents:
   - 49442
 59479:
-  aliases: ['Rhinolophus ferrumequinum']
+  aliases: []
   parents:
   - 49442
 2933649:
-  aliases: ['Rhinolophus foetidus']
+  aliases: []
   parents:
   - 49442
 472238:
-  aliases: ['Rhinolophus formosae']
+  aliases: []
   parents:
   - 49442
 3007093:
-  aliases: ['Rhinolophus francisi']
+  aliases: []
   parents:
   - 49442
 302410:
-  aliases: ['Rhinolophus fumigatus']
+  aliases: []
   parents:
   - 49442
 2603876:
-  aliases: ['Rhinolophus fumigatus/eloquens complex sp. 1 TD-2019']
+  aliases: []
   parents:
   - 49442
 2603877:
-  aliases: ['Rhinolophus fumigatus/eloquens complex sp. 2 TD-2019']
+  aliases: []
   parents:
   - 49442
 2603878:
-  aliases: ['Rhinolophus fumigatus/eloquens complex sp. 3 TD-2019']
+  aliases: []
   parents:
   - 49442
 2603874:
-  aliases: ['Rhinolophus fumigatus/eloquens complex sp. 4 TD-2019']
+  aliases: []
   parents:
   - 49442
 2603879:
-  aliases: ['Rhinolophus fumigatus/eloquens complex sp. 7 TD-2019']
+  aliases: []
   parents:
   - 49442
 2603880:
-  aliases: ['Rhinolophus fumigatus/eloquens complex sp. 8 TD-2019']
+  aliases: []
   parents:
   - 49442
 2603863:
-  aliases: ['Rhinolophus gorongosae']
+  aliases: []
   parents:
   - 49442
 302411:
-  aliases: ['Rhinolophus hildebrandti']
+  aliases: []
   parents:
   - 49442
 2603881:
-  aliases: ['Rhinolophus hildebrandtii complex sp. 1 TD-2019']
+  aliases: []
   parents:
   - 49442
 2603882:
-  aliases: ['Rhinolophus hildebrandtii complex sp. 2 TD-2019']
+  aliases: []
   parents:
   - 49442
 2957227:
-  aliases: ['Rhinolophus hilli']
+  aliases: []
   parents:
   - 49442
 77218:
-  aliases: ['Rhinolophus hipposideros']
+  aliases: []
   parents:
   - 49442
 2291618:
-  aliases: ['Rhinolophus indorouxii']
+  aliases: []
   parents:
   - 49442
 1078804:
-  aliases: ['Rhinolophus inops']
+  aliases: []
   parents:
   - 49442
 1078820:
-  aliases: ['Rhinolophus inops/arcuatus']
+  aliases: []
   parents:
   - 49442
 1078825:
-  aliases: ['Rhinolophus inops/subrufus']
+  aliases: []
   parents:
   - 49442
 2603864:
-  aliases: ['Rhinolophus kahuzi']
+  aliases: []
   parents:
   - 49442
 519039:
-  aliases: ['Rhinolophus landeri']
+  aliases: []
   parents:
   - 49442
 188570:
-  aliases: ['Rhinolophus lepidus']
+  aliases: []
   parents:
   - 49442
 2603865:
-  aliases: ['Rhinolophus lobatus']
+  aliases: []
   parents:
   - 49442
 1704495:
-  aliases: ['Rhinolophus luctoides']
+  aliases: []
   parents:
   - 49442
 337453:
-  aliases: ['Rhinolophus luctus']
+  aliases: []
   parents:
   - 49442
 2972396:
-  aliases: ['Rhinolophus mabuensis']
+  aliases: []
   parents:
   - 49442
 608657:
-  aliases: ['Rhinolophus maclaudi']
+  aliases: []
   parents:
   - 49442
 196889:
-  aliases: ['Rhinolophus macrotis']
+  aliases: []
   parents:
   - 49442
 608659:
-  aliases: ['Rhinolophus malayanus']
+  aliases: []
   parents:
   - 49442
 476588:
-  aliases: ['Rhinolophus marshalli']
+  aliases: []
   parents:
   - 49442
 76836:
-  aliases: ['Rhinolophus megaphyllus']
+  aliases: []
   parents:
   - 49442
 342862:
-  aliases: ['Rhinolophus mehelyi']
+  aliases: []
   parents:
   - 49442
 3344654:
-  aliases: ['Rhinolophus microglobosus']
+  aliases: []
   parents:
   - 49442
 169756:
-  aliases: ['Rhinolophus monoceros']
+  aliases: []
   parents:
   - 49442
 1871414:
-  aliases: ['Rhinolophus monticolus']
+  aliases: []
   parents:
   - 49442
 1704492:
-  aliases: ['Rhinolophus morio']
+  aliases: []
   parents:
   - 49442
 3052836:
-  aliases: ['Rhinolophus mossambicus']
+  aliases: []
   parents:
   - 49442
 3370727:
-  aliases: ['Rhinolophus nippon']
+  aliases: []
   parents:
   - 49442
 479722:
-  aliases: ['Rhinolophus osgoodi']
+  aliases: []
   parents:
   - 49442
 188571:
-  aliases: ['Rhinolophus pearsonii']
+  aliases: []
   parents:
   - 49442
 186998:
-  aliases: ['Rhinolophus perditus']
+  aliases: []
   parents:
   - 49442
 3030660:
-  aliases: ['Rhinolophus perniger']
+  aliases: []
   parents:
   - 49442
 76837:
-  aliases: ['Rhinolophus philippinensis']
+  aliases: []
   parents:
   - 49442
 159859:
-  aliases: ['Rhinolophus pumilus']
+  aliases: []
   parents:
   - 49442
 159858:
-  aliases: ['Rhinolophus pusillus']
+  aliases: []
   parents:
   - 49442
 188572:
-  aliases: ['Rhinolophus rex']
+  aliases: []
   parents:
   - 49442
 2603866:
-  aliases: ['Rhinolophus rhodesiae']
+  aliases: []
   parents:
   - 49442
 526812:
-  aliases: ['Rhinolophus robinsoni']
+  aliases: []
   parents:
   - 49442
 89398:
-  aliases: ['Rhinolophus rouxii']
+  aliases: []
   parents:
   - 49442
 545504:
-  aliases: ['Rhinolophus rufus']
+  aliases: []
   parents:
   - 49442
 519040:
-  aliases: ['Rhinolophus ruwenzorii']
+  aliases: []
   parents:
   - 49442
 3052837:
-  aliases: ['Rhinolophus sakejiensis']
+  aliases: []
   parents:
   - 49442
 59480:
-  aliases: ['Rhinolophus sedulus']
+  aliases: []
   parents:
   - 49442
 608708:
-  aliases: ['Rhinolophus shameli']
+  aliases: []
   parents:
   - 49442
 1871418:
-  aliases: ['Rhinolophus shortridgei']
+  aliases: []
   parents:
   - 49442
 867892:
-  aliases: ['Rhinolophus siamensis']
+  aliases: []
   parents:
   - 49442
 519041:
-  aliases: ['Rhinolophus simulator']
+  aliases: []
   parents:
   - 49442
 2603883:
-  aliases: ['Rhinolophus simulator complex sp. 1 TD-2019']
+  aliases: []
   parents:
   - 49442
 2603884:
-  aliases: ['Rhinolophus simulator complex sp. 2 TD-2019']
+  aliases: []
   parents:
   - 49442
 89399:
-  aliases: ['Rhinolophus sinicus']
+  aliases: []
   parents:
   - 49442
 430491:
-  aliases: ['Rhinolophus stheno']
+  aliases: []
   parents:
   - 49442
 545503:
-  aliases: ['Rhinolophus subrufus']
+  aliases: []
   parents:
   - 49442
 1078826:
-  aliases: ['Rhinolophus subrufus/arcuatus']
+  aliases: []
   parents:
   - 49442
 608709:
-  aliases: ['Rhinolophus swinnyi']
+  aliases: []
   parents:
   - 49442
 2998138:
-  aliases: ['Rhinolophus thailandensis']
+  aliases: []
   parents:
   - 49442
 476589:
-  aliases: ['Rhinolophus thomasi']
+  aliases: []
   parents:
   - 49442
 430492:
-  aliases: ['Rhinolophus trifoliatus']
+  aliases: []
   parents:
   - 49442
 1078802:
-  aliases: ['Rhinolophus virgo']
+  aliases: []
   parents:
   - 49442
 3449239:
-  aliases: ['Rhinolophus webalai']
+  aliases: []
   parents:
   - 49442
 2603867:
-  aliases: ['Rhinolophus willardi']
+  aliases: []
   parents:
   - 49442
 563833:
-  aliases: ['Rhinolophus xinanzhongguoensis']
+  aliases: []
   parents:
   - 49442
 2952509:
-  aliases: ['Rhinolophus yonghoiseni']
+  aliases: []
   parents:
   - 49442
 3370733:
-  aliases: ['Rhinolophus yunanensis']
+  aliases: []
   parents:
   - 49442
 471461:
-  aliases: ['Rhinopoma microphyllum harrisoni']
+  aliases: []
   parents:
   - 173903
 471460:
-  aliases: ['Rhinopoma microphyllum kinneari']
+  aliases: []
   parents:
   - 173903
 471462:
-  aliases: ['Rhinopoma microphyllum microphyllum']
+  aliases: []
   parents:
   - 173903
 9407:
-  aliases: ['Rousettus aegyptiacus']
+  aliases: []
   parents:
   - 9406
 58083:
-  aliases: ['Rousettus amplexicaudatus']
+  aliases: []
   parents:
   - 9406
 1129002:
-  aliases: ['Rousettus celebensis']
+  aliases: []
   parents:
   - 9406
 9408:
-  aliases: ['Rousettus leschenaultii']
+  aliases: []
   parents:
   - 9406
 2721789:
-  aliases: ['Rousettus linduensis']
+  aliases: []
   parents:
   - 9406
 77223:
-  aliases: ['Rousettus madagascariensis']
+  aliases: []
   parents:
   - 9406
 705079:
-  aliases: ['Rousettus obliviosus']
+  aliases: []
   parents:
   - 9406
 414523:
-  aliases: ['Rousettus spinalatus']
+  aliases: []
   parents:
   - 9406
 245071:
-  aliases: ['Saccopteryx sp. CRB2490']
+  aliases: []
   parents:
   - 2633232
 1609901:
-  aliases: ['Scotonycteris bergmansi']
+  aliases: []
   parents:
   - 1001562
 1609904:
-  aliases: ['Scotonycteris occidentalis']
+  aliases: []
   parents:
   - 1001562
 1001563:
-  aliases: ['Scotonycteris zenkeri']
+  aliases: []
   parents:
   - 1001562
 662898:
-  aliases: ['Sphaerias blanfordi']
+  aliases: []
   parents:
   - 662897
 1246966:
-  aliases: ['Stenonycteris']
+  aliases: []
   parents:
   - 1246967
 1983337:
-  aliases: ['Sturnira adrianae adrianae']
+  aliases: []
   parents:
   - 1983336
 1983338:
-  aliases: ['Sturnira adrianae caripana']
+  aliases: []
   parents:
   - 1983336
 1331069:
-  aliases: ['Sturnira lilium paulsoni']
+  aliases: []
   parents:
   - 27660
 192866:
-  aliases: ['Sturnira luisi serotinus']
+  aliases: []
   parents:
   - 192406
 192867:
-  aliases: ['Sturnira luisi thomasi']
+  aliases: []
   parents:
   - 192406
 192868:
-  aliases: ['Sturnira luisi vulcanensis']
+  aliases: []
   parents:
   - 192406
 192869:
-  aliases: ['Sturnira luisi zygomaticus']
+  aliases: []
   parents:
   - 192406
 1932380:
-  aliases: ['Sturnira sp. 3 AK-2017']
+  aliases: []
   parents:
   - 2631065
 244174:
-  aliases: ['Sturnira sp. CAI-2003A']
+  aliases: []
   parents:
   - 2631065
 244175:
-  aliases: ['Sturnira sp. CAI-2003B']
+  aliases: []
   parents:
   - 2631065
 3098844:
-  aliases: ['Sturnira sp. b NT-2023']
+  aliases: []
   parents:
   - 2631065
 2019461:
-  aliases: ['Sturnira sp. n. 3 GHC-2017']
+  aliases: []
   parents:
   - 2631065
 1091512:
-  aliases: ['Styloctenium mindorense']
+  aliases: []
   parents:
   - 1091511
 1442611:
-  aliases: ['Styloctenium wallacei']
+  aliases: []
   parents:
   - 1091511
 58085:
-  aliases: ['Syconycteris australis']
+  aliases: []
   parents:
   - 58084
 110943:
-  aliases: ['Taphozous sp.']
+  aliases: []
   parents:
   - 2622826
 1548710:
-  aliases: ['Taphozous sp. CS-2014']
+  aliases: []
   parents:
   - 2622826
 1002352:
-  aliases: ['Taphozous sp. IVK-2011']
+  aliases: []
   parents:
   - 2622826
 58087:
-  aliases: ['Thoopterus nigrescens']
+  aliases: []
   parents:
   - 58086
 318598:
-  aliases: ['Tonatia sp. ECT-2005']
+  aliases: []
   parents:
   - 2633921
 2996700:
-  aliases: ['Vampyressa melissa sinchi']
+  aliases: []
   parents:
   - 362825
 1158975:
-  aliases: ['unclassified Cynopterus']
+  aliases: []
   parents:
   - 9399
 2719124:
-  aliases: ['unclassified Dobsonia']
+  aliases: []
   parents:
   - 42146
 2620160:
-  aliases: ['unclassified Macroglossus']
+  aliases: []
   parents:
   - 29075
 2944748:
-  aliases: ['unclassified Megaerops']
+  aliases: []
   parents:
   - 77232
 2721790:
-  aliases: ['unclassified Nyctimene']
+  aliases: []
   parents:
   - 48987
 2647550:
-  aliases: ['unclassified Pteropus']
+  aliases: []
   parents:
   - 9401
 2629890:
-  aliases: ['unclassified Rhinolophus']
+  aliases: []
   parents:
   - 49442
 2640345:
-  aliases: ['unclassified Rousettus']
+  aliases: []
   parents:
   - 9406
 2634128:
-  aliases: ['unclassified Syconycteris']
+  aliases: []
   parents:
   - 58084
 1898386:
-  aliases: ['Cynopterus sp.']
+  aliases: []
   parents:
   - 1158975
 1158921:
-  aliases: ['Cynopterus sp. A JLE-2012']
+  aliases: []
   parents:
   - 1158975
 1477526:
-  aliases: ['Cynopterus sp. BC-2014']
+  aliases: []
   parents:
   - 1158975
 2944750:
-  aliases: ['Cynopterus sp. USNM MAMM 619523']
+  aliases: []
   parents:
   - 1158975
 2719125:
-  aliases: ['Dobsonia sp. 050810x2F']
+  aliases: []
   parents:
   - 2719124
 1898387:
-  aliases: ['Epomophorus anselli']
+  aliases: []
   parents:
   - 58066
 2448868:
-  aliases: ['Epomophorus cf. labiatus DMR-2017']
+  aliases: []
   parents:
   - 58066
 59450:
-  aliases: ['Epomophorus crypturus']
+  aliases: []
   parents:
   - 58066
 3369967:
-  aliases: ['Epomophorus dobsonii']
+  aliases: []
   parents:
   - 58066
 372077:
-  aliases: ['Epomophorus gambianus']
+  aliases: []
   parents:
   - 58066
 903567:
-  aliases: ['Epomophorus labiatus']
+  aliases: []
   parents:
   - 58066
 302407:
-  aliases: ['Epomophorus minor']
+  aliases: []
   parents:
   - 58066
 2853157:
-  aliases: ['Epomophorus pusillus']
+  aliases: []
   parents:
   - 58066
 58067:
-  aliases: ['Epomophorus wahlbergi']
+  aliases: []
   parents:
   - 58066
 1410044:
-  aliases: ['Epomops buettikoferi']
+  aliases: []
   parents:
   - 77230
 77231:
-  aliases: ['Epomops franqueti']
+  aliases: []
   parents:
   - 77230
 3025999:
-  aliases: ['Hipposideros grandis consonensis']
+  aliases: []
   parents:
   - 354743
 448084:
-  aliases: ['Hypsignathus monstrosus']
+  aliases: []
   parents:
   - 448083
 358130:
-  aliases: ['Macroglossus sp. TK 20305']
+  aliases: []
   parents:
   - 2620160
 448085:
-  aliases: ['Macroglossus sp. TK20306']
+  aliases: []
   parents:
   - 2620160
 2944749:
-  aliases: ['Megaerops sp. USNM MAMM 583818']
+  aliases: []
   parents:
   - 2944748
 1245032:
-  aliases: ['Megaloglossus azagnyi']
+  aliases: []
   parents:
   - 58072
 58073:
-  aliases: ['Megaloglossus woermanni']
+  aliases: []
   parents:
   - 58072
 319529:
-  aliases: ['Melonycteris woodfordi woodfordi']
+  aliases: []
   parents:
   - 319527
 58071:
-  aliases: ['Myonycteris angolensis']
+  aliases: []
   parents:
   - 77236
 77237:
-  aliases: ['Myonycteris brachycephala']
+  aliases: []
   parents:
   - 77236
 1245035:
-  aliases: ['Myonycteris leptodon']
+  aliases: []
   parents:
   - 77236
 77242:
-  aliases: ['Myonycteris relicta']
+  aliases: []
   parents:
   - 77236
 77243:
-  aliases: ['Myonycteris torquata']
+  aliases: []
   parents:
   - 77236
 498220:
-  aliases: ['Nanonycteris veldkampii']
+  aliases: []
   parents:
   - 498219
 1538293:
-  aliases: ['Nyctimene albiventer papuanus']
+  aliases: []
   parents:
   - 48988
 2721791:
-  aliases: ['Nyctimene sp. MZB-32262']
+  aliases: []
   parents:
   - 2721790
 1496130:
-  aliases: ['Pteropus admiralitatum colonus']
+  aliases: []
   parents:
   - 58082
 3439936:
-  aliases: ['Pteropus alecto alecto']
+  aliases: []
   parents:
   - 9402
 1495874:
-  aliases: ['Pteropus anetianus eotinus']
+  aliases: []
   parents:
   - 170220
 170221:
-  aliases: ['Pteropus capistratus ennisae']
+  aliases: []
   parents:
   - 1291037
 385575:
-  aliases: ['Pteropus dasymallus formosus']
+  aliases: []
   parents:
   - 126282
 2517870:
-  aliases: ['Pteropus dasymallus yayeyamae']
+  aliases: []
   parents:
   - 126282
 1562761:
-  aliases: ['Pteropus melanotus natalis']
+  aliases: []
   parents:
   - 1562755
 1495878:
-  aliases: ['Pteropus pelewensis pelewensis']
+  aliases: []
   parents:
   - 1495877
 1495872:
-  aliases: ['Pteropus pelewensis yapensis']
+  aliases: []
   parents:
   - 1495877
 1496126:
-  aliases: ['Pteropus rayneri grandis']
+  aliases: []
   parents:
   - 110942
 1495876:
-  aliases: ['Pteropus samoensis nawaiensis']
+  aliases: []
   parents:
   - 170230
 589510:
-  aliases: ['Pteropus seychellensis comorensis']
+  aliases: []
   parents:
   - 589506
 589511:
-  aliases: ['Pteropus seychellensis seychellensis']
+  aliases: []
   parents:
   - 589506
 1562770:
-  aliases: ['Pteropus sp.']
+  aliases: []
   parents:
   - 2647550
 638936:
-  aliases: ['Pteropus sp. CCS-2009a']
+  aliases: []
   parents:
   - 2647550
 1129003:
-  aliases: ['Pteropus sp. KTJD-2011']
+  aliases: []
   parents:
   - 2647550
 2170357:
-  aliases: ['Pteropus sp. M.47692.003']
+  aliases: []
   parents:
   - 2647550
 2170358:
-  aliases: ['Pteropus sp. M.47692.004']
+  aliases: []
   parents:
   - 2647550
 3044306:
-  aliases: ['Rhinolophus beddomei beddomei']
+  aliases: []
   parents:
   - 556920
 3044305:
-  aliases: ['Rhinolophus beddomei sobrinus']
+  aliases: []
   parents:
   - 556920
 1434704:
-  aliases: ['Rhinolophus darlingi barbetonensis']
+  aliases: []
   parents:
   - 49443
 1434706:
-  aliases: ['Rhinolophus darlingi darlingi']
+  aliases: []
   parents:
   - 49443
 1077283:
-  aliases: ['Rhinolophus ferrumequinum korai']
+  aliases: []
   parents:
   - 59479
 608660:
-  aliases: ['Rhinolophus ferrumequinum nippon']
+  aliases: []
   parents:
   - 59479
 1203030:
-  aliases: ['Rhinolophus ferrumequinum quelpartis']
+  aliases: []
   parents:
   - 59479
 1774222:
-  aliases: ['Rhinolophus ferrumequinum tragatus']
+  aliases: []
   parents:
   - 59479
 512570:
-  aliases: ['Rhinolophus lepidus cuneatus']
+  aliases: []
   parents:
   - 188570
 3387499:
-  aliases: ['Rhinolophus lepidus monticola']
+  aliases: []
   parents:
   - 188570
 2590040:
-  aliases: ['Rhinolophus macrotis caldwelli']
+  aliases: []
   parents:
   - 196889
 2590039:
-  aliases: ['Rhinolophus macrotis episcopus']
+  aliases: []
   parents:
   - 196889
 3030661:
-  aliases: ['Rhinolophus perniger lanosus']
+  aliases: []
   parents:
   - 3030660
 376555:
-  aliases: ['Rhinolophus pusillus blythi']
+  aliases: []
   parents:
   - 159858
 479477:
-  aliases: ['Rhinolophus rex paradoxolophus']
+  aliases: []
   parents:
   - 188572
 89808:
-  aliases: ['Rhinolophus rouxii rouxii']
+  aliases: []
   parents:
   - 89398
 1585245:
-  aliases: ['Rhinolophus sinicus sinicus']
+  aliases: []
   parents:
   - 89399
 3075052:
-  aliases: ['Rhinolophus sp.']
+  aliases: []
   parents:
   - 2629890
 3242299:
-  aliases: ['Rhinolophus sp. 1 HW-2024']
+  aliases: []
   parents:
   - 2629890
 519447:
-  aliases: ['Rhinolophus sp. 1 KS-2008']
+  aliases: []
   parents:
   - 2629890
 3115446:
-  aliases: ['Rhinolophus sp. 1 MU-2024a']
+  aliases: []
   parents:
   - 2629890
 1332270:
-  aliases: ['Rhinolophus sp. 1 PV-2013']
+  aliases: []
   parents:
   - 2629890
 1133290:
-  aliases: ['Rhinolophus sp. 1 XY-2012']
+  aliases: []
   parents:
   - 2629890
 393600:
-  aliases: ['Rhinolophus sp. 1234']
+  aliases: []
   parents:
   - 2629890
 3242300:
-  aliases: ['Rhinolophus sp. 2 HW-2024']
+  aliases: []
   parents:
   - 2629890
 519449:
-  aliases: ['Rhinolophus sp. 2 KS-2008']
+  aliases: []
   parents:
   - 2629890
 1133291:
-  aliases: ['Rhinolophus sp. 2 XY-2012']
+  aliases: []
   parents:
   - 2629890
 3242301:
-  aliases: ['Rhinolophus sp. 3 HW-2024']
+  aliases: []
   parents:
   - 2629890
 1001581:
-  aliases: ['Rhinolophus sp. AVB-2011']
+  aliases: []
   parents:
   - 2629890
 867885:
-  aliases: ['Rhinolophus sp. B JLE-2010']
+  aliases: []
   parents:
   - 2629890
 2942956:
-  aliases: ['Rhinolophus sp. B42']
+  aliases: []
   parents:
   - 2629890
 2942957:
-  aliases: ['Rhinolophus sp. B73']
+  aliases: []
   parents:
   - 2629890
 1158970:
-  aliases: ['Rhinolophus sp. BOLD:AAB4878']
+  aliases: []
   parents:
   - 2629890
 2448836:
-  aliases: ['Rhinolophus sp. CN 2016']
+  aliases: []
   parents:
   - 2629890
 2448882:
-  aliases: ['Rhinolophus sp. DMR-2017']
+  aliases: []
   parents:
   - 2629890
 415936:
-  aliases: ['Rhinolophus sp. GZNU200303']
+  aliases: []
   parents:
   - 2629890
 692277:
-  aliases: ['Rhinolophus sp. HHS-2009a']
+  aliases: []
   parents:
   - 2629890
 2810476:
-  aliases: ['Rhinolophus sp. HW-2021']
+  aliases: []
   parents:
   - 2629890
 1002349:
-  aliases: ['Rhinolophus sp. IVK-2011']
+  aliases: []
   parents:
   - 2629890
 271464:
-  aliases: ['Rhinolophus sp. JMW-2004a']
+  aliases: []
   parents:
   - 2629890
 271465:
-  aliases: ['Rhinolophus sp. JMW-2004b']
+  aliases: []
   parents:
   - 2629890
 1078817:
-  aliases: ['Rhinolophus sp. LEP-2011']
+  aliases: []
   parents:
   - 2629890
 2661589:
-  aliases: ['Rhinolophus sp. LIK17']
+  aliases: []
   parents:
   - 2629890
 2853601:
-  aliases: ['Rhinolophus sp. Nditam11']
+  aliases: []
   parents:
   - 2629890
 2750743:
-  aliases: ['Rhinolophus sp. PREDICT/PDF-2370']
+  aliases: []
   parents:
   - 2629890
 2750742:
-  aliases: ['Rhinolophus sp. PREDICT/PDF-2386']
+  aliases: []
   parents:
   - 2629890
 2750744:
-  aliases: ['Rhinolophus sp. PREDICT/PRD-0038']
+  aliases: []
   parents:
   - 2629890
 3040050:
-  aliases: ['Rhinolophus sp. Yunnan 1038']
+  aliases: []
   parents:
   - 2629890
 3040051:
-  aliases: ['Rhinolophus sp. Yunnan 329']
+  aliases: []
   parents:
   - 2629890
 2908703:
-  aliases: ['Rhinolophus sp. i KPD-2022']
+  aliases: []
   parents:
   - 2629890
 2972397:
-  aliases: ['Rhinolophus sp. n. MR-2022']
+  aliases: []
   parents:
   - 2629890
 2489498:
-  aliases: ['Rhinolophus sp. n. TK-2018']
+  aliases: []
   parents:
   - 2629890
 3418546:
-  aliases: ['Rhinolophus sp. y RL-2025']
+  aliases: []
   parents:
   - 2629890
 77220:
-  aliases: ['Rousettus aegyptiacus aegyptiacus']
+  aliases: []
   parents:
   - 9407
 77221:
-  aliases: ['Rousettus aegyptiacus princeps']
+  aliases: []
   parents:
   - 9407
 1898393:
-  aliases: ['Rousettus sp.']
+  aliases: []
   parents:
   - 2640345
 1812332:
-  aliases: ['Rousettus sp. FCA-2016a']
+  aliases: []
   parents:
   - 2640345
 1158137:
-  aliases: ['Rousettus sp. YPZ-2012']
+  aliases: []
   parents:
   - 2640345
 3370833:
-  aliases: ['Stenonycteris lanosa']
+  aliases: []
   parents:
   - 1246966
 77224:
-  aliases: ['Syconycteris sp.']
+  aliases: []
   parents:
   - 2634128
 2625338:
-  aliases: ['unclassified Epomophorus']
+  aliases: []
   parents:
   - 58066
 2621561:
-  aliases: ['unclassified Epomops']
+  aliases: []
   parents:
   - 77230
 2677420:
-  aliases: ['unclassified Hypsignathus']
+  aliases: []
   parents:
   - 448083
 2624632:
-  aliases: ['unclassified Myonycteris']
+  aliases: []
   parents:
   - 77236
 2719126:
-  aliases: ['Epomophorus sp. MNHN ZM 2011-726']
+  aliases: []
   parents:
   - 2625338
 2719127:
-  aliases: ['Epomophorus sp. MNHN ZM 2011-760']
+  aliases: []
   parents:
   - 2625338
 1898389:
-  aliases: ['Epomops sp.']
+  aliases: []
   parents:
   - 2621561
 1091513:
-  aliases: ['Hypsignathus sp. FCA-2011']
+  aliases: []
   parents:
   - 2677420
 1245033:
-  aliases: ['Myonycteris angolensis ruwenzorii']
+  aliases: []
   parents:
   - 58071
 1245034:
-  aliases: ['Myonycteris angolensis smithii']
+  aliases: []
   parents:
   - 58071
 2014926:
-  aliases: ['Myonycteris sp. TLG-2017']
+  aliases: []
   parents:
   - 2624632
 9443:
   aliases: ['Primates']
   parents: []
 376913:
-  aliases: ['Haplorrhini']
+  aliases: []
   parents:
   - 9443
 376911:
-  aliases: ['Strepsirrhini']
+  aliases: []
   parents:
   - 9443
 57118:
-  aliases: ['unclassified Primates']
+  aliases: []
   parents:
   - 9443
 376916:
-  aliases: ['Chiromyiformes']
+  aliases: []
   parents:
   - 376911
 376915:
-  aliases: ['Lemuriformes']
+  aliases: []
   parents:
   - 376911
 376917:
-  aliases: ['Lorisiformes']
+  aliases: []
   parents:
   - 376911
 976298:
-  aliases: ['Primates sp. BOLD:AAA0001']
+  aliases: []
   parents:
   - 57118
 1068292:
-  aliases: ['Primates sp. BOLD:AAC7735']
+  aliases: []
   parents:
   - 57118
 976299:
-  aliases: ['Primates sp. BOLD:AAC9009']
+  aliases: []
   parents:
   - 57118
 1068293:
-  aliases: ['Primates sp. BOLD:AAD0215']
+  aliases: []
   parents:
   - 57118
 976300:
-  aliases: ['Primates sp. BOLD:AAE4744']
+  aliases: []
   parents:
   - 57118
 1068294:
-  aliases: ['Primates sp. BOLD:AAF0367']
+  aliases: []
   parents:
   - 57118
 976301:
-  aliases: ['Primates sp. BOLD:AAJ7304']
+  aliases: []
   parents:
   - 57118
 976302:
-  aliases: ['Primates sp. BOLD:AAO0053']
+  aliases: []
   parents:
   - 57118
 314293:
-  aliases: ['Simiiformes']
+  aliases: []
   parents:
   - 376913
 376912:
-  aliases: ['Tarsiiformes']
+  aliases: []
   parents:
   - 376913
 9526:
-  aliases: ['Catarrhini']
+  aliases: []
   parents:
   - 314293
 30615:
-  aliases: ['Cheirogaleidae']
+  aliases: []
   parents:
   - 376915
 30613:
-  aliases: ['Daubentoniidae']
+  aliases: []
   parents:
   - 376916
 40297:
-  aliases: ['Galagidae']
+  aliases: []
   parents:
   - 376917
 30599:
-  aliases: ['Indriidae']
+  aliases: []
   parents:
   - 376915
 9445:
-  aliases: ['Lemuridae']
+  aliases: []
   parents:
   - 376915
 30614:
-  aliases: ['Lepilemuridae']
+  aliases: []
   parents:
   - 376915
 9461:
-  aliases: ['Lorisidae']
+  aliases: []
   parents:
   - 376917
 1513476:
-  aliases: ['Palaeopropithecidae']
+  aliases: []
   parents:
   - 376915
 9479:
-  aliases: ['Platyrrhini']
+  aliases: []
   parents:
   - 314293
 9475:
-  aliases: ['Tarsiidae']
+  aliases: []
   parents:
   - 376912
 3085341:
-  aliases: ['unclassified Simiiformes']
+  aliases: []
   parents:
   - 314293
 122247:
-  aliases: ['Allocebus']
+  aliases: []
   parents:
   - 30615
 376918:
-  aliases: ['Aotidae']
+  aliases: []
   parents:
   - 9479
 523820:
-  aliases: ['Archaeolemur']
+  aliases: []
   parents:
   - 30599
 261738:
-  aliases: ['Arctocebus']
+  aliases: []
   parents:
   - 9461
 378855:
-  aliases: ['Atelidae']
+  aliases: []
   parents:
   - 9479
 122245:
-  aliases: ['Avahi']
+  aliases: []
   parents:
   - 30599
 1868481:
-  aliases: ['Carlito']
+  aliases: []
   parents:
   - 9475
 9498:
-  aliases: ['Cebidae']
+  aliases: []
   parents:
   - 9479
 1971489:
-  aliases: ['Cephalopachus']
+  aliases: []
   parents:
   - 9475
 314294:
-  aliases: ['Cercopithecoidea']
+  aliases: []
   parents:
   - 9526
 9459:
-  aliases: ['Cheirogaleus']
+  aliases: []
   parents:
   - 30615
 13038:
-  aliases: ['Daubentonia']
+  aliases: []
   parents:
   - 30613
 13513:
-  aliases: ['Eulemur']
+  aliases: []
   parents:
   - 9445
 261735:
-  aliases: ['Euoticus']
+  aliases: []
   parents:
   - 40297
 9462:
-  aliases: ['Galago']
+  aliases: []
   parents:
   - 40297
 89671:
-  aliases: ['Galagoides']
+  aliases: []
   parents:
   - 40297
 523824:
-  aliases: ['Hadropithecus']
+  aliases: []
   parents:
   - 30599
 13556:
-  aliases: ['Hapalemur']
+  aliases: []
   parents:
   - 9445
 314295:
-  aliases: ['Hominoidea']
+  aliases: []
   parents:
   - 9526
 34826:
-  aliases: ['Indri']
+  aliases: []
   parents:
   - 30599
 9446:
-  aliases: ['Lemur']
+  aliases: []
   parents:
   - 9445
 9452:
-  aliases: ['Lepilemur']
+  aliases: []
   parents:
   - 30614
 9467:
-  aliases: ['Loris']
+  aliases: []
   parents:
   - 9461
 126593:
-  aliases: ['Megaladapis']
+  aliases: []
   parents:
   - 30614
 13149:
-  aliases: ['Microcebus']
+  aliases: []
   parents:
   - 30615
 83691:
-  aliases: ['Mirza']
+  aliases: []
   parents:
   - 30615
 9469:
-  aliases: ['Nycticebus']
+  aliases: []
   parents:
   - 9461
 30610:
-  aliases: ['Otolemur']
+  aliases: []
   parents:
   - 40297
 1513474:
-  aliases: ['Pachylemur']
+  aliases: []
   parents:
   - 9445
 322024:
-  aliases: ['Palaeopropithecus']
+  aliases: []
   parents:
   - 1513476
 2604441:
-  aliases: ['Paragalago']
+  aliases: []
   parents:
   - 40297
 9471:
-  aliases: ['Perodicticus']
+  aliases: []
   parents:
   - 9461
 261733:
-  aliases: ['Phaner']
+  aliases: []
   parents:
   - 30615
 376919:
-  aliases: ['Pitheciidae']
+  aliases: []
   parents:
   - 9479
 1328069:
-  aliases: ['Prolemur']
+  aliases: []
   parents:
   - 9445
 30600:
-  aliases: ['Propithecus']
+  aliases: []
   parents:
   - 30599
 70699:
-  aliases: ['Simiiformes sp.']
+  aliases: []
   parents:
   - 3085341
 9476:
-  aliases: ['Tarsius']
+  aliases: []
   parents:
   - 9475
 9454:
-  aliases: ['Varecia']
+  aliases: []
   parents:
   - 9445
 3030685:
-  aliases: ['Xanthonycticebus']
+  aliases: []
   parents:
   - 9461
 3413538:
-  aliases: ['unclassified Lorisidae']
+  aliases: []
   parents:
   - 9461
 3043103:
-  aliases: ['Allocebus trichotus']
+  aliases: []
   parents:
   - 122247
 38066:
-  aliases: ['Alouattinae']
+  aliases: []
   parents:
   - 378855
 9504:
-  aliases: ['Aotus']
+  aliases: []
   parents:
   - 376918
 523822:
-  aliases: ['Archaeolemur edwardsi']
+  aliases: []
   parents:
   - 523820
 523821:
-  aliases: ['Archaeolemur majori']
+  aliases: []
   parents:
   - 523820
 300161:
-  aliases: ['Arctocebus aureus']
+  aliases: []
   parents:
   - 261738
 261739:
-  aliases: ['Arctocebus calabarensis']
+  aliases: []
   parents:
   - 261738
 38068:
-  aliases: ['Atelinae']
+  aliases: []
   parents:
   - 378855
 3043105:
-  aliases: ['Avahi betsileo']
+  aliases: []
   parents:
   - 122245
 402244:
-  aliases: ['Avahi cleesei']
+  aliases: []
   parents:
   - 122245
 122246:
-  aliases: ['Avahi laniger']
+  aliases: []
   parents:
   - 122245
 3061928:
-  aliases: ['Avahi meridionalis']
+  aliases: []
   parents:
   - 122245
 3369724:
-  aliases: ['Avahi mooreorum']
+  aliases: []
   parents:
   - 122245
 132108:
-  aliases: ['Avahi occidentalis']
+  aliases: []
   parents:
   - 122245
 1313323:
-  aliases: ['Avahi peyrierasi']
+  aliases: []
   parents:
   - 122245
 402239:
-  aliases: ['Avahi unicolor']
+  aliases: []
   parents:
   - 122245
 38069:
-  aliases: ['Callicebinae']
+  aliases: []
   parents:
   - 376919
 9480:
-  aliases: ['Callitrichinae']
+  aliases: []
   parents:
   - 9498
 1868482:
-  aliases: ['Carlito syrichta']
+  aliases: []
   parents:
   - 1868481
 38070:
-  aliases: ['Cebinae']
+  aliases: []
   parents:
   - 9498
 9477:
-  aliases: ['Cephalopachus bancanus']
+  aliases: []
   parents:
   - 1971489
 9527:
-  aliases: ['Cercopithecidae']
+  aliases: []
   parents:
   - 314294
 3043109:
-  aliases: ['Cheirogaleus andysabini']
+  aliases: []
   parents:
   - 9459
 2563322:
-  aliases: ['Cheirogaleus cf. medius RW-2019']
+  aliases: []
   parents:
   - 9459
 291259:
-  aliases: ['Cheirogaleus crossleyi']
+  aliases: []
   parents:
   - 9459
 3043111:
-  aliases: ['Cheirogaleus grovesi']
+  aliases: []
   parents:
   - 9459
 1569974:
-  aliases: ['Cheirogaleus lavasoensis']
+  aliases: []
   parents:
   - 9459
 47177:
-  aliases: ['Cheirogaleus major']
+  aliases: []
   parents:
   - 9459
 9460:
-  aliases: ['Cheirogaleus medius']
+  aliases: []
   parents:
   - 9459
 867375:
-  aliases: ['Cheirogaleus minusculus']
+  aliases: []
   parents:
   - 9459
 3043106:
-  aliases: ['Cheirogaleus shethi']
+  aliases: []
   parents:
   - 9459
 752538:
-  aliases: ['Cheirogaleus sibreei']
+  aliases: []
   parents:
   - 9459
 31869:
-  aliases: ['Daubentonia madagascariensis']
+  aliases: []
   parents:
   - 13038
 1215604:
-  aliases: ['Eulemur albifrons']
+  aliases: []
   parents:
   - 13513
 1417236:
-  aliases: ['Eulemur albifrons x cinereiceps']
+  aliases: []
   parents:
   - 13513
 1417231:
-  aliases: ['Eulemur albifrons x rufifrons']
+  aliases: []
   parents:
   - 13513
 639525:
-  aliases: ['Eulemur cinereiceps']
+  aliases: []
   parents:
   - 13513
 13514:
-  aliases: ['Eulemur coronatus']
+  aliases: []
   parents:
   - 13513
 87288:
-  aliases: ['Eulemur flavifrons']
+  aliases: []
   parents:
   - 13513
 13515:
-  aliases: ['Eulemur fulvus']
+  aliases: []
   parents:
   - 13513
 30602:
-  aliases: ['Eulemur macaco']
+  aliases: []
   parents:
   - 13513
 34828:
-  aliases: ['Eulemur mongoz']
+  aliases: []
   parents:
   - 13513
 34829:
-  aliases: ['Eulemur rubriventer']
+  aliases: []
   parents:
   - 13513
 859984:
-  aliases: ['Eulemur rufifrons']
+  aliases: []
   parents:
   - 13513
 3697755:
-  aliases: ['Eulemur rufifrons x Eulemur cinereiceps']
+  aliases: []
   parents:
   - 13513
 859983:
-  aliases: ['Eulemur rufus']
+  aliases: []
   parents:
   - 13513
 122225:
-  aliases: ['Eulemur sanfordi']
+  aliases: []
   parents:
   - 13513
 261736:
-  aliases: ['Euoticus elegantulus']
+  aliases: []
   parents:
   - 261735
 34830:
-  aliases: ['Galago alleni']
+  aliases: []
   parents:
   - 9462
 261731:
-  aliases: ['Galago gabonensis']
+  aliases: []
   parents:
   - 9462
 111173:
-  aliases: ['Galago gallarum']
+  aliases: []
   parents:
   - 9462
 135486:
-  aliases: ['Galago matschiei']
+  aliases: []
   parents:
   - 9462
 30609:
-  aliases: ['Galago moholi']
+  aliases: []
   parents:
   - 9462
 9465:
-  aliases: ['Galago senegalensis']
+  aliases: []
   parents:
   - 9462
 1487601:
-  aliases: ['Galagoides cocos']
+  aliases: []
   parents:
   - 89671
 89672:
-  aliases: ['Galagoides demidoff']
+  aliases: []
   parents:
   - 89671
 337210:
-  aliases: ['Galagoides orinus']
+  aliases: []
   parents:
   - 89671
 1738047:
-  aliases: ['Galagoides rondoensis']
+  aliases: []
   parents:
   - 89671
 867376:
-  aliases: ['Galagoides thomasi']
+  aliases: []
   parents:
   - 89671
 523825:
-  aliases: ['Hadropithecus stenognathus']
+  aliases: []
   parents:
   - 523824
 3370048:
-  aliases: ['Hapalemur alaotrensis']
+  aliases: []
   parents:
   - 13556
 122222:
-  aliases: ['Hapalemur aureus']
+  aliases: []
   parents:
   - 13556
 3043110:
-  aliases: ['Hapalemur gilberti']
+  aliases: []
   parents:
   - 13556
 13557:
-  aliases: ['Hapalemur griseus']
+  aliases: []
   parents:
   - 13556
 3043112:
-  aliases: ['Hapalemur meridionalis']
+  aliases: []
   parents:
   - 13556
 867377:
-  aliases: ['Hapalemur occidentalis']
+  aliases: []
   parents:
   - 13556
 9604:
-  aliases: ['Hominidae']
+  aliases: []
   parents:
   - 314295
 9577:
-  aliases: ['Hylobatidae']
+  aliases: []
   parents:
   - 314295
 34827:
-  aliases: ['Indri indri']
+  aliases: []
   parents:
   - 34826
 9447:
-  aliases: ['Lemur catta']
+  aliases: []
   parents:
   - 9446
 342399:
-  aliases: ['Lepilemur aeeclis']
+  aliases: []
   parents:
   - 9452
 886957:
-  aliases: ['Lepilemur ahmansoni']
+  aliases: []
   parents:
   - 9452
 342401:
-  aliases: ['Lepilemur ankaranensis']
+  aliases: []
   parents:
   - 9452
 886958:
-  aliases: ['Lepilemur betsileo']
+  aliases: []
   parents:
   - 9452
 78583:
-  aliases: ['Lepilemur dorsalis']
+  aliases: []
   parents:
   - 9452
 122230:
-  aliases: ['Lepilemur edwardsi']
+  aliases: []
   parents:
   - 9452
 886959:
-  aliases: ['Lepilemur fleuretae']
+  aliases: []
   parents:
   - 9452
 886960:
-  aliases: ['Lepilemur grewcocki']
+  aliases: []
   parents:
   - 9452
 886961:
-  aliases: ['Lepilemur hollandorum']
+  aliases: []
   parents:
   - 9452
 756882:
-  aliases: ['Lepilemur hubbardi']
+  aliases: []
   parents:
   - 9452
 486960:
-  aliases: ['Lepilemur jamesi']
+  aliases: []
   parents:
   - 9452
 100475:
-  aliases: ['Lepilemur leucopus']
+  aliases: []
   parents:
   - 9452
 185457:
-  aliases: ['Lepilemur microdon']
+  aliases: []
   parents:
   - 9452
 886963:
-  aliases: ['Lepilemur milanoii']
+  aliases: []
   parents:
   - 9452
 9453:
-  aliases: ['Lepilemur mustelinus']
+  aliases: []
   parents:
   - 9452
 458173:
-  aliases: ['Lepilemur otto']
+  aliases: []
   parents:
   - 9452
 886964:
-  aliases: ['Lepilemur petteri']
+  aliases: []
   parents:
   - 9452
 886965:
-  aliases: ['Lepilemur randrianasoloi']
+  aliases: []
   parents:
   - 9452
 78866:
-  aliases: ['Lepilemur ruficaudatus']
+  aliases: []
   parents:
   - 9452
 3370157:
-  aliases: ['Lepilemur sahamalaza']
+  aliases: []
   parents:
   - 9452
 886966:
-  aliases: ['Lepilemur scottorum']
+  aliases: []
   parents:
   - 9452
 236288:
-  aliases: ['Lepilemur seali']
+  aliases: []
   parents:
   - 9452
 78584:
-  aliases: ['Lepilemur septentrionalis']
+  aliases: []
   parents:
   - 9452
 886967:
-  aliases: ['Lepilemur tymerlachsoni']
+  aliases: []
   parents:
   - 9452
 886968:
-  aliases: ['Lepilemur wrighti']
+  aliases: []
   parents:
   - 9452
 300163:
-  aliases: ['Loris lydekkerianus']
+  aliases: []
   parents:
   - 9467
 9468:
-  aliases: ['Loris tardigradus']
+  aliases: []
   parents:
   - 9467
 185953:
-  aliases: ['Megaladapis edwardsi']
+  aliases: []
   parents:
   - 126593
 864580:
-  aliases: ['Microcebus arnholdi']
+  aliases: []
   parents:
   - 13149
 143352:
-  aliases: ['Microcebus berthae']
+  aliases: []
   parents:
   - 13149
 412750:
-  aliases: ['Microcebus bongolavensis']
+  aliases: []
   parents:
   - 13149
 3043107:
-  aliases: ['Microcebus boraha']
+  aliases: []
   parents:
   - 13149
 412751:
-  aliases: ['Microcebus danfossi']
+  aliases: []
   parents:
   - 13149
 2483760:
-  aliases: ['Microcebus ganzhorni']
+  aliases: []
   parents:
   - 13149
 1131379:
-  aliases: ['Microcebus gerpi']
+  aliases: []
   parents:
   - 13149
 143354:
-  aliases: ['Microcebus griseorufus']
+  aliases: []
   parents:
   - 13149
 236275:
-  aliases: ['Microcebus jollyae']
+  aliases: []
   parents:
   - 13149
 2508170:
-  aliases: ['Microcebus jonahi']
+  aliases: []
   parents:
   - 13149
 343908:
-  aliases: ['Microcebus lehilahytsara']
+  aliases: []
   parents:
   - 13149
 412752:
-  aliases: ['Microcebus lokobensis']
+  aliases: []
   parents:
   - 13149
 548481:
-  aliases: ['Microcebus macarthurii']
+  aliases: []
   parents:
   - 13149
 415757:
-  aliases: ['Microcebus mamiratra']
+  aliases: []
   parents:
   - 13149
 3043108:
-  aliases: ['Microcebus manitatra']
+  aliases: []
   parents:
   - 13149
 864581:
-  aliases: ['Microcebus margotmarshae']
+  aliases: []
   parents:
   - 13149
 1310124:
-  aliases: ['Microcebus marohita']
+  aliases: []
   parents:
   - 13149
 30608:
-  aliases: ['Microcebus murinus']
+  aliases: []
   parents:
   - 13149
 143283:
-  aliases: ['Microcebus myoxinus']
+  aliases: []
   parents:
   - 13149
 122231:
-  aliases: ['Microcebus ravelobensis']
+  aliases: []
   parents:
   - 13149
 122232:
-  aliases: ['Microcebus rufus']
+  aliases: []
   parents:
   - 13149
 143353:
-  aliases: ['Microcebus sambiranensis']
+  aliases: []
   parents:
   - 13149
 236272:
-  aliases: ['Microcebus simmonsi']
+  aliases: []
   parents:
   - 13149
 1310123:
-  aliases: ['Microcebus tanosi']
+  aliases: []
   parents:
   - 13149
 143351:
-  aliases: ['Microcebus tavaratra']
+  aliases: []
   parents:
   - 13149
 47180:
-  aliases: ['Mirza coquereli']
+  aliases: []
   parents:
   - 83691
 339999:
-  aliases: ['Mirza zaza']
+  aliases: []
   parents:
   - 83691
 261741:
-  aliases: ['Nycticebus bengalensis']
+  aliases: []
   parents:
   - 9469
 3030686:
-  aliases: ['Nycticebus borneanus']
+  aliases: []
   parents:
   - 9469
 9470:
-  aliases: ['Nycticebus coucang']
+  aliases: []
   parents:
   - 9469
 2933639:
-  aliases: ['Nycticebus hilleri']
+  aliases: []
   parents:
   - 9469
 310934:
-  aliases: ['Nycticebus javanicus']
+  aliases: []
   parents:
   - 9469
 3030687:
-  aliases: ['Nycticebus kayan']
+  aliases: []
   parents:
   - 9469
 310932:
-  aliases: ['Nycticebus menagensis']
+  aliases: []
   parents:
   - 9469
 9463:
-  aliases: ['Otolemur crassicaudatus']
+  aliases: []
   parents:
   - 30610
 30611:
-  aliases: ['Otolemur garnettii']
+  aliases: []
   parents:
   - 30610
 337212:
-  aliases: ['Otolemur monteiri']
+  aliases: []
   parents:
   - 30610
 1513475:
-  aliases: ['Pachylemur jullyi']
+  aliases: []
   parents:
   - 1513474
 1513477:
-  aliases: ['Palaeopropithecus ingens']
+  aliases: []
   parents:
   - 322024
 1597978:
-  aliases: ['Palaeopropithecus maximus']
+  aliases: []
   parents:
   - 322024
 2604442:
-  aliases: ['Paragalago cocos']
+  aliases: []
   parents:
   - 2604441
 3043104:
-  aliases: ['Paragalago granti']
+  aliases: []
   parents:
   - 2604441
 2604443:
-  aliases: ['Paragalago zanzibaricus']
+  aliases: []
   parents:
   - 2604441
 3413539:
-  aliases: ['Perodicticinae sp.']
+  aliases: []
   parents:
   - 3413538
 9472:
-  aliases: ['Perodicticus potto']
+  aliases: []
   parents:
   - 9471
 1313324:
-  aliases: ['Phaner electromontis']
+  aliases: []
   parents:
   - 261733
 261734:
-  aliases: ['Phaner furcifer']
+  aliases: []
   parents:
   - 261733
 568393:
-  aliases: ['Phaner pallescens']
+  aliases: []
   parents:
   - 261733
 1313325:
-  aliases: ['Phaner parienti']
+  aliases: []
   parents:
   - 261733
 38039:
-  aliases: ['Pitheciinae']
+  aliases: []
   parents:
   - 376919
 1328070:
-  aliases: ['Prolemur simus']
+  aliases: []
   parents:
   - 1328069
 543560:
-  aliases: ['Propithecus candidus']
+  aliases: []
   parents:
   - 30600
 379532:
-  aliases: ['Propithecus coquereli']
+  aliases: []
   parents:
   - 30600
 475618:
-  aliases: ['Propithecus deckenii']
+  aliases: []
   parents:
   - 30600
 83281:
-  aliases: ['Propithecus diadema']
+  aliases: []
   parents:
   - 30600
 543559:
-  aliases: ['Propithecus edwardsi']
+  aliases: []
   parents:
   - 30600
 989338:
-  aliases: ['Propithecus perrieri']
+  aliases: []
   parents:
   - 30600
 30601:
-  aliases: ['Propithecus tattersalli']
+  aliases: []
   parents:
   - 30600
 34825:
-  aliases: ['Propithecus verreauxi']
+  aliases: []
   parents:
   - 30600
 378850:
-  aliases: ['Saimiriinae']
+  aliases: []
   parents:
   - 9498
 449501:
-  aliases: ['Tarsius dentatus']
+  aliases: []
   parents:
   - 9476
 642591:
-  aliases: ['Tarsius dentatus x lariang']
+  aliases: []
   parents:
   - 9476
 1748400:
-  aliases: ['Tarsius fuscus']
+  aliases: []
   parents:
   - 9476
 630277:
-  aliases: ['Tarsius lariang']
+  aliases: []
   parents:
   - 9476
 2925011:
-  aliases: ['Tarsius pumilus']
+  aliases: []
   parents:
   - 9476
 905053:
-  aliases: ['Tarsius sangirensis']
+  aliases: []
   parents:
   - 9476
 662464:
-  aliases: ['Tarsius tarsier']
+  aliases: []
   parents:
   - 9476
 981131:
-  aliases: ['Tarsius wallacei']
+  aliases: []
   parents:
   - 9476
 554167:
-  aliases: ['Varecia rubra']
+  aliases: []
   parents:
   - 9454
 9455:
-  aliases: ['Varecia variegata']
+  aliases: []
   parents:
   - 9454
 101278:
-  aliases: ['Xanthonycticebus pygmaeus']
+  aliases: []
   parents:
   - 3030685
 2490929:
-  aliases: ['Xenothricinae']
+  aliases: []
   parents:
   - 376919
 3471685:
-  aliases: ['unclassified Avahi']
+  aliases: []
   parents:
   - 122245
 38071:
-  aliases: ['unclassified Cebidae']
+  aliases: []
   parents:
   - 9498
 2628747:
-  aliases: ['unclassified Galago']
+  aliases: []
   parents:
   - 9462
 2641939:
-  aliases: ['unclassified Lemur']
+  aliases: []
   parents:
   - 9446
 2645584:
-  aliases: ['unclassified Lepilemur']
+  aliases: []
   parents:
   - 9452
 2620125:
-  aliases: ['unclassified Megaladapis']
+  aliases: []
   parents:
   - 126593
 2630091:
-  aliases: ['unclassified Microcebus']
+  aliases: []
   parents:
   - 13149
 2628182:
-  aliases: ['unclassified Mirza']
+  aliases: []
   parents:
   - 83691
 2646861:
-  aliases: ['unclassified Nycticebus']
+  aliases: []
   parents:
   - 9469
 2619300:
-  aliases: ['unclassified Palaeopropithecus']
+  aliases: []
   parents:
   - 322024
 2677806:
-  aliases: ['unclassified Propithecus']
+  aliases: []
   parents:
   - 30600
 2624233:
-  aliases: ['unclassified Tarsius']
+  aliases: []
   parents:
   - 9476
 3030688:
-  aliases: ['unclassified Xanthonycticebus']
+  aliases: []
   parents:
   - 3030685
 9499:
-  aliases: ['Alouatta']
+  aliases: []
   parents:
   - 38066
 168015:
-  aliases: ['Aotinae gen. sp.']
+  aliases: []
   parents:
   - 38071
 30591:
-  aliases: ['Aotus azarai']
+  aliases: []
   parents:
   - 9504
 361674:
-  aliases: ['Aotus brumbacki']
+  aliases: []
   parents:
   - 9504
 292213:
-  aliases: ['Aotus griseimembra']
+  aliases: []
   parents:
   - 9504
 43147:
-  aliases: ['Aotus lemurinus']
+  aliases: []
   parents:
   - 9504
 37293:
-  aliases: ['Aotus nancymaae']
+  aliases: []
   parents:
   - 9504
 57175:
-  aliases: ['Aotus nigriceps']
+  aliases: []
   parents:
   - 9504
 9505:
-  aliases: ['Aotus trivirgatus']
+  aliases: []
   parents:
   - 9504
 57176:
-  aliases: ['Aotus vociferans']
+  aliases: []
   parents:
   - 9504
 1263727:
-  aliases: ['Aotus zonalis']
+  aliases: []
   parents:
   - 9504
 9506:
-  aliases: ['Ateles']
+  aliases: []
   parents:
   - 38068
 3471686:
-  aliases: ['Avahi sp.']
+  aliases: []
   parents:
   - 3471685
 30593:
-  aliases: ['Brachyteles']
+  aliases: []
   parents:
   - 38068
 30595:
-  aliases: ['Cacajao']
+  aliases: []
   parents:
   - 38039
 9522:
-  aliases: ['Callicebus']
+  aliases: []
   parents:
   - 38069
 9494:
-  aliases: ['Callimico']
+  aliases: []
   parents:
   - 9480
 9481:
-  aliases: ['Callithrix']
+  aliases: []
   parents:
   - 9480
 1965109:
-  aliases: ['Cebuella']
+  aliases: []
   parents:
   - 9480
 9513:
-  aliases: ['Cebus']
+  aliases: []
   parents:
   - 38070
 1971490:
-  aliases: ['Cephalopachus bancanus bancanus']
+  aliases: []
   parents:
   - 9477
 2567999:
-  aliases: ['Cephalopachus bancanus borneanus']
+  aliases: []
   parents:
   - 9477
 9576:
-  aliases: ['Cercopithecidae gen. sp.']
+  aliases: []
   parents:
   - 9527
 9528:
-  aliases: ['Cercopithecinae']
+  aliases: []
   parents:
   - 9527
 1812102:
-  aliases: ['Cheracebus']
+  aliases: []
   parents:
   - 38069
 9524:
-  aliases: ['Chiropotes']
+  aliases: []
   parents:
   - 38039
 9569:
-  aliases: ['Colobinae']
+  aliases: []
   parents:
   - 9527
 122224:
-  aliases: ['Eulemur fulvus albocollaris']
+  aliases: []
   parents:
   - 13515
 47178:
-  aliases: ['Eulemur fulvus collaris']
+  aliases: []
   parents:
   - 13515
 40322:
-  aliases: ['Eulemur fulvus fulvus']
+  aliases: []
   parents:
   - 13515
 27680:
-  aliases: ['Eulemur fulvus mayottensis']
+  aliases: []
   parents:
   - 13515
 30603:
-  aliases: ['Eulemur macaco macaco']
+  aliases: []
   parents:
   - 30602
 1738052:
-  aliases: ['Galago senegalensis braccatus']
+  aliases: []
   parents:
   - 9465
 1738048:
-  aliases: ['Galago senegalensis senegalensis']
+  aliases: []
   parents:
   - 9465
 9464:
-  aliases: ['Galago sp.']
+  aliases: []
   parents:
   - 2628747
 1738051:
-  aliases: ['Galagoides demidoff murinus']
+  aliases: []
   parents:
   - 89672
 1738046:
-  aliases: ['Galagoides zanzibaricus udzungwensis']
+  aliases: []
   parents:
   - 2604443
 1738053:
-  aliases: ['Galagoides zanzibaricus zanzibaricus']
+  aliases: []
   parents:
   - 2604443
 185596:
-  aliases: ['Hapalemur griseus JF2002']
+  aliases: []
   parents:
   - 13557
 122219:
-  aliases: ['Hapalemur griseus griseus']
+  aliases: []
   parents:
   - 13557
 2883640:
-  aliases: ['Hominidae intergeneric hybrids']
+  aliases: []
   parents:
   - 9604
 207598:
-  aliases: ['Homininae']
+  aliases: []
   parents:
   - 9604
 325167:
-  aliases: ['Hoolock']
+  aliases: []
   parents:
   - 9577
 9578:
-  aliases: ['Hylobates']
+  aliases: []
   parents:
   - 9577
 9518:
-  aliases: ['Lagothrix']
+  aliases: []
   parents:
   - 38068
 69491:
-  aliases: ['Lemur sp.']
+  aliases: []
   parents:
   - 2641939
 2681187:
-  aliases: ['Leontocebus']
+  aliases: []
   parents:
   - 9480
 30587:
-  aliases: ['Leontopithecus']
+  aliases: []
   parents:
   - 9480
 185590:
-  aliases: ['Lepilemur sp. RANO234']
+  aliases: []
   parents:
   - 2645584
 185591:
-  aliases: ['Lepilemur sp. RANO235']
+  aliases: []
   parents:
   - 2645584
 185458:
-  aliases: ['Lepilemur sp. RANO236']
+  aliases: []
   parents:
   - 2645584
 400023:
-  aliases: ['Lepilemur sp. hubbardi']
+  aliases: []
   parents:
   - 2645584
 1738050:
-  aliases: ['Loris lydekkerianus lydekkerianus']
+  aliases: []
   parents:
   - 300163
 300166:
-  aliases: ['Loris lydekkerianus malabaricus']
+  aliases: []
   parents:
   - 300163
 261740:
-  aliases: ['Loris tardigradus nordicus']
+  aliases: []
   parents:
   - 9468
 1738049:
-  aliases: ['Loris tardigradus tardigradus']
+  aliases: []
   parents:
   - 9468
 126594:
-  aliases: ['Megaladapis sp.']
+  aliases: []
   parents:
   - 2620125
 322022:
-  aliases: ['Megaladapis sp. UA4821']
+  aliases: []
   parents:
   - 2620125
 322023:
-  aliases: ['Megaladapis sp. UA4822']
+  aliases: []
   parents:
   - 2620125
 322021:
-  aliases: ['Megaladapis sp. UA4823']
+  aliases: []
   parents:
   - 2620125
 322020:
-  aliases: ['Megaladapis sp. UA5482']
+  aliases: []
   parents:
   - 2620125
 1965102:
-  aliases: ['Mico']
+  aliases: []
   parents:
   - 9480
 3471683:
-  aliases: ['Microcebus sp.']
+  aliases: []
   parents:
   - 2630091
 469555:
-  aliases: ["Microcebus sp. 'anosynensis'"]
+  aliases: []
   parents:
   - 2630091
 469557:
-  aliases: ["Microcebus sp. 'mangabenensis'"]
+  aliases: []
   parents:
   - 2630091
 469556:
-  aliases: ["Microcebus sp. 'manombonensis'"]
+  aliases: []
   parents:
   - 2630091
 388736:
-  aliases: ['Microcebus sp. ANT5.1']
+  aliases: []
   parents:
   - 2630091
 412758:
-  aliases: ['Microcebus sp. Ambongabe']
+  aliases: []
   parents:
   - 2630091
 548482:
-  aliases: ['Microcebus sp. Anjiahely']
+  aliases: []
   parents:
   - 2630091
 418100:
-  aliases: ['Microcebus sp. Antanosy']
+  aliases: []
   parents:
   - 2630091
 412759:
-  aliases: ['Microcebus sp. Bora']
+  aliases: []
   parents:
   - 2630091
 764313:
-  aliases: ['Microcebus sp. DWW-2010a']
+  aliases: []
   parents:
   - 2630091
 270538:
-  aliases: ['Microcebus sp. EELHDZ M98']
+  aliases: []
   parents:
   - 2630091
 270540:
-  aliases: ['Microcebus sp. EELHDZ TAD23']
+  aliases: []
   parents:
   - 2630091
 270674:
-  aliases: ['Microcebus sp. EELHDZ VEV33']
+  aliases: []
   parents:
   - 2630091
 270675:
-  aliases: ['Microcebus sp. EELHDZ VEV35']
+  aliases: []
   parents:
   - 2630091
 2735722:
-  aliases: ['Microcebus sp. JM-2020']
+  aliases: []
   parents:
   - 2630091
 412760:
-  aliases: ['Microcebus sp. Mahajamba-Est']
+  aliases: []
   parents:
   - 2630091
 412761:
-  aliases: ['Microcebus sp. Maroakata']
+  aliases: []
   parents:
   - 2630091
 1310125:
-  aliases: ["Microcebus sp. d'Ambre"]
+  aliases: []
   parents:
   - 2630091
 2683930:
-  aliases: ['Microcebus sp. south Manambery']
+  aliases: []
   parents:
   - 2630091
 415977:
-  aliases: ['Mirza sp. 001y03']
+  aliases: []
   parents:
   - 2628182
 325165:
-  aliases: ['Nomascus']
+  aliases: []
   parents:
   - 9577
 310933:
-  aliases: ['Nycticebus coucang coucang']
+  aliases: []
   parents:
   - 9470
 2020906:
-  aliases: ['Nycticebus coucang insularis']
+  aliases: []
   parents:
   - 9470
 108082:
-  aliases: ['Nycticebus sp.']
+  aliases: []
   parents:
   - 2646861
 477174:
-  aliases: ['Otolemur garnettii garnettii']
+  aliases: []
   parents:
   - 30611
 337214:
-  aliases: ['Otolemur monteiri argentatus']
+  aliases: []
   parents:
   - 337212
 337213:
-  aliases: ['Otolemur monteiri monteiri']
+  aliases: []
   parents:
   - 337212
 322027:
-  aliases: ['Palaeopropithecus sp. KPK-2005']
+  aliases: []
   parents:
   - 2619300
 322025:
-  aliases: ['Palaeopropithecus sp. UA4466']
+  aliases: []
   parents:
   - 2619300
 322026:
-  aliases: ['Palaeopropithecus sp. UA6184']
+  aliases: []
   parents:
   - 2619300
 9473:
-  aliases: ['Perodicticus potto edwarsi']
+  aliases: []
   parents:
   - 9472
 261737:
-  aliases: ['Perodicticus potto ibeanus']
+  aliases: []
   parents:
   - 9472
 30597:
-  aliases: ['Pithecia']
+  aliases: []
   parents:
   - 38039
 1812035:
-  aliases: ['Plecturocebus']
+  aliases: []
   parents:
   - 38069
 607660:
-  aliases: ['Ponginae']
+  aliases: []
   parents:
   - 9604
 475619:
-  aliases: ['Propithecus deckenii coronatus']
+  aliases: []
   parents:
   - 475618
 481705:
-  aliases: ['Propithecus deckenii deckenii']
+  aliases: []
   parents:
   - 475618
 171945:
-  aliases: ['Propithecus diadema diadema']
+  aliases: []
   parents:
   - 83281
 171947:
-  aliases: ['Propithecus diadema marshi']
+  aliases: []
   parents:
   - 83281
 39582:
-  aliases: ['Propithecus sp.']
+  aliases: []
   parents:
   - 2677806
 3092528:
-  aliases: ['Propithecus sp. m MH-2023']
+  aliases: []
   parents:
   - 2677806
 122229:
-  aliases: ['Propithecus verreauxi verreauxi']
+  aliases: []
   parents:
   - 34825
 9486:
-  aliases: ['Saguinus']
+  aliases: []
   parents:
   - 9480
 9520:
-  aliases: ['Saimiri']
+  aliases: []
   parents:
   - 378850
 1532884:
-  aliases: ['Sapajus']
+  aliases: []
   parents:
   - 38070
 325166:
-  aliases: ['Symphalangus']
+  aliases: []
   parents:
   - 9577
 30612:
-  aliases: ['Tarsius sp.']
+  aliases: []
   parents:
   - 2624233
 1748402:
-  aliases: ['Tarsius sp. CD-2015']
+  aliases: []
   parents:
   - 2624233
 662655:
-  aliases: ['Tarsius sp. FFA-2009a']
+  aliases: []
   parents:
   - 2624233
 87289:
-  aliases: ['Varecia variegata variegata']
+  aliases: []
   parents:
   - 9455
 3030689:
-  aliases: ['Xanthonycticebus sp. i MB-2023']
+  aliases: []
   parents:
   - 3030688
 2490930:
-  aliases: ['Xenothrix']
+  aliases: []
   parents:
   - 2490929
 2688256:
-  aliases: ['unclassified Aotus (in: primates)']
+  aliases: []
   parents:
   - 9504
 3085340:
-  aliases: ['unclassified Callitrichinae']
+  aliases: []
   parents:
   - 9480
 2922387:
-  aliases: ['unclassified Hominidae']
+  aliases: []
   parents:
   - 9604
 54134:
-  aliases: ['Allenopithecus']
+  aliases: []
   parents:
   - 9528
 2059839:
-  aliases: ['Allochrocebus']
+  aliases: []
   parents:
   - 9528
 30590:
-  aliases: ['Alouatta belzebul']
+  aliases: []
   parents:
   - 9499
 9502:
-  aliases: ['Alouatta caraya']
+  aliases: []
   parents:
   - 9499
 2905217:
-  aliases: ['Alouatta discolor']
+  aliases: []
   parents:
   - 9499
 182256:
-  aliases: ['Alouatta guariba']
+  aliases: []
   parents:
   - 9499
 2946512:
-  aliases: ['Alouatta juara']
+  aliases: []
   parents:
   - 9499
 198115:
-  aliases: ['Alouatta macconnelli']
+  aliases: []
   parents:
   - 9499
 30589:
-  aliases: ['Alouatta palliata']
+  aliases: []
   parents:
   - 9499
 2487933:
-  aliases: ['Alouatta palliata x Alouatta pigra']
+  aliases: []
   parents:
   - 9499
 182253:
-  aliases: ['Alouatta pigra']
+  aliases: []
   parents:
   - 9499
 121123:
-  aliases: ['Alouatta sara']
+  aliases: []
   parents:
   - 9499
 9503:
-  aliases: ['Alouatta seniculus']
+  aliases: []
   parents:
   - 9499
 163110:
-  aliases: ['Alouatta stramineus']
+  aliases: []
   parents:
   - 9499
 2905218:
-  aliases: ['Alouatta ululata']
+  aliases: []
   parents:
   - 9499
 120088:
-  aliases: ['Aotus azarai azarai']
+  aliases: []
   parents:
   - 30591
 280755:
-  aliases: ['Aotus azarai boliviensis']
+  aliases: []
   parents:
   - 30591
 867331:
-  aliases: ['Aotus azarai infulatus']
+  aliases: []
   parents:
   - 30591
 231953:
-  aliases: ['Aotus sp. (in: primates)']
+  aliases: []
   parents:
   - 2688256
 1002694:
-  aliases: ['Aotus sp. AVB-2011']
+  aliases: []
   parents:
   - 2688256
 413234:
-  aliases: ['Aotus sp. Aot1']
+  aliases: []
   parents:
   - 2688256
 1230482:
-  aliases: ['Aotus sp. LC-2012']
+  aliases: []
   parents:
   - 2688256
 1090913:
-  aliases: ['Aotus sp. MAS-2011']
+  aliases: []
   parents:
   - 2688256
 222417:
-  aliases: ['Aotus sp. NIM-2003']
+  aliases: []
   parents:
   - 2688256
 261316:
-  aliases: ['Aotus sp. PDE-2004']
+  aliases: []
   parents:
   - 2688256
 940829:
-  aliases: ['Aotus sp. SHM-2010']
+  aliases: []
   parents:
   - 2688256
 9507:
-  aliases: ['Ateles belzebuth']
+  aliases: []
   parents:
   - 9506
 118643:
-  aliases: ['Ateles chamek']
+  aliases: []
   parents:
   - 9506
 9508:
-  aliases: ['Ateles fusciceps']
+  aliases: []
   parents:
   - 9506
 9509:
-  aliases: ['Ateles geoffroyi']
+  aliases: []
   parents:
   - 9506
 129801:
-  aliases: ['Ateles hybridus']
+  aliases: []
   parents:
   - 9506
 1529884:
-  aliases: ['Ateles marginatus']
+  aliases: []
   parents:
   - 9506
 9510:
-  aliases: ['Ateles paniscus']
+  aliases: []
   parents:
   - 9506
 36234:
-  aliases: ['Ateles paniscus x Ateles fusciceps']
+  aliases: []
   parents:
   - 9506
 30594:
-  aliases: ['Brachyteles arachnoides']
+  aliases: []
   parents:
   - 30593
 342807:
-  aliases: ['Brachyteles hypoxanthus']
+  aliases: []
   parents:
   - 30593
 2937889:
-  aliases: ['Cacajao amuna']
+  aliases: []
   parents:
   - 30595
 535896:
-  aliases: ['Cacajao ayresi']
+  aliases: []
   parents:
   - 30595
 30596:
-  aliases: ['Cacajao calvus']
+  aliases: []
   parents:
   - 30595
 535897:
-  aliases: ['Cacajao hosomi']
+  aliases: []
   parents:
   - 30595
 70825:
-  aliases: ['Cacajao melanocephalus']
+  aliases: []
   parents:
   - 30595
 70927:
-  aliases: ['Cacajao rubicundus']
+  aliases: []
   parents:
   - 30595
 1965113:
-  aliases: ['Calibella']
+  aliases: []
   parents:
   - 9481
 1861701:
-  aliases: ['Callicebus caquetensis']
+  aliases: []
   parents:
   - 9522
 867333:
-  aliases: ['Callicebus coimbrai']
+  aliases: []
   parents:
   - 9522
 1290433:
-  aliases: ['Callicebus dubius']
+  aliases: []
   parents:
   - 9522
 867334:
-  aliases: ['Callicebus nigrifrons']
+  aliases: []
   parents:
   - 9522
 1861702:
-  aliases: ['Callicebus ornatus']
+  aliases: []
   parents:
   - 9522
 70814:
-  aliases: ['Callicebus personatus']
+  aliases: []
   parents:
   - 9522
 9495:
-  aliases: ['Callimico goeldii']
+  aliases: []
   parents:
   - 9494
 1965096:
-  aliases: ['Callithrix']
+  aliases: []
   parents:
   - 9481
 38020:
-  aliases: ['Callitrichinae sp.']
+  aliases: []
   parents:
   - 3085340
 2826950:
-  aliases: ['Cebuella niveiventris']
+  aliases: []
   parents:
   - 1965109
 9493:
-  aliases: ['Cebuella pygmaea']
+  aliases: []
   parents:
   - 1965109
 3317177:
-  aliases: ['Cebus aequatorialis']
+  aliases: []
   parents:
   - 9513
 9514:
-  aliases: ['Cebus albifrons']
+  aliases: []
   parents:
   - 9513
 9516:
-  aliases: ['Cebus capucinus']
+  aliases: []
   parents:
   - 9513
 3128532:
-  aliases: ['Cebus castaneus']
+  aliases: []
   parents:
   - 9513
 2715852:
-  aliases: ['Cebus imitator']
+  aliases: []
   parents:
   - 9513
 37294:
-  aliases: ['Cebus kaapori']
+  aliases: []
   parents:
   - 9513
 37295:
-  aliases: ['Cebus olivaceus']
+  aliases: []
   parents:
   - 9513
 1985288:
-  aliases: ['Cebus unicolor']
+  aliases: []
   parents:
   - 9513
 1985289:
-  aliases: ['Cebus versicolor']
+  aliases: []
   parents:
   - 9513
 9529:
-  aliases: ['Cercocebus']
+  aliases: []
   parents:
   - 9528
 9533:
-  aliases: ['Cercopithecus']
+  aliases: []
   parents:
   - 9528
 2487712:
-  aliases: ['Cheracebus lucifer']
+  aliases: []
   parents:
   - 1812102
 210166:
-  aliases: ['Cheracebus lugens']
+  aliases: []
   parents:
   - 1812102
 1812106:
-  aliases: ['Cheracebus medemi']
+  aliases: []
   parents:
   - 1812102
 1560619:
-  aliases: ['Cheracebus purinus']
+  aliases: []
   parents:
   - 1812102
 1812110:
-  aliases: ['Cheracebus regulus']
+  aliases: []
   parents:
   - 1812102
 30592:
-  aliases: ['Cheracebus torquatus']
+  aliases: []
   parents:
   - 1812102
 198627:
-  aliases: ['Chiropotes albinasus']
+  aliases: []
   parents:
   - 9524
 626367:
-  aliases: ['Chiropotes albinasus x satanas']
+  aliases: []
   parents:
   - 9524
 658221:
-  aliases: ['Chiropotes chiropotes']
+  aliases: []
   parents:
   - 9524
 280163:
-  aliases: ['Chiropotes israelita']
+  aliases: []
   parents:
   - 9524
 3134011:
-  aliases: ['Chiropotes sagulatus']
+  aliases: []
   parents:
   - 9524
 9525:
-  aliases: ['Chiropotes satanas']
+  aliases: []
   parents:
   - 9524
 202458:
-  aliases: ['Chiropotes satanas x albinasus']
+  aliases: []
   parents:
   - 9524
 280160:
-  aliases: ['Chiropotes utahickae']
+  aliases: []
   parents:
   - 9524
 392815:
-  aliases: ['Chlorocebus']
+  aliases: []
   parents:
   - 9528
 9570:
-  aliases: ['Colobus']
+  aliases: []
   parents:
   - 9569
 9537:
-  aliases: ['Erythrocebus']
+  aliases: []
   parents:
   - 9528
 9592:
-  aliases: ['Gorilla']
+  aliases: []
   parents:
   - 207598
 2922388:
-  aliases: ['Hominidae sp.']
+  aliases: []
   parents:
   - 2922387
 9605:
-  aliases: ['Homo']
+  aliases: []
   parents:
   - 207598
 2883641:
-  aliases: ['Homo sapiens x Pan troglodytes tetraploid cell line']
+  aliases: []
   parents:
   - 2883640
 61851:
-  aliases: ['Hoolock hoolock']
+  aliases: []
   parents:
   - 325167
 593543:
-  aliases: ['Hoolock leuconedys']
+  aliases: []
   parents:
   - 325167
 1934191:
-  aliases: ['Hoolock leuconedys x Hoolock tianxing']
+  aliases: []
   parents:
   - 325167
 1934190:
-  aliases: ['Hoolock tianxing']
+  aliases: []
   parents:
   - 325167
 9579:
-  aliases: ['Hylobates agilis']
+  aliases: []
   parents:
   - 9578
 2768845:
-  aliases: ['Hylobates agilis x Hylobates albibarbis']
+  aliases: []
   parents:
   - 9578
 716691:
-  aliases: ['Hylobates albibarbis']
+  aliases: []
   parents:
   - 9578
 3370097:
-  aliases: ['Hylobates funereus']
+  aliases: []
   parents:
   - 9578
 9587:
-  aliases: ['Hylobates klossii']
+  aliases: []
   parents:
   - 9578
 9580:
-  aliases: ['Hylobates lar']
+  aliases: []
   parents:
   - 9578
 2841023:
-  aliases: ['Hylobates lar x Hylobates pileatus']
+  aliases: []
   parents:
   - 9578
 81572:
-  aliases: ['Hylobates moloch']
+  aliases: []
   parents:
   - 9578
 9588:
-  aliases: ['Hylobates muelleri']
+  aliases: []
   parents:
   - 9578
 9589:
-  aliases: ['Hylobates pileatus']
+  aliases: []
   parents:
   - 9578
 767357:
-  aliases: ['Lagothrix cana']
+  aliases: []
   parents:
   - 9518
 2565305:
-  aliases: ['Lagothrix flavicauda']
+  aliases: []
   parents:
   - 9518
 9519:
-  aliases: ['Lagothrix lagotricha']
+  aliases: []
   parents:
   - 9518
 767355:
-  aliases: ['Lagothrix lugens']
+  aliases: []
   parents:
   - 9518
 767356:
-  aliases: ['Lagothrix poeppigii']
+  aliases: []
   parents:
   - 9518
 2565306:
-  aliases: ['Lagothrix tschudii']
+  aliases: []
   parents:
   - 9518
 1618156:
-  aliases: ['Leontocebus cruzlimai']
+  aliases: []
   parents:
   - 2681187
 9487:
-  aliases: ['Leontocebus fuscicollis']
+  aliases: []
   parents:
   - 2681187
 2918762:
-  aliases: ['Leontocebus fuscus']
+  aliases: []
   parents:
   - 2681187
 9489:
-  aliases: ['Leontocebus nigricollis']
+  aliases: []
   parents:
   - 2681187
 122388:
-  aliases: ['Leontocebus tripartitus']
+  aliases: []
   parents:
   - 2681187
 57374:
-  aliases: ['Leontopithecus chrysomelas']
+  aliases: []
   parents:
   - 30587
 58710:
-  aliases: ['Leontopithecus chrysopygus']
+  aliases: []
   parents:
   - 30587
 30588:
-  aliases: ['Leontopithecus rosalia']
+  aliases: []
   parents:
   - 30587
 75565:
-  aliases: ['Lophocebus']
+  aliases: []
   parents:
   - 9528
 9539:
-  aliases: ['Macaca']
+  aliases: []
   parents:
   - 9528
 9567:
-  aliases: ['Mandrillus']
+  aliases: []
   parents:
   - 9528
 9482:
-  aliases: ['Mico argentatus']
+  aliases: []
   parents:
   - 1965102
 198701:
-  aliases: ['Mico cf. emiliae']
+  aliases: []
   parents:
   - 1965102
 3370242:
-  aliases: ['Mico chrysoleucos']
+  aliases: []
   parents:
   - 1965102
 48842:
-  aliases: ['Mico emiliae']
+  aliases: []
   parents:
   - 1965102
 52232:
-  aliases: ['Mico humeralifer']
+  aliases: []
   parents:
   - 1965102
 666519:
-  aliases: ['Mico humilis']
+  aliases: []
   parents:
   - 1965102
 2592805:
-  aliases: ['Mico intermedius']
+  aliases: []
   parents:
   - 1965102
 2592806:
-  aliases: ['Mico leucippe']
+  aliases: []
   parents:
   - 1965102
 2592807:
-  aliases: ['Mico marcai']
+  aliases: []
   parents:
   - 1965102
 57377:
-  aliases: ['Mico mauesi']
+  aliases: []
   parents:
   - 1965102
 1090896:
-  aliases: ['Mico melanurus']
+  aliases: []
   parents:
   - 1965102
 2592808:
-  aliases: ['Mico munduruku']
+  aliases: []
   parents:
   - 1965102
 1127763:
-  aliases: ['Mico rondoni']
+  aliases: []
   parents:
   - 1965102
 198702:
-  aliases: ['Mico saterei']
+  aliases: []
   parents:
   - 1965102
 2850016:
-  aliases: ['Mico schneideri']
+  aliases: []
   parents:
   - 1965102
 36230:
-  aliases: ['Miopithecus']
+  aliases: []
   parents:
   - 9528
 43779:
-  aliases: ['Nasalis']
+  aliases: []
   parents:
   - 9569
 1616038:
-  aliases: ['Nomascus annamensis']
+  aliases: []
   parents:
   - 325165
 2170374:
-  aliases: ['Nomascus cf. leucogenys SSH-2018']
+  aliases: []
   parents:
   - 325165
 29089:
-  aliases: ['Nomascus concolor']
+  aliases: []
   parents:
   - 325165
 61852:
-  aliases: ['Nomascus gabriellae']
+  aliases: []
   parents:
   - 325165
 2170372:
-  aliases: ['Nomascus gabriellae x Nomascus siki']
+  aliases: []
   parents:
   - 325165
 693984:
-  aliases: ['Nomascus hainanus']
+  aliases: []
   parents:
   - 325165
 61853:
-  aliases: ['Nomascus leucogenys']
+  aliases: []
   parents:
   - 325165
 2768844:
-  aliases: ['Nomascus leucogenys x Nomascus gabriellae']
+  aliases: []
   parents:
   - 325165
 2170373:
-  aliases: ['Nomascus leucogenys x Nomascus siki']
+  aliases: []
   parents:
   - 325165
 327374:
-  aliases: ['Nomascus nasutus']
+  aliases: []
   parents:
   - 325165
 9586:
-  aliases: ['Nomascus siki']
+  aliases: []
   parents:
   - 325165
 9596:
-  aliases: ['Pan']
+  aliases: []
   parents:
   - 207598
 9554:
-  aliases: ['Papio']
+  aliases: []
   parents:
   - 9528
 591932:
-  aliases: ['Piliocolobus']
+  aliases: []
   parents:
   - 9569
 2839867:
-  aliases: ['Pithecia aequatorialis']
+  aliases: []
   parents:
   - 30597
 2946514:
-  aliases: ['Pithecia albicans']
+  aliases: []
   parents:
   - 30597
 2946515:
-  aliases: ['Pithecia chrysocephala']
+  aliases: []
   parents:
   - 30597
 2946516:
-  aliases: ['Pithecia hirsuta']
+  aliases: []
   parents:
   - 30597
 30598:
-  aliases: ['Pithecia irrorata']
+  aliases: []
   parents:
   - 30597
 2946517:
-  aliases: ['Pithecia mittermeieri']
+  aliases: []
   parents:
   - 30597
 595220:
-  aliases: ['Pithecia monachus']
+  aliases: []
   parents:
   - 30597
 2946518:
-  aliases: ['Pithecia pissinatti']
+  aliases: []
   parents:
   - 30597
 43777:
-  aliases: ['Pithecia pithecia']
+  aliases: []
   parents:
   - 30597
 2946519:
-  aliases: ['Pithecia vanzolinii']
+  aliases: []
   parents:
   - 30597
 1812036:
-  aliases: ['Plecturocebus bernhardi']
+  aliases: []
   parents:
   - 1812035
 1812042:
-  aliases: ['Plecturocebus brunneus']
+  aliases: []
   parents:
   - 1812035
 867332:
-  aliases: ['Plecturocebus caligatus']
+  aliases: []
   parents:
   - 1812035
 1812037:
-  aliases: ['Plecturocebus cinerascens']
+  aliases: []
   parents:
   - 1812035
 202457:
-  aliases: ['Plecturocebus cupreus']
+  aliases: []
   parents:
   - 1812035
 2839868:
-  aliases: ['Plecturocebus discolor']
+  aliases: []
   parents:
   - 1812035
 230833:
-  aliases: ['Plecturocebus donacophilus']
+  aliases: []
   parents:
   - 1812035
 2946520:
-  aliases: ['Plecturocebus dubius']
+  aliases: []
   parents:
   - 1812035
 2488670:
-  aliases: ['Plecturocebus grovesi']
+  aliases: []
   parents:
   - 1812035
 78255:
-  aliases: ['Plecturocebus hoffmannsi']
+  aliases: []
   parents:
   - 1812035
 1812038:
-  aliases: ['Plecturocebus miltoni']
+  aliases: []
   parents:
   - 1812035
 9523:
-  aliases: ['Plecturocebus moloch']
+  aliases: []
   parents:
   - 1812035
 3370595:
-  aliases: ['Plecturocebus oenanthe']
+  aliases: []
   parents:
   - 1812035
 3370601:
-  aliases: ['Plecturocebus toppini']
+  aliases: []
   parents:
   - 1812035
 2487713:
-  aliases: ['Plecturocebus vieirai']
+  aliases: []
   parents:
   - 1812035
 9599:
-  aliases: ['Pongo']
+  aliases: []
   parents:
   - 607660
 9573:
-  aliases: ['Presbytis']
+  aliases: []
   parents:
   - 9569
 164647:
-  aliases: ['Procolobus']
+  aliases: []
   parents:
   - 9569
 54132:
-  aliases: ['Pygathrix']
+  aliases: []
   parents:
   - 9569
 542827:
-  aliases: ['Rhinopithecus']
+  aliases: []
   parents:
   - 9569
 371038:
-  aliases: ['Rungwecebus']
+  aliases: []
   parents:
   - 9528
 37588:
-  aliases: ['Saguinus bicolor']
+  aliases: []
   parents:
   - 9486
 43778:
-  aliases: ['Saguinus geoffroyi']
+  aliases: []
   parents:
   - 9486
 2586293:
-  aliases: ['Saguinus geoffroyi x Saguinus leucopus']
+  aliases: []
   parents:
   - 9486
 873073:
-  aliases: ['Saguinus graellsi']
+  aliases: []
   parents:
   - 9486
 9491:
-  aliases: ['Saguinus imperator']
+  aliases: []
   parents:
   - 9486
 1079039:
-  aliases: ['Saguinus inustus']
+  aliases: []
   parents:
   - 9486
 78454:
-  aliases: ['Saguinus labiatus']
+  aliases: []
   parents:
   - 9486
 290597:
-  aliases: ['Saguinus leucopus']
+  aliases: []
   parents:
   - 9486
 356666:
-  aliases: ['Saguinus martinsi']
+  aliases: []
   parents:
   - 9486
 873067:
-  aliases: ['Saguinus melanoleucus']
+  aliases: []
   parents:
   - 9486
 30586:
-  aliases: ['Saguinus midas']
+  aliases: []
   parents:
   - 9486
 9488:
-  aliases: ['Saguinus mystax']
+  aliases: []
   parents:
   - 9486
 356665:
-  aliases: ['Saguinus niger']
+  aliases: []
   parents:
   - 9486
 9490:
-  aliases: ['Saguinus oedipus']
+  aliases: []
   parents:
   - 9486
 2586294:
-  aliases: ['Saguinus oedipus x Saguinus leucopus']
+  aliases: []
   parents:
   - 9486
 2918763:
-  aliases: ['Saguinus ursulus']
+  aliases: []
   parents:
   - 9486
 3370761:
-  aliases: ['Saguinus weddelli']
+  aliases: []
   parents:
   - 9486
 27679:
-  aliases: ['Saimiri boliviensis']
+  aliases: []
   parents:
   - 9520
 2946521:
-  aliases: ['Saimiri cassiquiarensis']
+  aliases: []
   parents:
   - 9520
 2946522:
-  aliases: ['Saimiri macrodon']
+  aliases: []
   parents:
   - 9520
 70928:
-  aliases: ['Saimiri oerstedii']
+  aliases: []
   parents:
   - 9520
 9521:
-  aliases: ['Saimiri sciureus']
+  aliases: []
   parents:
   - 9520
 66265:
-  aliases: ['Saimiri ustus']
+  aliases: []
   parents:
   - 9520
 1561161:
-  aliases: ['Saimiri vanzolinii']
+  aliases: []
   parents:
   - 9520
 9515:
-  aliases: ['Sapajus apella']
+  aliases: []
   parents:
   - 1532884
 649471:
-  aliases: ['Sapajus cay']
+  aliases: []
   parents:
   - 1532884
 1112861:
-  aliases: ['Sapajus flavius']
+  aliases: []
   parents:
   - 1532884
 1126382:
-  aliases: ['Sapajus libidinosus']
+  aliases: []
   parents:
   - 1532884
 867366:
-  aliases: ['Sapajus nigritus']
+  aliases: []
   parents:
   - 1532884
 174599:
-  aliases: ['Sapajus xanthosternos']
+  aliases: []
   parents:
   - 1532884
 88028:
-  aliases: ['Semnopithecus']
+  aliases: []
   parents:
   - 9569
 1203020:
-  aliases: ['Simias']
+  aliases: []
   parents:
   - 9569
 9590:
-  aliases: ['Symphalangus syndactylus']
+  aliases: []
   parents:
   - 325166
 9564:
-  aliases: ['Theropithecus']
+  aliases: []
   parents:
   - 9528
 54136:
-  aliases: ['Trachypithecus']
+  aliases: []
   parents:
   - 9569
 2490931:
-  aliases: ['Xenothrix mcgregori']
+  aliases: []
   parents:
   - 2490930
 2623697:
-  aliases: ['unclassified Alouatta']
+  aliases: []
   parents:
   - 9499
 120432:
-  aliases: ['unclassified Ateles']
+  aliases: []
   parents:
   - 9506
 2704456:
-  aliases: ['unclassified Cacajao']
+  aliases: []
   parents:
   - 30595
 2627897:
-  aliases: ['unclassified Callicebus']
+  aliases: []
   parents:
   - 9522
 2634122:
-  aliases: ['unclassified Callimico']
+  aliases: []
   parents:
   - 9494
 3406878:
-  aliases: ['unclassified Callithrix (in: primates)']
+  aliases: []
   parents:
   - 9481
 2618788:
-  aliases: ['unclassified Cebus']
+  aliases: []
   parents:
   - 9513
 3074503:
-  aliases: ['unclassified Cercopithecinae']
+  aliases: []
   parents:
   - 9528
 2649368:
-  aliases: ['unclassified Chiropotes']
+  aliases: []
   parents:
   - 9524
 2647113:
-  aliases: ['unclassified Hylobates']
+  aliases: []
   parents:
   - 9578
 2645779:
-  aliases: ['unclassified Lagothrix']
+  aliases: []
   parents:
   - 9518
 2850015:
-  aliases: ['unclassified Mico']
+  aliases: []
   parents:
   - 1965102
 2646430:
-  aliases: ['unclassified Pithecia']
+  aliases: []
   parents:
   - 30597
 2642123:
-  aliases: ['unclassified Saguinus']
+  aliases: []
   parents:
   - 9486
 2635411:
-  aliases: ['unclassified Saimiri']
+  aliases: []
   parents:
   - 9520
 2619504:
-  aliases: ['unclassified Sapajus']
+  aliases: []
   parents:
   - 1532884
 54135:
-  aliases: ['Allenopithecus nigroviridis']
+  aliases: []
   parents:
   - 54134
 100224:
-  aliases: ['Allochrocebus lhoesti']
+  aliases: []
   parents:
   - 2059839
 147649:
-  aliases: ['Allochrocebus preussi']
+  aliases: []
   parents:
   - 2059839
 147650:
-  aliases: ['Allochrocebus solatus']
+  aliases: []
   parents:
   - 2059839
 182257:
-  aliases: ['Alouatta belzebul belzebul']
+  aliases: []
   parents:
   - 30590
 183328:
-  aliases: ['Alouatta guariba clamitans']
+  aliases: []
   parents:
   - 182256
 182252:
-  aliases: ['Alouatta palliata aequatorialis']
+  aliases: []
   parents:
   - 30589
 182249:
-  aliases: ['Alouatta palliata coibensis']
+  aliases: []
   parents:
   - 30589
 182248:
-  aliases: ['Alouatta palliata mexicana']
+  aliases: []
   parents:
   - 30589
 182250:
-  aliases: ['Alouatta palliata palliata']
+  aliases: []
   parents:
   - 30589
 182251:
-  aliases: ['Alouatta palliata trabeata']
+  aliases: []
   parents:
   - 30589
 1347729:
-  aliases: ['Alouatta seniculus puruensis']
+  aliases: []
   parents:
   - 9503
 182254:
-  aliases: ['Alouatta seniculus seniculus']
+  aliases: []
   parents:
   - 9503
 9501:
-  aliases: ['Alouatta sp.']
+  aliases: []
   parents:
   - 2623697
 118644:
-  aliases: ['Ateles belzebuth marginatus']
+  aliases: []
   parents:
   - 9507
 183327:
-  aliases: ['Ateles fusciceps robustus']
+  aliases: []
   parents:
   - 9508
 1497546:
-  aliases: ['Ateles fusciceps rufiventris']
+  aliases: []
   parents:
   - 9508
 1497547:
-  aliases: ['Ateles geoffroyi azuerensis']
+  aliases: []
   parents:
   - 9509
 795835:
-  aliases: ['Ateles geoffroyi frontatus']
+  aliases: []
   parents:
   - 9509
 1214775:
-  aliases: ['Ateles geoffroyi ornatus']
+  aliases: []
   parents:
   - 9509
 118647:
-  aliases: ['Ateles geoffroyi panamensis']
+  aliases: []
   parents:
   - 9509
 118648:
-  aliases: ['Ateles geoffroyi vellerosus']
+  aliases: []
   parents:
   - 9509
 118649:
-  aliases: ['Ateles geoffroyi yucatanensis']
+  aliases: []
   parents:
   - 9509
 1230481:
-  aliases: ['Ateles hybridus hybridus']
+  aliases: []
   parents:
   - 129801
 9511:
-  aliases: ['Ateles sp.']
+  aliases: []
   parents:
   - 120432
 2746757:
-  aliases: ['Ateles sp. Ate-1']
+  aliases: []
   parents:
   - 120432
 2746758:
-  aliases: ['Ateles sp. Ate-2']
+  aliases: []
   parents:
   - 120432
 1967450:
-  aliases: ['Ateles sp. EG-2017']
+  aliases: []
   parents:
   - 120432
 278713:
-  aliases: ['Ateles sp. JPV-2004']
+  aliases: []
   parents:
   - 120432
 269772:
-  aliases: ['Ateles sp. KO-2004']
+  aliases: []
   parents:
   - 120432
 119629:
-  aliases: ['Ateles sp. haplotype Abh10']
+  aliases: []
   parents:
   - 120432
 119630:
-  aliases: ['Ateles sp. haplotype Abh11']
+  aliases: []
   parents:
   - 120432
 119638:
-  aliases: ['Ateles sp. haplotype Abh19']
+  aliases: []
   parents:
   - 120432
 119628:
-  aliases: ['Ateles sp. haplotype Abh9']
+  aliases: []
   parents:
   - 120432
 119632:
-  aliases: ['Ateles sp. haplotype Afr19']
+  aliases: []
   parents:
   - 120432
 119633:
-  aliases: ['Ateles sp. haplotype Afr20']
+  aliases: []
   parents:
   - 120432
 119634:
-  aliases: ['Ateles sp. haplotype Afr21']
+  aliases: []
   parents:
   - 120432
 119640:
-  aliases: ['Ateles sp. haplotype Afr27']
+  aliases: []
   parents:
   - 120432
 119639:
-  aliases: ['Ateles sp. haplotype Agp13']
+  aliases: []
   parents:
   - 120432
 119631:
-  aliases: ['Ateles sp. haplotype Agsubspp. 16']
+  aliases: []
   parents:
   - 120432
 85699:
-  aliases: ['Cacajao calvus calvus']
+  aliases: []
   parents:
   - 30596
 658398:
-  aliases: ['Cacajao calvus novaesi']
+  aliases: []
   parents:
   - 30596
 658400:
-  aliases: ['Cacajao calvus rubicundus']
+  aliases: []
   parents:
   - 30596
 2946513:
-  aliases: ['Cacajao calvus ucayalii']
+  aliases: []
   parents:
   - 30596
 2704457:
-  aliases: ['Cacajao sp. CTGAM5666']
+  aliases: []
   parents:
   - 2704456
 78274:
-  aliases: ['Callicebus personatus nigrifrons']
+  aliases: []
   parents:
   - 70814
 78275:
-  aliases: ['Callicebus personatus personatus']
+  aliases: []
   parents:
   - 70814
 116962:
-  aliases: ['Callicebus sp.']
+  aliases: []
   parents:
   - 2627897
 1861704:
-  aliases: ['Callicebus sp. 1 MH-2016']
+  aliases: []
   parents:
   - 2627897
 1861705:
-  aliases: ['Callicebus sp. 2 MH-2016']
+  aliases: []
   parents:
   - 2627897
 1090915:
-  aliases: ['Callicebus sp. MAS-2011']
+  aliases: []
   parents:
   - 2627897
 2650809:
-  aliases: ['Callicebus sp. n. GD-2019']
+  aliases: []
   parents:
   - 2627897
 1758239:
-  aliases: ['Callimico sp.']
+  aliases: []
   parents:
   - 2634122
 1090914:
-  aliases: ['Callimico sp. MAS-2011']
+  aliases: []
   parents:
   - 2634122
 57375:
-  aliases: ['Callithrix aurita']
+  aliases: []
   parents:
   - 1965096
 1346251:
-  aliases: ['Callithrix flaviceps']
+  aliases: []
   parents:
   - 1965096
 52231:
-  aliases: ['Callithrix geoffroyi']
+  aliases: []
   parents:
   - 1965096
 9483:
-  aliases: ['Callithrix jacchus']
+  aliases: []
   parents:
   - 1965096
 1476500:
-  aliases: ['Callithrix jacchus x penicillata']
+  aliases: []
   parents:
   - 1965096
 867363:
-  aliases: ['Callithrix kuhlii']
+  aliases: []
   parents:
   - 1965096
 57378:
-  aliases: ['Callithrix penicillata']
+  aliases: []
   parents:
   - 1965096
 9485:
-  aliases: ['Callithrix sp.']
+  aliases: []
   parents:
   - 1965096
 2765886:
-  aliases: ['Callithrix sp. 1 JM-2020']
+  aliases: []
   parents:
   - 3406878
 2765895:
-  aliases: ['Callithrix sp. 10 JM-2020']
+  aliases: []
   parents:
   - 3406878
 2765896:
-  aliases: ['Callithrix sp. 11 JM-2020']
+  aliases: []
   parents:
   - 3406878
 2765897:
-  aliases: ['Callithrix sp. 12 JM-2020']
+  aliases: []
   parents:
   - 3406878
 2765898:
-  aliases: ['Callithrix sp. 13 JM-2020']
+  aliases: []
   parents:
   - 3406878
 2765899:
-  aliases: ['Callithrix sp. 14 JM-2020']
+  aliases: []
   parents:
   - 3406878
 2765900:
-  aliases: ['Callithrix sp. 15 JM-2020']
+  aliases: []
   parents:
   - 3406878
 2765901:
-  aliases: ['Callithrix sp. 16 JM-2020']
+  aliases: []
   parents:
   - 3406878
 2765902:
-  aliases: ['Callithrix sp. 17 JM-2020']
+  aliases: []
   parents:
   - 3406878
 2765903:
-  aliases: ['Callithrix sp. 18 JM-2020']
+  aliases: []
   parents:
   - 3406878
 2765887:
-  aliases: ['Callithrix sp. 2 JM-2020']
+  aliases: []
   parents:
   - 3406878
 2765888:
-  aliases: ['Callithrix sp. 3 JM-2020']
+  aliases: []
   parents:
   - 3406878
 2765889:
-  aliases: ['Callithrix sp. 4 JM-2020']
+  aliases: []
   parents:
   - 3406878
 2765890:
-  aliases: ['Callithrix sp. 5 JM-2020']
+  aliases: []
   parents:
   - 3406878
 2765891:
-  aliases: ['Callithrix sp. 6 JM-2020']
+  aliases: []
   parents:
   - 3406878
 2765892:
-  aliases: ['Callithrix sp. 7 JM-2020']
+  aliases: []
   parents:
   - 3406878
 2765893:
-  aliases: ['Callithrix sp. 8 JM-2020']
+  aliases: []
   parents:
   - 3406878
 2765894:
-  aliases: ['Callithrix sp. 9 JM-2020']
+  aliases: []
   parents:
   - 3406878
 2873328:
-  aliases: ['Callithrix sp. BJT022']
+  aliases: []
   parents:
   - 3406878
 217956:
-  aliases: ['Callithrix sp. DB-2003']
+  aliases: []
   parents:
   - 1965096
 1985287:
-  aliases: ['Cebus olivaceus castaneus']
+  aliases: []
   parents:
   - 37295
 1090893:
-  aliases: ['Cebus olivaceus nigrivittatus']
+  aliases: []
   parents:
   - 37295
 9517:
-  aliases: ['Cebus sp.']
+  aliases: []
   parents:
   - 2618788
 1967451:
-  aliases: ['Cebus sp. 1 EG-2017']
+  aliases: []
   parents:
   - 2618788
 1967452:
-  aliases: ['Cebus sp. 2 EG-2017']
+  aliases: []
   parents:
   - 2618788
 1090916:
-  aliases: ['Cebus sp. MAS-2011']
+  aliases: []
   parents:
   - 2618788
 255237:
-  aliases: ['Cercocebus agilis']
+  aliases: []
   parents:
   - 9529
 9531:
-  aliases: ['Cercocebus atys']
+  aliases: []
   parents:
   - 9529
 75569:
-  aliases: ['Cercocebus chrysogaster']
+  aliases: []
   parents:
   - 9529
 9532:
-  aliases: ['Cercocebus galeritus']
+  aliases: []
   parents:
   - 9529
 3074498:
-  aliases: ['Cercocebus lunulatus']
+  aliases: []
   parents:
   - 9529
 9530:
-  aliases: ['Cercocebus torquatus']
+  aliases: []
   parents:
   - 9529
 867370:
-  aliases: ['Cercopithecus albogularis']
+  aliases: []
   parents:
   - 9533
 36223:
-  aliases: ['Cercopithecus ascanius']
+  aliases: []
   parents:
   - 9533
 303588:
-  aliases: ['Cercopithecus campbelli']
+  aliases: []
   parents:
   - 9533
 9535:
-  aliases: ['Cercopithecus cephus']
+  aliases: []
   parents:
   - 9533
 1137511:
-  aliases: ['Cercopithecus denti']
+  aliases: []
   parents:
   - 9533
 36224:
-  aliases: ['Cercopithecus diana']
+  aliases: []
   parents:
   - 9533
 1137474:
-  aliases: ['Cercopithecus doggetti']
+  aliases: []
   parents:
   - 9533
 161496:
-  aliases: ['Cercopithecus erythrogaster']
+  aliases: []
   parents:
   - 9533
 167130:
-  aliases: ['Cercopithecus erythrotis']
+  aliases: []
   parents:
   - 9533
 9536:
-  aliases: ['Cercopithecus hamlyni']
+  aliases: []
   parents:
   - 9533
 1137481:
-  aliases: ['Cercopithecus kandti']
+  aliases: []
   parents:
   - 9533
 1191211:
-  aliases: ['Cercopithecus lomamiensis']
+  aliases: []
   parents:
   - 9533
 36225:
-  aliases: ['Cercopithecus mitis']
+  aliases: []
   parents:
   - 9533
 36226:
-  aliases: ['Cercopithecus mona']
+  aliases: []
   parents:
   - 9533
 36227:
-  aliases: ['Cercopithecus neglectus']
+  aliases: []
   parents:
   - 9533
 36228:
-  aliases: ['Cercopithecus nictitans']
+  aliases: []
   parents:
   - 9533
 100487:
-  aliases: ['Cercopithecus petaurista']
+  aliases: []
   parents:
   - 9533
 102108:
-  aliases: ['Cercopithecus pogonias']
+  aliases: []
   parents:
   - 9533
 1137049:
-  aliases: ['Cercopithecus roloway']
+  aliases: []
   parents:
   - 9533
 1579530:
-  aliases: ['Cercopithecus sclateri']
+  aliases: []
   parents:
   - 9533
 263448:
-  aliases: ['Cercopithecus wolfi']
+  aliases: []
   parents:
   - 9533
 1758238:
-  aliases: ['Chiropotes sp.']
+  aliases: []
   parents:
   - 2649368
 2736752:
-  aliases: ['Chiropotes sp. CTGAM5363']
+  aliases: []
   parents:
   - 2649368
 2704455:
-  aliases: ['Chiropotes sp. CTGAM5663']
+  aliases: []
   parents:
   - 2649368
 1090917:
-  aliases: ['Chiropotes sp. MAS-2011']
+  aliases: []
   parents:
   - 2649368
 1472258:
-  aliases: ['Chiropotes sp. ZFMK_2008.244']
+  aliases: []
   parents:
   - 2649368
 9534:
-  aliases: ['Chlorocebus aethiops']
+  aliases: []
   parents:
   - 392815
 1903316:
-  aliases: ['Chlorocebus aethiops x Chlorocebus pygerythrus']
+  aliases: []
   parents:
   - 392815
 1476079:
-  aliases: ['Chlorocebus aethiops x djamdjamensis']
+  aliases: []
   parents:
   - 392815
 460675:
-  aliases: ['Chlorocebus cynosuros']
+  aliases: []
   parents:
   - 392815
 1284215:
-  aliases: ['Chlorocebus djamdjamensis']
+  aliases: []
   parents:
   - 392815
 3369779:
-  aliases: ['Chlorocebus dryas']
+  aliases: []
   parents:
   - 392815
 60710:
-  aliases: ['Chlorocebus pygerythrus']
+  aliases: []
   parents:
   - 392815
 60711:
-  aliases: ['Chlorocebus sabaeus']
+  aliases: []
   parents:
   - 392815
 60712:
-  aliases: ['Chlorocebus tantalus']
+  aliases: []
   parents:
   - 392815
 54131:
-  aliases: ['Colobus angolensis']
+  aliases: []
   parents:
   - 9570
 33548:
-  aliases: ['Colobus guereza']
+  aliases: []
   parents:
   - 9570
 9572:
-  aliases: ['Colobus polykomos']
+  aliases: []
   parents:
   - 9570
 517012:
-  aliases: ['Colobus satanas']
+  aliases: []
   parents:
   - 9570
 378195:
-  aliases: ['Colobus vellerosus']
+  aliases: []
   parents:
   - 9570
 378196:
-  aliases: ['Colobus vellerosus x angolensis']
+  aliases: []
   parents:
   - 9570
 9538:
-  aliases: ['Erythrocebus patas']
+  aliases: []
   parents:
   - 9537
 499232:
-  aliases: ['Gorilla beringei']
+  aliases: []
   parents:
   - 9592
 9593:
-  aliases: ['Gorilla gorilla']
+  aliases: []
   parents:
   - 9592
 1425170:
-  aliases: ['Homo heidelbergensis']
+  aliases: []
   parents:
   - 9605
 9606:
-  aliases: ['Homo sapiens']
+  aliases: []
   parents:
   - 9605
 716690:
-  aliases: ['Hylobates agilis agilis']
+  aliases: []
   parents:
   - 9579
 9583:
-  aliases: ['Hylobates agilis unko']
+  aliases: []
   parents:
   - 9579
 716695:
-  aliases: ['Hylobates lar carpenteri']
+  aliases: []
   parents:
   - 9580
 716696:
-  aliases: ['Hylobates lar entelloides']
+  aliases: []
   parents:
   - 9580
 716697:
-  aliases: ['Hylobates lar lar']
+  aliases: []
   parents:
   - 9580
 716698:
-  aliases: ['Hylobates lar vestitus']
+  aliases: []
   parents:
   - 9580
 716694:
-  aliases: ['Hylobates muelleri abbotti']
+  aliases: []
   parents:
   - 9588
 716692:
-  aliases: ['Hylobates muelleri muelleri']
+  aliases: []
   parents:
   - 9588
 9581:
-  aliases: ['Hylobates sp.']
+  aliases: []
   parents:
   - 2647113
 288892:
-  aliases: ['Hylobates sp. AMA-2004']
+  aliases: []
   parents:
   - 2647113
 419588:
-  aliases: ['Hylobates sp. ECACC MLA144']
+  aliases: []
   parents:
   - 2647113
 280856:
-  aliases: ['Hylobates sp. IGL-2004']
+  aliases: []
   parents:
   - 2647113
 2768846:
-  aliases: ['Hylobates sp. KM-2020']
+  aliases: []
   parents:
   - 2647113
 2023128:
-  aliases: ['Hylobates sp. OH-2017']
+  aliases: []
   parents:
   - 2647113
 425245:
-  aliases: ['Hylobates sp. PS-2007']
+  aliases: []
   parents:
   - 2647113
 150249:
-  aliases: ['Hylobates sp. TIB-201']
+  aliases: []
   parents:
   - 2647113
 638937:
-  aliases: ['Lagothrix sp. CCS-2009a']
+  aliases: []
   parents:
   - 2645779
 1967456:
-  aliases: ['Lagothrix sp. EG-2017']
+  aliases: []
   parents:
   - 2645779
 48018:
-  aliases: ['Leontocebus fuscicollis fuscicollis']
+  aliases: []
   parents:
   - 9487
 881947:
-  aliases: ['Leontocebus fuscicollis illigeri']
+  aliases: []
   parents:
   - 9487
 881950:
-  aliases: ['Leontocebus fuscicollis lagonotus']
+  aliases: []
   parents:
   - 9487
 881946:
-  aliases: ['Leontocebus fuscicollis leucogenys']
+  aliases: []
   parents:
   - 9487
 881949:
-  aliases: ['Leontocebus fuscicollis nigrifrons']
+  aliases: []
   parents:
   - 9487
 343424:
-  aliases: ['Leontocebus fuscicollis weddelli']
+  aliases: []
   parents:
   - 9487
 873070:
-  aliases: ['Leontocebus nigricollis nigricollis']
+  aliases: []
   parents:
   - 9489
 75567:
-  aliases: ['Lophocebus albigena']
+  aliases: []
   parents:
   - 75565
 75566:
-  aliases: ['Lophocebus aterrimus']
+  aliases: []
   parents:
   - 75565
 9540:
-  aliases: ['Macaca arctoides']
+  aliases: []
   parents:
   - 9539
 9551:
-  aliases: ['Macaca assamensis']
+  aliases: []
   parents:
   - 9539
 281404:
-  aliases: ['Macaca balantak']
+  aliases: []
   parents:
   - 9539
 281405:
-  aliases: ['Macaca balantak x tonkeana']
+  aliases: []
   parents:
   - 9539
 90381:
-  aliases: ['Macaca brunnescens']
+  aliases: []
   parents:
   - 9539
 78449:
-  aliases: ['Macaca cyclopis']
+  aliases: []
   parents:
   - 9539
 9541:
-  aliases: ['Macaca fascicularis']
+  aliases: []
   parents:
   - 9539
 3016450:
-  aliases: ['Macaca fascicularis x Macaca mulatta']
+  aliases: []
   parents:
   - 9539
 9542:
-  aliases: ['Macaca fuscata']
+  aliases: []
   parents:
   - 9539
 90382:
-  aliases: ['Macaca hecki']
+  aliases: []
   parents:
   - 9539
 171293:
-  aliases: ['Macaca hecki x tonkeana']
+  aliases: []
   parents:
   - 9539
 90387:
-  aliases: ['Macaca leonina']
+  aliases: []
   parents:
   - 9539
 1885588:
-  aliases: ['Macaca leucogenys']
+  aliases: []
   parents:
   - 9539
 90383:
-  aliases: ['Macaca maura']
+  aliases: []
   parents:
   - 9539
 168259:
-  aliases: ['Macaca maura x tonkeana']
+  aliases: []
   parents:
   - 9539
 9544:
-  aliases: ['Macaca mulatta']
+  aliases: []
   parents:
   - 9539
 402888:
-  aliases: ['Macaca munzala']
+  aliases: []
   parents:
   - 9539
 9545:
-  aliases: ['Macaca nemestrina']
+  aliases: []
   parents:
   - 9539
 54600:
-  aliases: ['Macaca nigra']
+  aliases: []
   parents:
   - 9539
 90384:
-  aliases: ['Macaca nigrescens']
+  aliases: []
   parents:
   - 9539
 90385:
-  aliases: ['Macaca ochreata']
+  aliases: []
   parents:
   - 9539
 230653:
-  aliases: ['Macaca pagensis']
+  aliases: []
   parents:
   - 9539
 9548:
-  aliases: ['Macaca radiata']
+  aliases: []
   parents:
   - 9539
 244255:
-  aliases: ['Macaca siberu']
+  aliases: []
   parents:
   - 9539
 54601:
-  aliases: ['Macaca silenus']
+  aliases: []
   parents:
   - 9539
 9552:
-  aliases: ['Macaca sinica']
+  aliases: []
   parents:
   - 9539
 9546:
-  aliases: ['Macaca sylvanus']
+  aliases: []
   parents:
   - 9539
 54602:
-  aliases: ['Macaca thibetana']
+  aliases: []
   parents:
   - 9539
 40843:
-  aliases: ['Macaca tonkeana']
+  aliases: []
   parents:
   - 9539
 9568:
-  aliases: ['Mandrillus leucophaeus']
+  aliases: []
   parents:
   - 9567
 9561:
-  aliases: ['Mandrillus sphinx']
+  aliases: []
   parents:
   - 9567
 867362:
-  aliases: ['Mico argentatus argentatus']
+  aliases: []
   parents:
   - 9482
 2946523:
-  aliases: ['Mico sp. n. MJ-2022']
+  aliases: []
   parents:
   - 2850015
 100488:
-  aliases: ['Miopithecus ogouensis']
+  aliases: []
   parents:
   - 36230
 36231:
-  aliases: ['Miopithecus talapoin']
+  aliases: []
   parents:
   - 36230
 43780:
-  aliases: ['Nasalis larvatus']
+  aliases: []
   parents:
   - 43779
 716684:
-  aliases: ['Nomascus concolor concolor']
+  aliases: []
   parents:
   - 29089
 423450:
-  aliases: ['Nomascus concolor furvogaster']
+  aliases: []
   parents:
   - 29089
 423449:
-  aliases: ['Nomascus concolor jingdongensis']
+  aliases: []
   parents:
   - 29089
 716685:
-  aliases: ['Nomascus concolor lu']
+  aliases: []
   parents:
   - 29089
 9597:
-  aliases: ['Pan paniscus']
+  aliases: []
   parents:
   - 9596
 9598:
-  aliases: ['Pan troglodytes']
+  aliases: []
   parents:
   - 9596
 9555:
-  aliases: ['Papio anubis']
+  aliases: []
   parents:
   - 9554
 1945556:
-  aliases: ['Papio anubis x Papio cynocephalus']
+  aliases: []
   parents:
   - 9554
 1945557:
-  aliases: ['Papio anubis x Papio ursinus']
+  aliases: []
   parents:
   - 9554
 1560552:
-  aliases: ['Papio anubis x hamadryas']
+  aliases: []
   parents:
   - 9554
 9556:
-  aliases: ['Papio cynocephalus']
+  aliases: []
   parents:
   - 9554
 208510:
-  aliases: ['Papio cynocephalus x Papio anubis']
+  aliases: []
   parents:
   - 9554
 9557:
-  aliases: ['Papio hamadryas']
+  aliases: []
   parents:
   - 9554
 208091:
-  aliases: ['Papio kindae']
+  aliases: []
   parents:
   - 9554
 1945558:
-  aliases: ['Papio kindae x Papio cynocephalus']
+  aliases: []
   parents:
   - 9554
 1945559:
-  aliases: ['Papio kindae x Papio ursinus griseipes']
+  aliases: []
   parents:
   - 9554
 100937:
-  aliases: ['Papio papio']
+  aliases: []
   parents:
   - 9554
 36229:
-  aliases: ['Papio ursinus']
+  aliases: []
   parents:
   - 9554
 3074504:
-  aliases: ['Papionini sp.']
+  aliases: []
   parents:
   - 3074503
 164648:
-  aliases: ['Piliocolobus badius']
+  aliases: []
   parents:
   - 591932
 591938:
-  aliases: ['Piliocolobus foai']
+  aliases: []
   parents:
   - 591932
 591933:
-  aliases: ['Piliocolobus gordonorum']
+  aliases: []
   parents:
   - 591932
 591937:
-  aliases: ['Piliocolobus kirkii']
+  aliases: []
   parents:
   - 591932
 591944:
-  aliases: ['Piliocolobus pennantii']
+  aliases: []
   parents:
   - 591932
 591945:
-  aliases: ['Piliocolobus preussi']
+  aliases: []
   parents:
   - 591932
 591934:
-  aliases: ['Piliocolobus rufomitratus']
+  aliases: []
   parents:
   - 591932
 591936:
-  aliases: ['Piliocolobus tephrosceles']
+  aliases: []
   parents:
   - 591932
 591935:
-  aliases: ['Piliocolobus tholloni']
+  aliases: []
   parents:
   - 591932
 285955:
-  aliases: ['Pithecia pithecia pithecia']
+  aliases: []
   parents:
   - 43777
 1758237:
-  aliases: ['Pithecia sp.']
+  aliases: []
   parents:
   - 2646430
 2946524:
-  aliases: ['Pithecia sp. MJ-2022']
+  aliases: []
   parents:
   - 2646430
 2704458:
-  aliases: ['Pithecia sp. UFPA Pit22']
+  aliases: []
   parents:
   - 2646430
 285954:
-  aliases: ['Plecturocebus donacophilus donacophilus']
+  aliases: []
   parents:
   - 230833
 9601:
-  aliases: ['Pongo abelii']
+  aliases: []
   parents:
   - 9599
 502961:
-  aliases: ['Pongo abelii x pygmaeus']
+  aliases: []
   parents:
   - 9599
 9600:
-  aliases: ['Pongo pygmaeus']
+  aliases: []
   parents:
   - 9599
 2051901:
-  aliases: ['Pongo tapanuliensis']
+  aliases: []
   parents:
   - 9599
 3370610:
-  aliases: ['Presbytis bicolor']
+  aliases: []
   parents:
   - 9573
 1046090:
-  aliases: ['Presbytis chrysomelas']
+  aliases: []
   parents:
   - 9573
 78452:
-  aliases: ['Presbytis comata']
+  aliases: []
   parents:
   - 9573
 78453:
-  aliases: ['Presbytis femoralis']
+  aliases: []
   parents:
   - 9573
 1046092:
-  aliases: ['Presbytis frontata']
+  aliases: []
   parents:
   - 9573
 1046093:
-  aliases: ['Presbytis hosei']
+  aliases: []
   parents:
   - 9573
 78451:
-  aliases: ['Presbytis melalophos']
+  aliases: []
   parents:
   - 9573
 1046098:
-  aliases: ['Presbytis potenziani']
+  aliases: []
   parents:
   - 9573
 1046101:
-  aliases: ['Presbytis rubicunda']
+  aliases: []
   parents:
   - 9573
 66055:
-  aliases: ['Presbytis senex']
+  aliases: []
   parents:
   - 9573
 3370616:
-  aliases: ['Presbytis siberu']
+  aliases: []
   parents:
   - 9573
 3370617:
-  aliases: ['Presbytis sumatrana']
+  aliases: []
   parents:
   - 9573
 1046103:
-  aliases: ['Presbytis thomasi']
+  aliases: []
   parents:
   - 9573
 373033:
-  aliases: ['Procolobus verus']
+  aliases: []
   parents:
   - 164647
 693712:
-  aliases: ['Pygathrix cinerea']
+  aliases: []
   parents:
   - 54132
 1194332:
-  aliases: ['Pygathrix cinerea 1 RL-2012']
+  aliases: []
   parents:
   - 54132
 1194333:
-  aliases: ['Pygathrix cinerea 2 RL-2012']
+  aliases: []
   parents:
   - 54132
 54133:
-  aliases: ['Pygathrix nemaeus']
+  aliases: []
   parents:
   - 54132
 310352:
-  aliases: ['Pygathrix nigripes']
+  aliases: []
   parents:
   - 54132
 66062:
-  aliases: ['Rhinopithecus avunculus']
+  aliases: []
   parents:
   - 542827
 61621:
-  aliases: ['Rhinopithecus bieti']
+  aliases: []
   parents:
   - 542827
 1194334:
-  aliases: ['Rhinopithecus bieti 1 RL-2012']
+  aliases: []
   parents:
   - 542827
 1194335:
-  aliases: ['Rhinopithecus bieti 2 RL-2012']
+  aliases: []
   parents:
   - 542827
 224329:
-  aliases: ['Rhinopithecus brelichi']
+  aliases: []
   parents:
   - 542827
 61622:
-  aliases: ['Rhinopithecus roxellana']
+  aliases: []
   parents:
   - 542827
 1194336:
-  aliases: ['Rhinopithecus strykeri']
+  aliases: []
   parents:
   - 542827
 371039:
-  aliases: ['Rungwecebus kipunji']
+  aliases: []
   parents:
   - 371038
 37589:
-  aliases: ['Saguinus bicolor bicolor']
+  aliases: []
   parents:
   - 37588
 881951:
-  aliases: ['Saguinus imperator subgrisescens']
+  aliases: []
   parents:
   - 9491
 873066:
-  aliases: ['Saguinus labiatus labiatus']
+  aliases: []
   parents:
   - 78454
 2918764:
-  aliases: ['Saguinus labiatus rufiventer']
+  aliases: []
   parents:
   - 78454
 3104633:
-  aliases: ['Saguinus martinsi ochraceus']
+  aliases: []
   parents:
   - 356666
 873068:
-  aliases: ['Saguinus melanoleucus melanoleucus']
+  aliases: []
   parents:
   - 873067
 78354:
-  aliases: ['Saguinus midas midas']
+  aliases: []
   parents:
   - 30586
 873069:
-  aliases: ['Saguinus mystax mystax']
+  aliases: []
   parents:
   - 9488
 2979364:
-  aliases: ['Saguinus mystax pileatus']
+  aliases: []
   parents:
   - 9488
 2979365:
-  aliases: ['Saguinus mystax pluto']
+  aliases: []
   parents:
   - 9488
 100754:
-  aliases: ['Saguinus sp.']
+  aliases: []
   parents:
   - 2642123
 2952760:
-  aliases: ['Saguinus sp. CN232']
+  aliases: []
   parents:
   - 2642123
 2952761:
-  aliases: ['Saguinus sp. CN274']
+  aliases: []
   parents:
   - 2642123
 2952762:
-  aliases: ['Saguinus sp. CN287']
+  aliases: []
   parents:
   - 2642123
 2952796:
-  aliases: ['Saguinus sp. CTGA163']
+  aliases: []
   parents:
   - 2642123
 1967463:
-  aliases: ['Saguinus sp. EG-2017']
+  aliases: []
   parents:
   - 2642123
 2931043:
-  aliases: ['Saguinus sp. INUSTUS706']
+  aliases: []
   parents:
   - 2642123
 2952770:
-  aliases: ['Saguinus sp. INUSTUS708']
+  aliases: []
   parents:
   - 2642123
 2952769:
-  aliases: ['Saguinus sp. INUSTUS723']
+  aliases: []
   parents:
   - 2642123
 2946525:
-  aliases: ['Saguinus sp. MJ-2022']
+  aliases: []
   parents:
   - 2642123
 2952797:
-  aliases: ['Saguinus sp. SBB1000']
+  aliases: []
   parents:
   - 2642123
 2952798:
-  aliases: ['Saguinus sp. SBB1115']
+  aliases: []
   parents:
   - 2642123
 2918757:
-  aliases: ['Saguinus sp. SBBXSMA711']
+  aliases: []
   parents:
   - 2642123
 2952766:
-  aliases: ['Saguinus sp. SG15']
+  aliases: []
   parents:
   - 2642123
 2931044:
-  aliases: ['Saguinus sp. SG17']
+  aliases: []
   parents:
   - 2642123
 2931045:
-  aliases: ['Saguinus sp. SG19']
+  aliases: []
   parents:
   - 2642123
 2952767:
-  aliases: ['Saguinus sp. SG20']
+  aliases: []
   parents:
   - 2642123
 2952765:
-  aliases: ['Saguinus sp. SG25']
+  aliases: []
   parents:
   - 2642123
 2931051:
-  aliases: ['Saguinus sp. SG26']
+  aliases: []
   parents:
   - 2642123
 2952768:
-  aliases: ['Saguinus sp. SIM_F']
+  aliases: []
   parents:
   - 2642123
 2931047:
-  aliases: ['Saguinus sp. SLEUCALI']
+  aliases: []
   parents:
   - 2642123
 2952799:
-  aliases: ['Saguinus sp. SMA57']
+  aliases: []
   parents:
   - 2642123
 2952800:
-  aliases: ['Saguinus sp. SMAR567']
+  aliases: []
   parents:
   - 2642123
 2952771:
-  aliases: ['Saguinus sp. SMI1278']
+  aliases: []
   parents:
   - 2642123
 2931046:
-  aliases: ['Saguinus sp. SMI218']
+  aliases: []
   parents:
   - 2642123
 2952764:
-  aliases: ['Saguinus sp. SMI250']
+  aliases: []
   parents:
   - 2642123
 2952763:
-  aliases: ['Saguinus sp. SMI257']
+  aliases: []
   parents:
   - 2642123
 2952759:
-  aliases: ['Saguinus sp. SMIRC21']
+  aliases: []
   parents:
   - 2642123
 2918756:
-  aliases: ['Saguinus sp. SMIXSBB']
+  aliases: []
   parents:
   - 2642123
 2931048:
-  aliases: ['Saguinus sp. SOEDCALI']
+  aliases: []
   parents:
   - 2642123
 2931049:
-  aliases: ['Saguinus sp. SW4466']
+  aliases: []
   parents:
   - 2642123
 260575:
-  aliases: ['Saguinus sp. T1030']
+  aliases: []
   parents:
   - 2642123
 2931050:
-  aliases: ['Saguinus sp. TMDSU']
+  aliases: []
   parents:
   - 2642123
 2979366:
-  aliases: ['Saguinus sp. k TH-2022']
+  aliases: []
   parents:
   - 2642123
 39432:
-  aliases: ['Saimiri boliviensis boliviensis']
+  aliases: []
   parents:
   - 27679
 495297:
-  aliases: ['Saimiri boliviensis peruviensis']
+  aliases: []
   parents:
   - 27679
 942008:
-  aliases: ['Saimiri oerstedii citrinellus']
+  aliases: []
   parents:
   - 70928
 867380:
-  aliases: ['Saimiri oerstedii oerstedii']
+  aliases: []
   parents:
   - 70928
 495298:
-  aliases: ['Saimiri sciureus albigena']
+  aliases: []
   parents:
   - 9521
 495299:
-  aliases: ['Saimiri sciureus cassiquiarensis']
+  aliases: []
   parents:
   - 9521
 198114:
-  aliases: ['Saimiri sciureus collinsi']
+  aliases: []
   parents:
   - 9521
 495300:
-  aliases: ['Saimiri sciureus macrodon']
+  aliases: []
   parents:
   - 9521
 190117:
-  aliases: ['Saimiri sciureus sciureus']
+  aliases: []
   parents:
   - 9521
 1561164:
-  aliases: ['Saimiri sp.']
+  aliases: []
   parents:
   - 2635411
 1967464:
-  aliases: ['Saimiri sp. 1 EG-2017']
+  aliases: []
   parents:
   - 2635411
 1967465:
-  aliases: ['Saimiri sp. 2 EG-2017']
+  aliases: []
   parents:
   - 2635411
 1967466:
-  aliases: ['Saimiri sp. 3 EG-2017']
+  aliases: []
   parents:
   - 2635411
 1090919:
-  aliases: ['Saimiri sp. MAS-2011']
+  aliases: []
   parents:
   - 2635411
 174598:
-  aliases: ['Sapajus apella apella']
+  aliases: []
   parents:
   - 9515
 1547595:
-  aliases: ['Sapajus apella macrocephalus']
+  aliases: []
   parents:
   - 9515
 1532888:
-  aliases: ['Sapajus apella margaritae']
+  aliases: []
   parents:
   - 9515
 867367:
-  aliases: ['Sapajus nigritus robustus']
+  aliases: []
   parents:
   - 867366
 1874197:
-  aliases: ['Sapajus sp.']
+  aliases: []
   parents:
   - 2619504
 2093836:
-  aliases: ['Sapajus sp. 10 FD-2018']
+  aliases: []
   parents:
   - 2619504
 2093837:
-  aliases: ['Sapajus sp. 22 FD-2018']
+  aliases: []
   parents:
   - 2619504
 2093835:
-  aliases: ['Sapajus sp. 9 FD-2018']
+  aliases: []
   parents:
   - 2619504
 2093839:
-  aliases: ['Sapajus sp. M12 FD-2018']
+  aliases: []
   parents:
   - 2619504
 2093840:
-  aliases: ['Sapajus sp. M39 FD-2018']
+  aliases: []
   parents:
   - 2619504
 2093838:
-  aliases: ['Sapajus sp. M5 FD-2018']
+  aliases: []
   parents:
   - 2619504
 2805706:
-  aliases: ['Sapajus sp. Pr035']
+  aliases: []
   parents:
   - 2619504
 2805936:
-  aliases: ['Semnopithecus ajax']
+  aliases: []
   parents:
   - 88028
 88029:
-  aliases: ['Semnopithecus entellus']
+  aliases: []
   parents:
   - 88028
 867382:
-  aliases: ['Semnopithecus hector']
+  aliases: []
   parents:
   - 88028
 1208734:
-  aliases: ['Semnopithecus hypoleucos']
+  aliases: []
   parents:
   - 88028
 1208733:
-  aliases: ['Semnopithecus priam']
+  aliases: []
   parents:
   - 88028
 2804203:
-  aliases: ['Semnopithecus schistaceus']
+  aliases: []
   parents:
   - 88028
 170207:
-  aliases: ['Simias concolor']
+  aliases: []
   parents:
   - 1203020
 405039:
-  aliases: ['Symphalangus syndactylus syndactylus']
+  aliases: []
   parents:
   - 9590
 9565:
-  aliases: ['Theropithecus gelada']
+  aliases: []
   parents:
   - 9564
 222416:
-  aliases: ['Trachypithecus auratus']
+  aliases: []
   parents:
   - 54136
 271261:
-  aliases: ['Trachypithecus barbei']
+  aliases: []
   parents:
   - 54136
 122765:
-  aliases: ['Trachypithecus cristatus']
+  aliases: []
   parents:
   - 54136
 465717:
-  aliases: ['Trachypithecus delacouri']
+  aliases: []
   parents:
   - 54136
 54180:
-  aliases: ['Trachypithecus francoisi']
+  aliases: []
   parents:
   - 54136
 744437:
-  aliases: ['Trachypithecus francoisi x poliocephalus']
+  aliases: []
   parents:
   - 54136
 164650:
-  aliases: ['Trachypithecus geei']
+  aliases: []
   parents:
   - 54136
 271260:
-  aliases: ['Trachypithecus germaini']
+  aliases: []
   parents:
   - 54136
 867383:
-  aliases: ['Trachypithecus hatinhensis']
+  aliases: []
   parents:
   - 54136
 66063:
-  aliases: ['Trachypithecus johnii']
+  aliases: []
   parents:
   - 54136
 465718:
-  aliases: ['Trachypithecus laotum']
+  aliases: []
   parents:
   - 54136
 1966384:
-  aliases: ['Trachypithecus mauritius']
+  aliases: []
   parents:
   - 54136
 54181:
-  aliases: ['Trachypithecus obscurus']
+  aliases: []
   parents:
   - 54136
 61618:
-  aliases: ['Trachypithecus phayrei']
+  aliases: []
   parents:
   - 54136
 164651:
-  aliases: ['Trachypithecus pileatus']
+  aliases: []
   parents:
   - 54136
 465719:
-  aliases: ['Trachypithecus poliocephalus']
+  aliases: []
   parents:
   - 54136
 1042121:
-  aliases: ['Trachypithecus shortridgei']
+  aliases: []
   parents:
   - 54136
 54137:
-  aliases: ['Trachypithecus vetulus']
+  aliases: []
   parents:
   - 54136
 2665952:
-  aliases: ['environmental samples']
+  aliases: []
   parents:
   - 9605
 2959323:
-  aliases: ['unclassified Cercocebus']
+  aliases: []
   parents:
   - 9529
 2618071:
-  aliases: ['unclassified Cercopithecus']
+  aliases: []
   parents:
   - 9533
 2685534:
-  aliases: ['unclassified Chlorocebus']
+  aliases: []
   parents:
   - 392815
 2618863:
-  aliases: ['unclassified Colobus']
+  aliases: []
   parents:
   - 9570
 2813598:
-  aliases: ['unclassified Homo']
+  aliases: []
   parents:
   - 9605
 2623225:
-  aliases: ['unclassified Macaca']
+  aliases: []
   parents:
   - 9539
 3612877:
-  aliases: ['unclassified Pan']
+  aliases: []
   parents:
   - 9596
 2632072:
-  aliases: ['unclassified Papio']
+  aliases: []
   parents:
   - 9554
 2624844:
-  aliases: ['unclassified Pongo']
+  aliases: []
   parents:
   - 9599
 2651172:
-  aliases: ['unclassified Presbytis']
+  aliases: []
   parents:
   - 9573
 2644350:
-  aliases: ['unclassified Rhinopithecus']
+  aliases: []
   parents:
   - 542827
 2632571:
-  aliases: ['unclassified Semnopithecus']
+  aliases: []
   parents:
   - 88028
 2623509:
-  aliases: ['unclassified Trachypithecus']
+  aliases: []
   parents:
   - 54136
 1137512:
-  aliases: ['Allochrocebus preussi insularis']
+  aliases: []
   parents:
   - 147649
 1137513:
-  aliases: ['Allochrocebus preussi preussi']
+  aliases: []
   parents:
   - 147649
 1592215:
-  aliases: ['Cercocebus atys atys']
+  aliases: []
   parents:
   - 9531
 3413534:
-  aliases: ['Cercocebus sp.']
+  aliases: []
   parents:
   - 2959323
 2959324:
-  aliases: ['Cercocebus sp. Y45']
+  aliases: []
   parents:
   - 2959323
 81944:
-  aliases: ['Cercocebus torquatus torquatus']
+  aliases: []
   parents:
   - 9530
 1137444:
-  aliases: ['Cercopithecus albogularis albotorquatus']
+  aliases: []
   parents:
   - 867370
 1137476:
-  aliases: ['Cercopithecus albogularis erythrarchus']
+  aliases: []
   parents:
   - 867370
 1137483:
-  aliases: ['Cercopithecus albogularis francescae']
+  aliases: []
   parents:
   - 867370
 867372:
-  aliases: ['Cercopithecus albogularis kolbi']
+  aliases: []
   parents:
   - 867370
 1137484:
-  aliases: ['Cercopithecus albogularis labiatus']
+  aliases: []
   parents:
   - 867370
 1137488:
-  aliases: ['Cercopithecus albogularis moloneyi']
+  aliases: []
   parents:
   - 867370
 1137489:
-  aliases: ['Cercopithecus albogularis monoides']
+  aliases: []
   parents:
   - 867370
 192855:
-  aliases: ['Cercopithecus ascanius ascanius']
+  aliases: []
   parents:
   - 36223
 192856:
-  aliases: ['Cercopithecus ascanius katangae']
+  aliases: []
   parents:
   - 36223
 192857:
-  aliases: ['Cercopithecus ascanius schmidti']
+  aliases: []
   parents:
   - 36223
 192858:
-  aliases: ['Cercopithecus ascanius whitesidei']
+  aliases: []
   parents:
   - 36223
 304410:
-  aliases: ['Cercopithecus campbelli lowei']
+  aliases: []
   parents:
   - 303588
 192859:
-  aliases: ['Cercopithecus cephus cephodes']
+  aliases: []
   parents:
   - 9535
 192860:
-  aliases: ['Cercopithecus cephus cephus']
+  aliases: []
   parents:
   - 9535
 167131:
-  aliases: ['Cercopithecus cephus ngottoensis']
+  aliases: []
   parents:
   - 9535
 304409:
-  aliases: ['Cercopithecus erythrogaster erythrogaster']
+  aliases: []
   parents:
   - 161496
 1137433:
-  aliases: ['Cercopithecus erythrogaster pococki']
+  aliases: []
   parents:
   - 161496
 1137435:
-  aliases: ['Cercopithecus erythrotis camerunensis']
+  aliases: []
   parents:
   - 167130
 1137434:
-  aliases: ['Cercopithecus erythrotis erythrotis']
+  aliases: []
   parents:
   - 167130
 867373:
-  aliases: ['Cercopithecus hamlyni hamlyni']
+  aliases: []
   parents:
   - 9536
 1137473:
-  aliases: ['Cercopithecus mitis boutourlinii']
+  aliases: []
   parents:
   - 36225
 1137480:
-  aliases: ['Cercopithecus mitis heymansi']
+  aliases: []
   parents:
   - 36225
 1137482:
-  aliases: ['Cercopithecus mitis mitis']
+  aliases: []
   parents:
   - 36225
 1137490:
-  aliases: ['Cercopithecus mitis opisthostictus']
+  aliases: []
   parents:
   - 36225
 1137491:
-  aliases: ['Cercopithecus mitis stuhlmanni']
+  aliases: []
   parents:
   - 36225
 192861:
-  aliases: ['Cercopithecus mona campbelli']
+  aliases: []
   parents:
   - 36226
 100489:
-  aliases: ['Cercopithecus mona mona']
+  aliases: []
   parents:
   - 36226
 1137494:
-  aliases: ['Cercopithecus nictitans martini']
+  aliases: []
   parents:
   - 36228
 1137495:
-  aliases: ['Cercopithecus nictitans nictitans']
+  aliases: []
   parents:
   - 36228
 192893:
-  aliases: ['Cercopithecus petaurista buettikoferi']
+  aliases: []
   parents:
   - 100487
 192862:
-  aliases: ['Cercopithecus petaurista petaurista']
+  aliases: []
   parents:
   - 100487
 192863:
-  aliases: ['Cercopithecus pogonias grayi']
+  aliases: []
   parents:
   - 102108
 1137506:
-  aliases: ['Cercopithecus pogonias nigripes']
+  aliases: []
   parents:
   - 102108
 1137507:
-  aliases: ['Cercopithecus pogonias pogonias']
+  aliases: []
   parents:
   - 102108
 1137509:
-  aliases: ['Cercopithecus pogonias schwarzianus']
+  aliases: []
   parents:
   - 102108
 3413535:
-  aliases: ['Cercopithecus sp.']
+  aliases: []
   parents:
   - 2618071
 2959303:
-  aliases: ['Cercopithecus sp. T1676']
+  aliases: []
   parents:
   - 2618071
 2959302:
-  aliases: ['Cercopithecus sp. T1713']
+  aliases: []
   parents:
   - 2618071
 2959304:
-  aliases: ['Cercopithecus sp. T1714']
+  aliases: []
   parents:
   - 2618071
 2959300:
-  aliases: ['Cercopithecus sp. T2598']
+  aliases: []
   parents:
   - 2618071
 2959305:
-  aliases: ['Cercopithecus sp. T2601']
+  aliases: []
   parents:
   - 2618071
 2959325:
-  aliases: ['Cercopithecus sp. T2610']
+  aliases: []
   parents:
   - 2618071
 2959301:
-  aliases: ['Cercopithecus sp. T2619']
+  aliases: []
   parents:
   - 2618071
 2959306:
-  aliases: ['Cercopithecus sp. T2632']
+  aliases: []
   parents:
   - 2618071
 2959311:
-  aliases: ['Cercopithecus sp. T2647']
+  aliases: []
   parents:
   - 2618071
 2959330:
-  aliases: ['Cercopithecus sp. T2648']
+  aliases: []
   parents:
   - 2618071
 2959326:
-  aliases: ['Cercopithecus sp. T2649']
+  aliases: []
   parents:
   - 2618071
 2959329:
-  aliases: ['Cercopithecus sp. T2665']
+  aliases: []
   parents:
   - 2618071
 2959331:
-  aliases: ['Cercopithecus sp. T2678']
+  aliases: []
   parents:
   - 2618071
 2959307:
-  aliases: ['Cercopithecus sp. T2681']
+  aliases: []
   parents:
   - 2618071
 2959312:
-  aliases: ['Cercopithecus sp. T2682']
+  aliases: []
   parents:
   - 2618071
 2959313:
-  aliases: ['Cercopithecus sp. T2685']
+  aliases: []
   parents:
   - 2618071
 2959308:
-  aliases: ['Cercopithecus sp. T2688']
+  aliases: []
   parents:
   - 2618071
 2959310:
-  aliases: ['Cercopithecus sp. T2689']
+  aliases: []
   parents:
   - 2618071
 2959309:
-  aliases: ['Cercopithecus sp. T2690']
+  aliases: []
   parents:
   - 2618071
 1144881:
-  aliases: ['Cercopithecus sp. WMS-2012']
+  aliases: []
   parents:
   - 2618071
 2959327:
-  aliases: ['Cercopithecus sp. Y36']
+  aliases: []
   parents:
   - 2618071
 2959328:
-  aliases: ['Cercopithecus sp. Y40']
+  aliases: []
   parents:
   - 2618071
 1137505:
-  aliases: ['Cercopithecus wolfi elegans']
+  aliases: []
   parents:
   - 263448
 1137508:
-  aliases: ['Cercopithecus wolfi pyrogaster']
+  aliases: []
   parents:
   - 263448
 867374:
-  aliases: ['Cercopithecus wolfi wolfi']
+  aliases: []
   parents:
   - 263448
 101841:
-  aliases: ['Chlorocebus aethiops aethiops']
+  aliases: []
   parents:
   - 9534
 100936:
-  aliases: ['Chlorocebus aethiops vervet']
+  aliases: []
   parents:
   - 9534
 508712:
-  aliases: ['Chlorocebus pygerythrus hilgerti']
+  aliases: []
   parents:
   - 60710
 460674:
-  aliases: ['Chlorocebus pygerythrus pygerythrus']
+  aliases: []
   parents:
   - 60710
 2269071:
-  aliases: ['Chlorocebus pygerythrus x Chlorocebus aethiops']
+  aliases: []
   parents:
   - 60710
 2282232:
-  aliases: ['Chlorocebus sp. LDS-2018']
+  aliases: []
   parents:
   - 2685534
 1090918:
-  aliases: ['Chlorocebus sp. MAS-2011']
+  aliases: []
   parents:
   - 2685534
 1284216:
-  aliases: ['Chlorocebus sp. TH-2013']
+  aliases: []
   parents:
   - 2685534
 508710:
-  aliases: ['Chlorocebus tantalus budgetti']
+  aliases: []
   parents:
   - 60712
 336983:
-  aliases: ['Colobus angolensis palliatus']
+  aliases: []
   parents:
   - 54131
 373031:
-  aliases: ['Colobus guereza caudatus']
+  aliases: []
   parents:
   - 33548
 132548:
-  aliases: ['Colobus guereza kikuyuensis']
+  aliases: []
   parents:
   - 33548
 373030:
-  aliases: ['Colobus guereza matschiei']
+  aliases: []
   parents:
   - 33548
 373032:
-  aliases: ['Colobus guereza occidentalis']
+  aliases: []
   parents:
   - 33548
 517013:
-  aliases: ['Colobus satanas satanas']
+  aliases: []
   parents:
   - 517012
 34824:
-  aliases: ['Colobus sp.']
+  aliases: []
   parents:
   - 2618863
 288544:
-  aliases: ['Colobus sp. DTG-2004']
+  aliases: []
   parents:
   - 2618863
 325172:
-  aliases: ['Colobus sp. MB-2005']
+  aliases: []
   parents:
   - 2618863
 3591507:
-  aliases: ['Colobus sp. T76239-1']
+  aliases: []
   parents:
   - 2618863
 1159185:
-  aliases: ['Gorilla beringei beringei']
+  aliases: []
   parents:
   - 499232
 46359:
-  aliases: ['Gorilla beringei graueri']
+  aliases: []
   parents:
   - 499232
 406788:
-  aliases: ['Gorilla gorilla diehli']
+  aliases: []
   parents:
   - 9593
 9595:
-  aliases: ['Gorilla gorilla gorilla']
+  aliases: []
   parents:
   - 9593
 183511:
-  aliases: ['Gorilla gorilla uellensis']
+  aliases: []
   parents:
   - 9593
 2665953:
-  aliases: ['Homo sapiens environmental sample']
+  aliases: []
   parents:
   - 2665952
 63221:
-  aliases: ['Homo sapiens neanderthalensis']
+  aliases: []
   parents:
   - 9606
 741158:
-  aliases: ["Homo sapiens subsp. 'Denisova'"]
+  aliases: []
   parents:
   - 9606
 2813599:
-  aliases: ['Homo sp.']
+  aliases: []
   parents:
   - 2813598
 75568:
-  aliases: ['Lophocebus albigena albigena']
+  aliases: []
   parents:
   - 75567
 1411634:
-  aliases: ['Macaca assamensis assamensis']
+  aliases: []
   parents:
   - 9551
 1747270:
-  aliases: ['Macaca fascicularis aureus']
+  aliases: []
   parents:
   - 9541
 1215360:
-  aliases: ['Macaca fascicularis fascicularis']
+  aliases: []
   parents:
   - 9541
 90386:
-  aliases: ['Macaca fascicularis philippinensis']
+  aliases: []
   parents:
   - 9541
 9543:
-  aliases: ['Macaca fuscata fuscata']
+  aliases: []
   parents:
   - 9542
 179089:
-  aliases: ['Macaca fuscata yakui']
+  aliases: []
   parents:
   - 9542
 1654737:
-  aliases: ['Macaca mulatta brevicaudus']
+  aliases: []
   parents:
   - 9544
 1449913:
-  aliases: ['Macaca mulatta lasiotus']
+  aliases: []
   parents:
   - 9544
 2008792:
-  aliases: ['Macaca mulatta vestita']
+  aliases: []
   parents:
   - 9544
 90388:
-  aliases: ['Macaca nemestrina nemestrina']
+  aliases: []
   parents:
   - 9545
 439030:
-  aliases: ['Macaca radiata radiata']
+  aliases: []
   parents:
   - 9548
 9549:
-  aliases: ['Macaca sp.']
+  aliases: []
   parents:
   - 2623225
 2838830:
-  aliases: ['Macaca sp. XT-2021']
+  aliases: []
   parents:
   - 2623225
 257877:
-  aliases: ['Macaca thibetana thibetana']
+  aliases: []
   parents:
   - 54602
 560240:
-  aliases: ['Miopithecus talapoin talapoin']
+  aliases: []
   parents:
   - 36231
 3612878:
-  aliases: ['Pan sp.']
+  aliases: []
   parents:
   - 3612877
 756884:
-  aliases: ['Pan troglodytes ellioti']
+  aliases: []
   parents:
   - 9598
 37010:
-  aliases: ['Pan troglodytes schweinfurthii']
+  aliases: []
   parents:
   - 9598
 37011:
-  aliases: ['Pan troglodytes troglodytes']
+  aliases: []
   parents:
   - 9598
 37012:
-  aliases: ['Pan troglodytes verus']
+  aliases: []
   parents:
   - 9598
 1294088:
-  aliases: ['Pan troglodytes verus x troglodytes']
+  aliases: []
   parents:
   - 9598
 211508:
-  aliases: ['Papio anubis anubis']
+  aliases: []
   parents:
   - 9555
 106398:
-  aliases: ['Papio cynocephalus cynocephalus']
+  aliases: []
   parents:
   - 9556
 501791:
-  aliases: ['Papio cynocephalus ibeanus']
+  aliases: []
   parents:
   - 9556
 9562:
-  aliases: ['Papio hamadryas hamadryas']
+  aliases: []
   parents:
   - 9557
 61183:
-  aliases: ['Papio sp.']
+  aliases: []
   parents:
   - 2632072
 285280:
-  aliases: ['Papio sp. Africa-2004']
+  aliases: []
   parents:
   - 2632072
 425246:
-  aliases: ['Papio sp. PS-2007']
+  aliases: []
   parents:
   - 2632072
 208090:
-  aliases: ['Papio ursinus griseipes']
+  aliases: []
   parents:
   - 36229
 208089:
-  aliases: ['Papio ursinus ursinus']
+  aliases: []
   parents:
   - 36229
 491852:
-  aliases: ['Piliocolobus badius badius']
+  aliases: []
   parents:
   - 164648
 491853:
-  aliases: ['Piliocolobus badius temminckii']
+  aliases: []
   parents:
   - 164648
 2753605:
-  aliases: ['Pongo pygmaeus morio']
+  aliases: []
   parents:
   - 9600
 9602:
-  aliases: ['Pongo pygmaeus pygmaeus']
+  aliases: []
   parents:
   - 9600
 2753606:
-  aliases: ['Pongo pygmaeus wurmbii']
+  aliases: []
   parents:
   - 9600
 9603:
-  aliases: ['Pongo sp.']
+  aliases: []
   parents:
   - 2624844
 272114:
-  aliases: ['Presbytis comata comata']
+  aliases: []
   parents:
   - 78452
 1046091:
-  aliases: ['Presbytis comata fredericae']
+  aliases: []
   parents:
   - 78452
 1840579:
-  aliases: ['Presbytis femoralis femoralis']
+  aliases: []
   parents:
   - 78453
 1840580:
-  aliases: ['Presbytis femoralis percura']
+  aliases: []
   parents:
   - 78453
 1046094:
-  aliases: ['Presbytis hosei hosei']
+  aliases: []
   parents:
   - 1046093
 1046096:
-  aliases: ['Presbytis melalophos melalophos']
+  aliases: []
   parents:
   - 78451
 272115:
-  aliases: ['Presbytis melalophos mitrata']
+  aliases: []
   parents:
   - 78451
 1046099:
-  aliases: ['Presbytis potenziani potenziani']
+  aliases: []
   parents:
   - 1046098
 1046102:
-  aliases: ['Presbytis rubicunda rubicunda']
+  aliases: []
   parents:
   - 1046101
 2822462:
-  aliases: ['Presbytis sp. Pres2']
+  aliases: []
   parents:
   - 2651172
 303485:
-  aliases: ['Pygathrix nemaeus nemaeus']
+  aliases: []
   parents:
   - 54133
 1859147:
-  aliases: ['Rhinopithecus sp.']
+  aliases: []
   parents:
   - 2644350
 867381:
-  aliases: ['Semnopithecus entellus entellus']
+  aliases: []
   parents:
   - 88029
 1778600:
-  aliases: ['Semnopithecus sp.']
+  aliases: []
   parents:
   - 2632571
 272118:
-  aliases: ['Trachypithecus auratus auratus']
+  aliases: []
   parents:
   - 222416
 449596:
-  aliases: ['Trachypithecus auratus mauritius']
+  aliases: []
   parents:
   - 222416
 36233:
-  aliases: ['Trachypithecus auratus pyrrhus']
+  aliases: []
   parents:
   - 222416
 272119:
-  aliases: ['Trachypithecus francoisi francoisi']
+  aliases: []
   parents:
   - 54180
 272121:
-  aliases: ['Trachypithecus phayrei crepuscula']
+  aliases: []
   parents:
   - 61618
 1118394:
-  aliases: ['Trachypithecus phayrei holotephreus']
+  aliases: []
   parents:
   - 61618
 272120:
-  aliases: ['Trachypithecus phayrei phayrei']
+  aliases: []
   parents:
   - 61618
 1268362:
-  aliases: ['Trachypithecus phayrei shanicus']
+  aliases: []
   parents:
   - 61618
 662738:
-  aliases: ['Trachypithecus poliocephalus leucocephalus']
+  aliases: []
   parents:
   - 465719
 1118393:
-  aliases: ['Trachypithecus poliocephalus poliocephalus']
+  aliases: []
   parents:
   - 465719
 580599:
-  aliases: ['Trachypithecus sp.']
+  aliases: []
   parents:
   - 2623509
 614071:
-  aliases: ['Trachypithecus vetulus vetulus']
+  aliases: []
   parents:
   - 54137

--- a/scripts/generate_taxonomy_lineage.py
+++ b/scripts/generate_taxonomy_lineage.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+import argparse
+import gzip
+import sqlite3
+import urllib.error
+import urllib.request
+
+
+def load_db(url) -> sqlite3.Connection:
+    try:
+        with urllib.request.urlopen(url) as response:
+            data = gzip.decompress(response.read())
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(
+            f"downloading db from {url} failed with code {e.code}, {e.reason}"
+        )
+
+    conn = sqlite3.connect(":memory:")
+    conn.deserialize(data)
+
+    return conn
+
+
+def fetch_sublineage(db_conn: sqlite3.Connection, root: int):
+    query = """
+    WITH RECURSIVE sublineage AS (
+        SELECT * FROM taxonomy WHERE tax_id = ?
+        UNION ALL
+        SELECT t.* FROM taxonomy t
+        JOIN sublineage s ON t.parent_id = s.tax_id
+        WHERE t.tax_id != t.parent_id
+      )
+      SELECT * FROM sublineage;
+    """
+
+    result = []
+    db_conn.row_factory = sqlite3.Row
+    for row in db_conn.execute(query, (root,)).fetchall():
+        data = dict(row)
+        if data["tax_id"] == root:
+            data["parent_id"] = None
+        result.append(data)
+
+    # sort by depth level, and alphabetically on scientific name within depth level
+    return {
+        i["tax_id"]: i
+        for i in sorted(result, key=lambda x: (x["depth"], x["scientific_name"]))
+    }
+
+
+def convert_to_silo_format(sublineage, root_id, root_label):
+    silo_hierarchy = dict()
+    for tax_id, data in sublineage.items():
+        aliases = data["scientific_name"] if data["tax_id"] != root_id else root_label
+        parent = data["parent_id"]
+        silo_hierarchy[tax_id] = {
+            "aliases": [aliases],
+            "parents": [parent] if parent else [],
+        }
+    return silo_hierarchy
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--roots",
+        type=int,
+        required=True,
+        nargs="+",
+        help="Taxon IDs for the roots of sublineages to generate",
+    )
+    parser.add_argument(
+        "--labels",
+        type=str,
+        required=True,
+        nargs="+",
+        help="Labels to use for sublineages specified by --roots",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        required=True,
+        help="Name of the output file to store lineages in",
+    )
+    parser.add_argument(
+        "--db_version",
+        type=str,
+        default="ncbi_taxonomy_latest.sqlite.gz",
+        help="DB version to generate sublineages from. Provide the full file name. [DEFAULT: ncbi_taxonomy_latest.sqlite.gz]",
+    )
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    base_url = "https://loculus-public.hel1.your-objectstorage.com/taxonomy"
+    url = f"{base_url}/{args.db_version}"
+
+    if len(args.roots) != len(args.labels):
+        raise ValueError("Got a different number of roots and labels")
+    roots = [
+        {"tax_id": root, "label": label} for root, label in zip(args.roots, args.labels)
+    ]
+
+    print(f"Downloading db {url}")
+    db_conn = load_db(url)
+    sublineages = []
+    for root in roots:
+        print(f"Getting sublineage '{root['label']}' starting at {root['tax_id']}...")
+        sublineage = fetch_sublineage(db_conn, root["tax_id"])
+        silo = convert_to_silo_format(sublineage, root["tax_id"], root["label"])
+        sublineages.append(silo)
+        print(f"Sublineage '{root['label']}' contains {len(silo)} taxa")
+
+    print(f"Writing sublineages to {args.output}")
+    with open(args.output, "w") as o:
+        for sublineage in sublineages:
+            for name in sublineage:
+                o.write(f"{name}:\n")
+                o.write(f"  aliases: {sublineage[name]['aliases']}\n")
+                if sublineage[name]["parents"]:
+                    o.write("  parents:\n")
+                    for parent in sublineage[name]["parents"]:
+                        o.write(f"  - {parent}\n")
+                else:
+                    o.write("  parents: []\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_taxonomy_lineage.py
+++ b/scripts/generate_taxonomy_lineage.py
@@ -51,10 +51,10 @@ def fetch_sublineage(db_conn: sqlite3.Connection, root: int):
 def convert_to_silo_format(sublineage, root_id, root_label):
     silo_hierarchy = dict()
     for tax_id, data in sublineage.items():
-        aliases = data["scientific_name"] if data["tax_id"] != root_id else root_label
+        aliases = root_label if data["tax_id"] == root_id else []
         parent = data["parent_id"]
         silo_hierarchy[tax_id] = {
-            "aliases": [aliases],
+            "aliases": [aliases] if aliases else [],
             "parents": [parent] if parent else [],
         }
     return silo_hierarchy
@@ -100,6 +100,11 @@ def main():
 
     if len(args.roots) != len(args.labels):
         raise ValueError("Got a different number of roots and labels")
+    if len(set(args.roots)) != len(args.roots) or len(set(args.labels)) != len(
+        args.labels
+    ):
+        raise ValueError("Labels or roots were not unique")
+
     roots = [
         {"tax_id": root, "label": label} for root, label in zip(args.roots, args.labels)
     ]


### PR DESCRIPTION
This PR adds a script that creates taxonomic sublineages to use in SILO. The goal is to enable hierarchical filtering of sequences in loculus/pathoplexus based on the host taxon.

```sh
python3 ./scripts/generate_taxonomy_lineage.py \
    --roots 7157 9397 9443 \
    --labels Mosquitos Bats Primates \
    --output ./definitions/taxonomy/2026-04-15/lineages.yaml
```