### PR TITLE
Update mpox for latest dataset, with outbreak-lineages

### DIFF
--- a/definitions/mpox/2025-07-07--14-07-11Z/lineages.yaml
+++ b/definitions/mpox/2025-07-07--14-07-11Z/lineages.yaml
@@ -1,0 +1,303 @@
+None:
+  aliases: []
+  parents: []
+A:
+  aliases: []
+  parents: []
+A.1:
+  aliases: []
+  parents:
+  - A
+A.1.1:
+  aliases: []
+  #  - B
+  parents:
+  - A.1
+B.1:
+  aliases: []
+  #  - A.1.1.1
+  parents:
+  - A.1.1
+B.1.1:
+  aliases: []
+  #  - A.1.1.1.1
+  parents:
+  - B.1
+B.1.2:
+  aliases: []
+  #  - A.1.1.1.2
+  parents:
+  - B.1
+B.1.3:
+  aliases: []
+  #  - A.1.1.1.3
+  #  - C
+  parents:
+  - B.1
+C.1:
+  aliases: []
+  #  - A.1.1.1.3.1
+  #  - B.1.3.1
+  parents:
+  - B.1.3
+C.1.1:
+  aliases: []
+  #  - A.1.1.1.3.1.1
+  #  - B.1.3.1.1
+  #  - E
+  parents:
+  - C.1
+E.1:
+  aliases: []
+  #  - A.1.1.1.3.1.1.1
+  #  - C.1.1.1
+  parents:
+  - C.1.1
+E.1.1:
+  aliases: []
+  parents:
+  - E.1
+E.2:
+  aliases: []
+  #  - A.1.1.1.3.1.1.2
+  #  - C.1.1.2
+  parents:
+  - C.1.1
+E.2.1:
+  aliases: []
+  parents:
+  - E.2
+E.3:
+  aliases: []
+  #  - A.1.1.1.3.1.1.3
+  #  - C.1.1.3
+  parents:
+  - C.1.1
+E.3.1:
+  aliases: []
+  parents:
+  - E.3
+E.4:
+  aliases: []
+  parents:
+  - C.1.1
+C.1.2:
+  aliases: []
+  parents:
+  - C.1
+C.1.3:
+  aliases: []
+  parents:
+  - C.1
+B.1.4:
+  aliases: []
+  #  - A.1.1.1.4
+  parents:
+  - B.1
+B.1.5:
+  aliases: []
+  #  - A.1.1.1.5
+  parents:
+  - B.1
+B.1.6:
+  aliases: []
+  #  - A.1.1.1.6
+  #  - D
+  parents:
+  - B.1
+D.1:
+  aliases: []
+  #  - A.1.1.1.6.1
+  #  - B.1.6.1
+  parents:
+  - B.1.6
+B.1.7:
+  aliases: []
+  #  - A.1.1.1.7
+  parents:
+  - B.1
+B.1.8:
+  aliases: []
+  #  - A.1.1.1.8
+  parents:
+  - B.1
+B.1.9:
+  aliases: []
+  #  - A.1.1.1.9
+  parents:
+  - B.1
+B.1.10:
+  aliases: []
+  #  - A.1.1.1.10
+  parents:
+  - B.1
+B.1.11:
+  aliases: []
+  #  - A.1.1.1.11
+  parents:
+  - B.1
+B.1.12:
+  aliases: []
+  #  - A.1.1.1.12
+  parents:
+  - B.1
+B.1.13:
+  aliases: []
+  #  - A.1.1.1.13
+  parents:
+  - B.1
+B.1.14:
+  aliases: []
+  #  - A.1.1.1.14
+  parents:
+  - B.1
+B.1.15:
+  aliases: []
+  #  - A.1.1.1.15
+  parents:
+  - B.1
+B.1.16:
+  aliases: []
+  #  - A.1.1.1.16
+  parents:
+  - B.1
+B.1.17:
+  aliases: []
+  #  - A.1.1.1.17
+  parents:
+  - B.1
+B.1.18:
+  aliases: []
+  #  - A.1.1.1.18
+  parents:
+  - B.1
+B.1.19:
+  aliases: []
+  #  - A.1.1.1.19
+  parents:
+  - B.1
+B.1.20:
+  aliases: []
+  #  - A.1.1.1.20
+  #  - F
+  parents:
+  - B.1
+F.1:
+  aliases: []
+  #  - A.1.1.1.20.1
+  #  - B.1.20.1
+  parents:
+  - B.1.20
+F.1.1:
+  aliases: []
+  parents:
+  - F.1
+F.2:
+  aliases: []
+  #  - A.1.1.1.20.2
+  #  - B.1.20.2
+  parents:
+  - B.1.20
+F.2.1:
+  aliases: []
+  parents:
+  - F.2
+F.3:
+  aliases: []
+  #  - A.1.1.1.20.3
+  #  - B.1.20.3
+  parents:
+  - B.1.20
+F.4:
+  aliases: []
+  #  - A.1.1.1.20.4
+  #  - B.1.20.4
+  parents:
+  - B.1.20
+F.4.1:
+  aliases: []
+  parents:
+  - F.4
+F.5:
+  aliases: []
+  #  - A.1.1.1.20.5
+  #  - B.1.20.5
+  parents:
+  - B.1.20
+F.6:
+  aliases: []
+  #  - A.1.1.1.20.6
+  #  - B.1.20.6
+  parents:
+  - B.1.20
+B.1.21:
+  aliases: []
+  #  - A.1.1.1.21
+  parents:
+  - B.1
+B.1.22:
+  aliases: []
+  #  - A.1.1.1.22
+  parents:
+  - B.1
+J.1:
+  aliases: []
+  parents:
+  - B.1.22
+B.1.23:
+  aliases: []
+  #  - A.1.1.1.23
+  parents:
+  - B.1
+A.2:
+  aliases: []
+  parents:
+  - A
+A.2.1:
+  aliases: []
+  parents:
+  - A.2
+H.1:
+  aliases: []
+  parents:
+  - A.2.1
+H.2:
+  aliases: []
+  parents:
+  - A.2.1
+A.2.2:
+  aliases: []
+  parents:
+  - A.2
+G.1:
+  aliases: []
+  parents:
+  - A.2.2
+A.2.3:
+  aliases: []
+  parents:
+  - A.2
+A.2.4:
+  aliases: []
+  parents:
+  - A.2
+A.2.5:
+  aliases: []
+  parents:
+  - A.2
+A.3:
+  aliases: []
+  parents:
+  - A
+A.4:
+  aliases: []
+  parents:
+  - A
+A.4.1:
+  aliases: []
+  parents:
+  - A.4
+A.5:
+  aliases: []
+  parents:
+  - A

--- a/definitions/mpox/2025-07-07--14-07-11Z/outbreak-lineages.yaml
+++ b/definitions/mpox/2025-07-07--14-07-11Z/outbreak-lineages.yaml
@@ -1,0 +1,318 @@
+None:
+  aliases: []
+  parents: []
+sh2017/A:
+  aliases: []
+  parents: []
+sh2017/A.1:
+  aliases: []
+  parents:
+  - sh2017/A
+sh2017/A.1.1:
+  aliases: []
+  #  - sh2017/B
+  parents:
+  - sh2017/A.1
+sh2017/B.1:
+  aliases: []
+  #  - sh2017/A.1.1.1
+  parents:
+  - sh2017/A.1.1
+sh2017/B.1.1:
+  aliases: []
+  #  - sh2017/A.1.1.1.1
+  parents:
+  - sh2017/B.1
+sh2017/B.1.2:
+  aliases: []
+  #  - sh2017/A.1.1.1.2
+  parents:
+  - sh2017/B.1
+sh2017/B.1.3:
+  aliases: []
+  #  - sh2017/A.1.1.1.3
+  #  - sh2017/C
+  parents:
+  - sh2017/B.1
+sh2017/C.1:
+  aliases: []
+  #  - sh2017/A.1.1.1.3.1
+  #  - sh2017/B.1.3.1
+  parents:
+  - sh2017/B.1.3
+sh2017/C.1.1:
+  aliases: []
+  #  - sh2017/A.1.1.1.3.1.1
+  #  - sh2017/B.1.3.1.1
+  #  - sh2017/E
+  parents:
+  - sh2017/C.1
+sh2017/E.1:
+  aliases: []
+  #  - sh2017/A.1.1.1.3.1.1.1
+  #  - sh2017/C.1.1.1
+  parents:
+  - sh2017/C.1.1
+sh2017/E.1.1:
+  aliases: []
+  parents:
+  - sh2017/E.1
+sh2017/E.2:
+  aliases: []
+  #  - sh2017/A.1.1.1.3.1.1.2
+  #  - sh2017/C.1.1.2
+  parents:
+  - sh2017/C.1.1
+sh2017/E.2.1:
+  aliases: []
+  parents:
+  - sh2017/E.2
+sh2017/E.3:
+  aliases: []
+  #  - sh2017/A.1.1.1.3.1.1.3
+  #  - sh2017/C.1.1.3
+  parents:
+  - sh2017/C.1.1
+sh2017/E.3.1:
+  aliases: []
+  parents:
+  - sh2017/E.3
+sh2017/E.4:
+  aliases: []
+  parents:
+  - sh2017/C.1.1
+sh2017/C.1.2:
+  aliases: []
+  parents:
+  - sh2017/C.1
+sh2017/C.1.3:
+  aliases: []
+  parents:
+  - sh2017/C.1
+sh2017/B.1.4:
+  aliases: []
+  #  - sh2017/A.1.1.1.4
+  parents:
+  - sh2017/B.1
+sh2017/B.1.5:
+  aliases: []
+  #  - sh2017/A.1.1.1.5
+  parents:
+  - sh2017/B.1
+sh2017/B.1.6:
+  aliases: []
+  #  - sh2017/A.1.1.1.6
+  #  - sh2017/D
+  parents:
+  - sh2017/B.1
+sh2017/D.1:
+  aliases: []
+  #  - sh2017/A.1.1.1.6.1
+  #  - sh2017/B.1.6.1
+  parents:
+  - sh2017/B.1.6
+sh2017/B.1.7:
+  aliases: []
+  #  - sh2017/A.1.1.1.7
+  parents:
+  - sh2017/B.1
+sh2017/B.1.8:
+  aliases: []
+  #  - sh2017/A.1.1.1.8
+  parents:
+  - sh2017/B.1
+sh2017/B.1.9:
+  aliases: []
+  #  - sh2017/A.1.1.1.9
+  parents:
+  - sh2017/B.1
+sh2017/B.1.10:
+  aliases: []
+  #  - sh2017/A.1.1.1.10
+  parents:
+  - sh2017/B.1
+sh2017/B.1.11:
+  aliases: []
+  #  - sh2017/A.1.1.1.11
+  parents:
+  - sh2017/B.1
+sh2017/B.1.12:
+  aliases: []
+  #  - sh2017/A.1.1.1.12
+  parents:
+  - sh2017/B.1
+sh2017/B.1.13:
+  aliases: []
+  #  - sh2017/A.1.1.1.13
+  parents:
+  - sh2017/B.1
+sh2017/B.1.14:
+  aliases: []
+  #  - sh2017/A.1.1.1.14
+  parents:
+  - sh2017/B.1
+sh2017/B.1.15:
+  aliases: []
+  #  - sh2017/A.1.1.1.15
+  parents:
+  - sh2017/B.1
+sh2017/B.1.16:
+  aliases: []
+  #  - sh2017/A.1.1.1.16
+  parents:
+  - sh2017/B.1
+sh2017/B.1.17:
+  aliases: []
+  #  - sh2017/A.1.1.1.17
+  parents:
+  - sh2017/B.1
+sh2017/B.1.18:
+  aliases: []
+  #  - sh2017/A.1.1.1.18
+  parents:
+  - sh2017/B.1
+sh2017/B.1.19:
+  aliases: []
+  #  - sh2017/A.1.1.1.19
+  parents:
+  - sh2017/B.1
+sh2017/B.1.20:
+  aliases: []
+  #  - sh2017/A.1.1.1.20
+  #  - sh2017/F
+  parents:
+  - sh2017/B.1
+sh2017/F.1:
+  aliases: []
+  #  - sh2017/A.1.1.1.20.1
+  #  - sh2017/B.1.20.1
+  parents:
+  - sh2017/B.1.20
+sh2017/F.1.1:
+  aliases: []
+  parents:
+  - sh2017/F.1
+sh2017/F.2:
+  aliases: []
+  #  - sh2017/A.1.1.1.20.2
+  #  - sh2017/B.1.20.2
+  parents:
+  - sh2017/B.1.20
+sh2017/F.2.1:
+  aliases: []
+  parents:
+  - sh2017/F.2
+sh2017/F.3:
+  aliases: []
+  #  - sh2017/A.1.1.1.20.3
+  #  - sh2017/B.1.20.3
+  parents:
+  - sh2017/B.1.20
+sh2017/F.4:
+  aliases: []
+  #  - sh2017/A.1.1.1.20.4
+  #  - sh2017/B.1.20.4
+  parents:
+  - sh2017/B.1.20
+sh2017/F.4.1:
+  aliases: []
+  parents:
+  - sh2017/F.4
+sh2017/F.5:
+  aliases: []
+  #  - sh2017/A.1.1.1.20.5
+  #  - sh2017/B.1.20.5
+  parents:
+  - sh2017/B.1.20
+sh2017/F.6:
+  aliases: []
+  #  - sh2017/A.1.1.1.20.6
+  #  - sh2017/B.1.20.6
+  parents:
+  - sh2017/B.1.20
+sh2017/B.1.21:
+  aliases: []
+  #  - sh2017/A.1.1.1.21
+  parents:
+  - sh2017/B.1
+sh2017/B.1.22:
+  aliases: []
+  #  - sh2017/A.1.1.1.22
+  parents:
+  - sh2017/B.1
+sh2017/J.1:
+  aliases: []
+  parents:
+  - sh2017/B.1.22
+sh2017/B.1.23:
+  aliases: []
+  #  - sh2017/A.1.1.1.23
+  parents:
+  - sh2017/B.1
+sh2017/A.2:
+  aliases: []
+  parents:
+  - sh2017/A
+sh2017/A.2.1:
+  aliases: []
+  parents:
+  - sh2017/A.2
+sh2017/H.1:
+  aliases: []
+  parents:
+  - sh2017/A.2.1
+sh2017/H.2:
+  aliases: []
+  parents:
+  - sh2017/A.2.1
+sh2017/A.2.2:
+  aliases: []
+  parents:
+  - sh2017/A.2
+sh2017/G.1:
+  aliases: []
+  parents:
+  - sh2017/A.2.2
+sh2017/A.2.3:
+  aliases: []
+  parents:
+  - sh2017/A.2
+sh2017/A.2.4:
+  aliases: []
+  parents:
+  - sh2017/A.2
+sh2017/A.2.5:
+  aliases: []
+  parents:
+  - sh2017/A.2
+sh2017/A.3:
+  aliases: []
+  parents:
+  - sh2017/A
+sh2023/A:
+  aliases: []
+  parents: []
+sh2023/A.1:
+  aliases: []
+  parents:
+  - sh2023/A
+sh2023/A.2:
+  aliases: []
+  parents:
+  - sh2023/A
+sh2023/A.3:
+  aliases: []
+  parents:
+  - sh2023/A
+sh2023/A.4:
+  aliases: []
+  parents:
+  - sh2023/A
+sh2023/A.4.1:
+  aliases: []
+  parents:
+  - sh2023/A.4
+sh2023/A.5:
+  aliases: []
+  parents:
+  - sh2023/A


### PR DESCRIPTION
Lineages will likely get deprecated, for now just need to make the migration work without errors.
